### PR TITLE
Pass initrd=<initrdFile> to iPXE imgargs in order to support netbooti…

### DIFF
--- a/data/profiles/linux.ipxe
+++ b/data/profiles/linux.ipxe
@@ -1,5 +1,4 @@
-set base-url http://<%=server%>:<%=port%>
-kernel ${base-url}/<%=kernel%>
-initrd ${base-url}/<%=initrd%>
-imgargs <%=kernelversion%> auto=true SYSLOGSERVER=<%=server%> API_CB=<%=server%>:<%=port%> BASEFS=<%=basefs%> OVERLAYFS=<%=overlayfs%> BOOTIF=01-<%=macaddress%> console=tty0 console=<%=comport%>,115200n8 <%=kargs%>
+kernel <%=kernelUri%>
+initrd <%=initrdUri%>
+imgargs <%=kernelFile%> initrd=<%=initrdFile%> auto=true SYSLOGSERVER=<%=server%> API_CB=<%=server%>:<%=port%> BASEFS=<%=basefs%> OVERLAYFS=<%=overlayfs%> BOOTIF=01-<%=macaddress%> console=tty0 console=<%=comport%>,115200n8 <%=kargs%>
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell


### PR DESCRIPTION
…ng via EFI

We need to pass initrd=<filename of loaded initrd> to the imgargs in order to support netbooting via EFI iPXE clients, otherwise we get a root=null kernel panic error when the kernel tries to load the initrd.

See http://forum.ipxe.org/showthread.php?tid=7551&pid=11280#pid11280

Requires https://github.com/RackHD/on-tasks/pull/12
