### PR TITLE
Return 404 instead of 204 if /workflows/:id is not found

### DIFF
--- a/lib/api/workflows.js
+++ b/lib/api/workflows.js
@@ -125,7 +125,7 @@ function workflowsRouterFactory (taskgraphRunner, rest, waterline, _) {
      */
 
     router.get('/workflows/:identifier', rest(function (req) {
-        return waterline.graphobjects.findByIdentifier(req.params.identifier);
+        return waterline.graphobjects.needByIdentifier(req.params.identifier);
     }));
 
     return router;

--- a/spec/lib/api/workflows-spec.js
+++ b/spec/lib/api/workflows-spec.js
@@ -34,7 +34,8 @@ describe('Http.Api.Workflows', function () {
         };
         waterline.graphobjects = {
             find: sinon.stub().resolves([]),
-            findByIdentifier: sinon.stub().resolves()
+            findByIdentifier: sinon.stub().resolves(),
+            needByIdentifier: sinon.stub().resolves()
         };
         waterline.lookups = {
             // This method is for lookups only and it
@@ -59,16 +60,25 @@ describe('Http.Api.Workflows', function () {
     describe('GET /workflows/:id', function () {
         it('should return a single persisted graph', function () {
             var graph = { name: 'foobar' };
-            waterline.graphobjects.findByIdentifier.resolves(graph);
+            waterline.graphobjects.needByIdentifier.resolves(graph);
 
             return helper.request().get('/api/1.1/workflows/12345')
             .expect('Content-Type', /^application\/json/)
             .expect(200, graph)
             .expect(function () {
-                expect(waterline.graphobjects.findByIdentifier).to.have.been.calledOnce;
-                expect(waterline.graphobjects.findByIdentifier)
+                expect(waterline.graphobjects.needByIdentifier).to.have.been.calledOnce;
+                expect(waterline.graphobjects.needByIdentifier)
                 .to.have.been.calledWith('12345');
             });
+        });
+
+        it('should return a 404 if not found', function () {
+            var Errors = helper.injector.get('Errors');
+            waterline.graphobjects.needByIdentifier.rejects(new Errors.NotFoundError('test'));
+
+            return helper.request().get('/api/1.1/workflows/12345')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404);
         });
     });
 


### PR DESCRIPTION
Self explanatory.

https://hwjiraprd01.corp.emc.com/browse/MON-534
https://hwjiraprd01.corp.emc.com/browse/ODR-176
