### PR TITLE
UEFI PXE Boot ESXI:

### DIFF
--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -6,6 +6,6 @@ chain tftp://<%=server%>/undionly.kpxe
 boot
 
 :is_efi
-kernel http://<%=server%>:<%=port%>/vmware/efi/boot/bootx64.efi -c http://<%=se$
+kernel http://<%=server%>:<%=port%>/vmware/efi/boot/bootx64.efi -c http://<%=server%>:<%=port%>/api/common/templates/<%=esxBootConfigTemplate%>
 boot
 


### PR DESCRIPTION
 in ipxe script if chain booting with undionly.kpxe fails(not supported in uefi) try to load bootx64.efi)

vey147:
Compatibility between Legacy and UEFI modes is verified for ESXi. We want to be able to move back and forth between legacy and UEFI boot profiles: 
1. Want to boot UEFI and bootstrap ESXi 
2. Then switch to legacy boot and bootstrap ESXi 
3. Then back to a UEFI mode and bootstrap ESXi 
