### PR TITLE
Added obm setting check when posting or patching in nodes api

### DIFF
--- a/lib/api/nodes.js
+++ b/lib/api/nodes.js
@@ -164,14 +164,31 @@ function nodesRouterFactory (
      *     HTTP/1.1 404 Not Found
      *     {
      *       "error": "Not Found"
-     *      }
+     *     }
+     *     HTTP/1.1 400 Bad Request
+     *     {
+     *       "message": "Service xxx is not supported in node type xxx"
+     *     }
      */
 
     router.patch('/nodes/:identifier', rest(function (req) {
-        return waterline.nodes.updateByIdentifier(
-            req.params.identifier,
-            req.body
-        );
+        return waterline.nodes.needByIdentifier(req.params.identifier)
+        .then(function (node){
+            if (req.body.hasOwnProperty('obmSettings')) {
+                var invalid = ObmService.checkInvalidService(node, req.body.obmSettings);
+                if (invalid) {
+                    throw new Errors.BadRequestError(
+                        'Service ' + invalid + ' is not supported in node type ' + node.type
+                    );
+                }
+            }
+        })
+        .then(function () {
+            return waterline.nodes.updateByIdentifier (
+                req.params.identifier,
+                req.body
+            );
+        });
     }, {
         deserializer: 'Serializables.V1.Node'
     }));
@@ -271,20 +288,31 @@ function nodesRouterFactory (
      *     HTTP/1.1 404 Not Found
      *     {
      *       "error": "Not Found"
-     *      }
+     *     }
+     *     HTTP/1.1 400 Bad Request
+     *     {
+     *       "message": "Service xxx is not supported in node type xxx"
+     *     }
      */
 
     router.post('/nodes/:identifier/obm', rest(function (req) {
         return waterline.nodes.needByIdentifier(req.params.identifier)
-        .then(function (node) {
-            if (node) {
-                var obmSettings = node.obmSettings || [];
-                obmSettings.push(req.body);
-                return waterline.nodes.updateByIdentifier(
-                    req.params.identifier,
-                    { obmSettings: obmSettings }
+        .then(function (node){
+            var invalid = ObmService.checkInvalidService(node, req.body);
+            if (invalid) {
+                throw new Errors.BadRequestError(
+                    'Service ' + invalid + ' is not supported in node type ' + node.type
                 );
             }
+            return node;
+        })
+        .then(function (node) {
+            var obmSettings = node.obmSettings || [];
+            obmSettings.push(req.body);
+            return waterline.nodes.updateByIdentifier(
+                req.params.identifier,
+                { obmSettings: obmSettings }
+            );
         });
     }, {
         deserializer: 'Serializables.V1.Obm',

--- a/lib/api/nodes.js
+++ b/lib/api/nodes.js
@@ -167,20 +167,15 @@ function nodesRouterFactory (
      *     }
      *     HTTP/1.1 400 Bad Request
      *     {
-     *       "message": "Service xxx is not supported in node type xxx"
+     *       "message": "Service xxx is not supported in current node"
      *     }
      */
 
     router.patch('/nodes/:identifier', rest(function (req) {
         return waterline.nodes.needByIdentifier(req.params.identifier)
         .then(function (node){
-            if (req.body.hasOwnProperty('obmSettings')) {
-                var invalid = ObmService.checkInvalidService(node, req.body.obmSettings);
-                if (invalid) {
-                    throw new Errors.BadRequestError(
-                        'Service ' + invalid + ' is not supported in node type ' + node.type
-                    );
-                }
+            if (req.body.obmSettings) {
+                return ObmService.checkValidService(node, req.body.obmSettings);
             }
         })
         .then(function () {
@@ -291,20 +286,17 @@ function nodesRouterFactory (
      *     }
      *     HTTP/1.1 400 Bad Request
      *     {
-     *       "message": "Service xxx is not supported in node type xxx"
+     *       "message": "Service xxx is not supported in current node"
      *     }
      */
 
     router.post('/nodes/:identifier/obm', rest(function (req) {
         return waterline.nodes.needByIdentifier(req.params.identifier)
         .then(function (node){
-            var invalid = ObmService.checkInvalidService(node, req.body);
-            if (invalid) {
-                throw new Errors.BadRequestError(
-                    'Service ' + invalid + ' is not supported in node type ' + node.type
-                );
-            }
-            return node;
+            return ObmService.checkValidService(node, req.body)
+            .then(function () {
+                return node;
+            });
         })
         .then(function (node) {
             var obmSettings = node.obmSettings || [];

--- a/spec/lib/api/nodes-spec.js
+++ b/spec/lib/api/nodes-spec.js
@@ -250,7 +250,7 @@ describe('Http.Api.Nodes', function () {
                 obmSettings: [
                     {
                         config: {},
-                        service: 'noop-obm-service'
+                        service: 'panduit-obm-service'
                     }
                 ]
             };
@@ -269,7 +269,7 @@ describe('Http.Api.Nodes', function () {
 
     describe('DELETE /nodes/:identifier', function () {
         it('should delete a node', function () {
-            waterline.nodes.needByIdentifier.resolves(node)
+            waterline.nodes.needByIdentifier.resolves(node);
             taskGraphProtocol.getActiveTaskGraph.resolves();
             waterline.lookups.update.resolves();
             waterline.nodes.destroy.resolves();
@@ -351,7 +351,7 @@ describe('Http.Api.Nodes', function () {
 
         it('should add a new set of OBM settings if none exist', function () {
             waterline.nodes.needByIdentifier.resolves({ id: node.id });
-            var updated = { id: node.id, obmSettings: [ obmSetting] };
+            var updated = { id: node.id, obmSettings: [ obmSetting ] };
             waterline.nodes.updateByIdentifier.resolves(updated);
             return helper.request().post('/api/1.1/nodes/1234/obm')
                 .send(obmSetting)
@@ -378,7 +378,7 @@ describe('Http.Api.Nodes', function () {
         it('should not add a new unsupported OBM settings', function () {
             var invalidSetting = {
                 config: {},
-                service: 'noop-obm-service'
+                service: 'panduit-obm-service'
             };
 
             waterline.nodes.needByIdentifier.resolves(node);


### PR DESCRIPTION
Only enclosure node supports Panduit OBM settings, so adding check of invalid obm settings when user post or patch this info.
In this implementation, compute node only supports ipmi obm settings, and enclosure node only supports Panduit.

https://hwjiraprd01.corp.emc.com/browse/MAG-222

Related PRs:
https://github.com/RackHD/on-tasks/pull/55
https://github.com/RackHD/on-core/pull/22