### PR TITLE
Fix ODR-260 and provide solution for RHEL/CentOS 7 network setting failure issue

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -9,7 +9,7 @@ keyboard 'us'
 timezone America/Los_Angeles --isUtc
 firewall --enabled --http --ssh
 selinux --permissive
-bootloader --location=mbr --driveorder=sda --append="crashkernel=auth rhgb"
+bootloader --location=mbr --driveorder=sda --append="crashkernel=auth rhgb net.ifnames=0 biosdevname=0"
 services --enabled=NetworkManager,sshd
 network --device=<%=macaddress%> --noipv6 --activate
 
@@ -58,6 +58,8 @@ net-tools
 %post --log=/root/install-post.log
 (
 # PLACE YOUR POST DIRECTIVES HERE
+rm -f /etc/sysconfig/network-scripts/ifcfg-*
+rm -f /etc/udev/rules.d/70-persistent-net.rule
 PATH=/bin:/sbin:/usr/bin:/usr/sbin
 export PATH
 


### PR DESCRIPTION
To fix ODR-260 and provide solution for RHEL/CentOS 7 network setting failure issue in some cases (apply to ODR-319). 
* ODR-260: RHEL/CentOS bootstrap failed to set network on D51 sometimes
* Fix issue that T41 network setting won't take effective until we reboot OS manually after RHEL7/CentOS7 bootstrapping (part of ODR-319).

I tested this change with configuration of (RHEL7/CentOS7+T41), (RHEL7+D51). All network settings are good and it solved RHEL7/CentOS7 network related issues we have seen before.   