### PR TITLE
Add sleep after ifopen in boilerplate.ipxe to temporarily work around…

### DIFF
--- a/data/profiles/boilerplate.ipxe
+++ b/data/profiles/boilerplate.ipxe
@@ -33,6 +33,8 @@ iseq ${interface} ${net${ifIndex}/mac} && goto ifBoot || inc ifIndex && goto ifF
 iseq ${ifBootAttempt} ${ifBootAttemptMax} && goto ifBootFailure || goto ifBootContinue
 :ifBootContinue
 ifopen net${ifIndex}
+echo "Sleeping to allow link up"
+sleep 35
 ifconf net${ifIndex} && goto ifConfigured || inc ifBootAttempt && goto ifBoot
 
 # Find Interface Failure


### PR DESCRIPTION
… spanning tree deployment issues.

Temporary work around to deal with networking issues related to VCE's current rack topology.

See https://hwjiraprd01.corp.emc.com/browse/ODR-220
