### PR TITLE
remove  node update based on enclosure node update

### DIFF
--- a/lib/api/nodes.js
+++ b/lib/api/nodes.js
@@ -12,13 +12,13 @@ di.annotate(nodesRouterFactory, new di.Inject(
         'Services.Waterline',
         'Protocol.TaskGraphRunner',
         'Http.Services.RestApi',
+        'Http.Services.Api.Nodes',
         'Services.Configuration',
         'Task.Services.OBM',
         'ipmi-obm-service',
         'Logger',
         '_',
-        'Errors',
-        'Promise'
+        'Errors'
     )
 );
 
@@ -26,13 +26,13 @@ function nodesRouterFactory (
     waterline,
     taskGraphProtocol,
     rest,
+    nodeApiService,
     configuration,
     ObmService,
     ipmiObmServiceFactory,
     Logger,
     _,
-    Errors,
-    Promise
+    Errors
 ) {
     var router = express.Router();
 
@@ -209,27 +209,7 @@ function nodesRouterFactory (
     router.delete('/nodes/:identifier', rest(function (req) {
         return waterline.nodes.needByIdentifier(req.params.identifier)
         .then(function (node) {
-            return taskGraphProtocol.getActiveTaskGraph( { target: node.id })
-            .then(function (graph) {
-                if (graph) {
-                    throw new Errors.BadRequestError('Could not remove node ' + node.id +
-                        ', active workflow is running');
-                }
-            })
-            .then(function () {
-                return Promise.settle([
-                    //lookups should be destoryed here, only clear node field
-                    //as a workaround until the issue that when lookups are cleared
-                    //it cannot be updated timely in nodes' next bootup is fixed
-                    waterline.lookups.update({ node: node.id },{ node: '' } ),
-                    waterline.nodes.destroy({ id: node.id }),
-                    waterline.catalogs.destroy({ node: node.id }),
-                    waterline.workitems.destroy({ node: node.id })
-                    ]);
-            })
-            .then(function () {
-                return node;
-            });
+            return nodeApiService.removeNode(node);
         });
     }));
 

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -1,0 +1,132 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = nodeApiServiceFactory;
+di.annotate(nodeApiServiceFactory, new di.Provide('Http.Services.Api.Nodes'));
+di.annotate(nodeApiServiceFactory,
+    new di.Inject(
+        'Protocol.TaskGraphRunner',
+        'Services.Waterline',
+        'Errors',
+        'Logger',
+        '_',
+        'Promise'
+    )
+);
+function nodeApiServiceFactory(
+    taskGraphProtocol,
+    waterline,
+    Errors,
+    Logger,
+    _,
+    Promise
+) {
+    var logger = Logger.initialize(nodeApiServiceFactory);
+
+    function NodeApiService() {
+    }
+
+    /**
+     * Find Enclosure nodes which enclose compute node
+     * @param  {Object}     node
+     * @return {Promise}
+     */
+    NodeApiService.prototype._findEnclNodes = function(node) {
+        // Find the enclosure nodes who enclose this compute node
+        if (!_.has(node, 'relations')) {
+            return Promise.resolve();
+        }
+
+        var relation = _.find(node.relations, { relationType: 'enclosedBy' });
+        if (!relation || !_.has(relation, 'targets') ) {
+            return Promise.resolve();
+        }
+
+        return Promise.map(relation.targets, function (enclNodeId) {
+            return waterline.nodes.needByIdentifier(enclNodeId)
+            .catch(function (err) {
+                logger.error("Error Getting Enclosure Node", { error: err });
+                return;
+            });
+        });
+    };
+
+    /**
+     * Remove the relations between node and enclosure node, if enclosure node
+     * doesn't enclose any nodes, this enclosure node is also removed.
+     * @param  {Object}     node
+     * @param  {Array}      enclNodes
+     * @return {Promise}
+     */
+    NodeApiService.prototype._removeEnclRelations = function(node, enclNodes) {
+        if (!enclNodes) {
+            return Promise.resolve();
+        }
+
+        // Remove the relationship between enclosure and compute node
+        return Promise.map(enclNodes, function(enclNode) {
+            if (!_.has(enclNode, 'relations')) {
+                return;
+            }
+
+            var index = _.findIndex(enclNode.relations, { relationType: 'encloses' });
+            if (index === -1 || !_.has(enclNode.relations[index], 'targets')) {
+                return;
+            }
+
+            if (_.indexOf(enclNode.relations[index].targets, node.id) !== -1) {
+                _.pull(enclNode.relations[index].targets, node.id);
+            }
+            // If Enclosure node doesn't have enclosed nodes
+            // remove this enclosure node, else remove relationships
+            if (enclNode.relations[index].targets.length === 0) {
+                return waterline.nodes.destroy({ id: enclNode.id });
+            } else {
+                return waterline.nodes.updateByIdentifier(
+                    enclNode.id, { relations : enclNode.relations });
+            }
+        });
+    };
+
+    /**
+     * Remove node related data and remove its relations with other nodes
+     * @param  {Object}     node
+     * @return {Promise}
+     */
+    NodeApiService.prototype.removeNode = function(node) {
+        var self = this;
+
+        return taskGraphProtocol.getActiveTaskGraph( { target: node.id })
+        .then(function (graph) {
+            if (graph) {
+                throw new Errors.BadRequestError('Could not remove node ' + node.id +
+                    ', active workflow is running');
+            }
+        })
+        .then(function () {
+            return Promise.settle([
+                //lookups should be destoryed here, only clear node field
+                //as a workaround until the issue that when lookups are cleared
+                //it cannot be updated timely in nodes' next bootup is fixed
+                waterline.lookups.update({ node: node.id },{ node: '' } ),
+                waterline.nodes.destroy({ id: node.id }),
+                waterline.catalogs.destroy({ node: node.id }),
+                waterline.workitems.destroy({ node: node.id })
+                ]);
+        })
+        .then(function () {
+            return self._findEnclNodes(node);
+        })
+        .then(function (enclNodes) {
+            return self._removeEnclRelations(node, enclNodes);
+        })
+        .then(function () {
+            return node;
+        });
+    };
+
+    return new NodeApiService();
+}

--- a/spec/lib/api/nodes-spec.js
+++ b/spec/lib/api/nodes-spec.js
@@ -8,6 +8,7 @@ describe('Http.Api.Nodes', function () {
     var waterline;
     var ObmService;
     var taskGraphProtocol;
+    var nodeApiService;
     var Promise;
     var Errors;
 
@@ -28,7 +29,9 @@ describe('Http.Api.Nodes', function () {
             sinon.stub(ObmService.prototype, 'identifyOn');
             sinon.stub(ObmService.prototype, 'identifyOff');
             taskGraphProtocol = helper.injector.get('Protocol.TaskGraphRunner');
+            nodeApiService = helper.injector.get('Http.Services.Api.Nodes');
             sinon.stub(taskGraphProtocol);
+            sinon.stub(nodeApiService);
 
             Promise = helper.injector.get('Promise');
             Errors = helper.injector.get('Errors');
@@ -50,6 +53,7 @@ describe('Http.Api.Nodes', function () {
         resetStubs(waterline.workitems);
         resetStubs(waterline.graphobjects);
         resetStubs(taskGraphProtocol);
+        resetStubs(nodeApiService);
 
         ObmService.prototype.identifyOn.reset();
         ObmService.prototype.identifyOff.reset();
@@ -270,23 +274,13 @@ describe('Http.Api.Nodes', function () {
     describe('DELETE /nodes/:identifier', function () {
         it('should delete a node', function () {
             waterline.nodes.needByIdentifier.resolves(node);
-            taskGraphProtocol.getActiveTaskGraph.resolves();
-            waterline.lookups.update.resolves();
-            waterline.nodes.destroy.resolves();
-            waterline.catalogs.destroy.resolves();
-            waterline.workitems.destroy.resolves();
+            nodeApiService.removeNode.resolves(node);
 
             return helper.request().delete('/api/1.1/nodes/1234')
                 .expect('Content-Type', /^application\/json/)
                 .expect(200, node)
                 .expect(function () {
-                    expect(taskGraphProtocol.getActiveTaskGraph).to.have.been.calledOnce;
-                    expect(waterline.lookups.update).to.have.been.calledOnce;
-                    expect(waterline.nodes.destroy).to.have.been.calledOnce;
-                    expect(waterline.catalogs.destroy).to.have.been.calledOnce;
-                    expect(waterline.workitems.destroy).to.have.been.calledOnce;
-                    expect(waterline.nodes.destroy.firstCall.args[0])
-                        .to.have.property('id').that.equals(node.id);
+                    expect(nodeApiService.removeNode).to.have.been.calledOnce;
                 });
         });
 

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -1,0 +1,251 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+"use strict";
+
+describe("Http.Services.Api.Nodes", function () {
+    var nodeApiService;
+    var Errors;
+    var taskGraphProtocol;
+    var waterline;
+
+    var computeNode = {
+        id: '1234abcd1234abcd1234abcd',
+        name: 'computeNode',
+        relations: [
+            {
+                "relationType": "enclosedBy",
+                "targets": [
+                    "1234abcd1234abcd1234abcf"
+                ]
+            }
+        ]
+    };
+    var enclosureNode = {
+        id: '1234abcd1234abcd1234abcf',
+        name: 'enclosureNode',
+        relations: [
+            {
+                "relationType": "encloses",
+                "targets": [
+                    "1234abcd1234abcd1234abcd",
+                    "1234abcd1234abcd1234abce"
+                ]
+            }
+        ]
+    };
+    var enclosureNode1 = {
+        id: '1234abcd1234abcd1234abcf',
+        name: 'enclosureNode',
+        relations: [
+            {
+                "relationType": "encloses",
+                "targets": [
+                    "1234abcd1234abcd1234abcd"
+                ]
+            }
+        ]
+    };
+
+    before("Http.Services.Api.Nodes before", function() {
+        helper.setupInjector([
+            helper.require("/lib/services/nodes-api-service")
+        ]);
+        nodeApiService = helper.injector.get("Http.Services.Api.Nodes");
+        Errors = helper.injector.get("Errors");
+        taskGraphProtocol = helper.injector.get("Protocol.TaskGraphRunner");
+        waterline = helper.injector.get('Services.Waterline');
+        waterline.nodes = {
+            needByIdentifier: function() {},
+            updateByIdentifier: function() {},
+            destroy: function() {}
+        };
+        waterline.catalogs = {
+            destroy: function() {}
+        };
+        waterline.workitems = {
+            destroy: function() {}
+        };
+        waterline.lookups = {
+            update: function() {}
+        };
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach("Http.Services.Api.Nodes beforeEach", function() {
+    });
+
+    afterEach("Http.Services.Api.Nodes afterEach", function() {
+        this.sandbox.restore();
+    });
+
+    describe("removeNode", function() {
+        before("removeNode before", function() {
+        });
+
+        beforeEach(function() {
+            this.sandbox.stub(waterline.lookups, 'update').resolves();
+            this.sandbox.stub(waterline.nodes, 'destroy').resolves();
+            this.sandbox.stub(waterline.workitems, 'destroy').resolves();
+            this.sandbox.stub(waterline.catalogs, 'destroy').resolves();
+        });
+
+        it("removeNode should fail when a workflow is running", function() {
+            this.sandbox.stub(taskGraphProtocol, 'getActiveTaskGraph').resolves('true');
+            return expect(nodeApiService.removeNode(computeNode))
+                   .to.be.rejectedWith(Errors.BadRequestError);
+        });
+
+        it("removeNode should remove one node", function() {
+            this.sandbox.stub(taskGraphProtocol, 'getActiveTaskGraph').resolves('');
+            this.sandbox.stub(nodeApiService, '_findEnclNodes').resolves();
+            this.sandbox.stub(nodeApiService, '_removeEnclRelations').resolves();
+
+            return nodeApiService.removeNode(computeNode)
+            .then(function (node) {
+                expect(waterline.lookups.update).to.have.been.calledOnce;
+                expect(waterline.nodes.destroy).to.have.been.calledOnce;
+                expect(waterline.catalogs.destroy).to.have.been.calledOnce;
+                expect(waterline.workitems.destroy).to.have.been.calledOnce;
+                expect(nodeApiService._findEnclNodes).to.have.been.calledOnce;
+                expect(nodeApiService._removeEnclRelations).to.have.been.calledOnce;
+                expect(node).to.equal(computeNode);
+            });
+        });
+    });
+    describe("_findEnclNodes", function() {
+        before("_findEnclNodes before", function() {
+        });
+
+        beforeEach(function() {
+        });
+
+        it("_findEnclNodes should find related enclosure nodes", function() {
+            this.sandbox.stub(waterline.nodes, 'needByIdentifier').resolves(enclosureNode);
+
+            return nodeApiService._findEnclNodes(computeNode)
+            .then(function (nodes) {
+                expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
+                expect(nodes[0]).to.equal(enclosureNode);
+            });
+        });
+
+        it("_findEnclNodes should return nothing if cannot find enclosure node", function() {
+            this.sandbox.stub(waterline.nodes, 'needByIdentifier').rejects(Errors.NotFoundError(''));
+
+            return nodeApiService._findEnclNodes(computeNode)
+            .then(function (nodes) {
+                expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
+                expect(nodes[0]).to.equal(undefined);
+            });
+        });
+
+        it("_findEnclNodes should return nothing if don't have relations", function() {
+            var node = {
+                id: '1234abcd1234abcd1234abcd',
+                name: 'computeNode'
+            };
+
+            return nodeApiService._findEnclNodes(node)
+            .then(function (nodes) {
+                expect(nodes).to.equal(undefined);
+            });
+        });
+
+        it("_findEnclNodes should return nothing if node is null", function() {
+
+            return nodeApiService._findEnclNodes(null)
+            .then(function (nodes) {
+                expect(nodes).to.equal(undefined);
+            });
+        });
+
+    });
+
+    describe("_removeEnclRelations", function() {
+        before("_removeEnclRelations before", function() {
+        });
+
+        beforeEach(function() {
+            this.sandbox.stub(waterline.nodes, 'updateByIdentifier').resolves();
+            this.sandbox.stub(waterline.nodes, 'destroy').resolves();
+        });
+
+        it("_removeEnclRelations should fail if enclosure node is null", function() {
+            return nodeApiService._removeEnclRelations(computeNode, null)
+            .then(function () {
+                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
+                expect(waterline.nodes.destroy).to.not.have.been.called;
+            });
+        });
+
+        it("_removeEnclRelations should fail if enclosure node is null", function() {
+            var enclNodes = [
+                {
+                    id: '1234abcd1234abcd1234abcd',
+                    name: 'computeNode'
+                }
+            ];
+
+            return nodeApiService._removeEnclRelations(computeNode, enclNodes)
+            .then(function () {
+                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
+                expect(waterline.nodes.destroy).to.not.have.been.called;
+            });
+        });
+
+        it("_removeEnclRelations should fail if relationType is incorrect", function() {
+            var enclNodes = [
+                {
+                    id: '1234abcd1234abcd1234abcd',
+                    name: 'computeNode',
+                    relations: [
+                        {
+                            "relationType": "enclosedBy",
+                        }
+                    ]
+                }
+            ];
+
+            return nodeApiService._removeEnclRelations(computeNode, enclNodes)
+            .then(function () {
+                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
+                expect(waterline.nodes.destroy).to.not.have.been.called;
+            });
+        });
+
+        it("_removeEnclRelations should fail if don't have targets", function() {
+            var enclNodes = [
+                {
+                    id: '1234abcd1234abcd1234abcd',
+                    name: 'computeNode',
+                    relations: [
+                        {
+                            "relationType": "encloses"
+                        }
+                    ]
+                }
+            ];
+
+            return nodeApiService._removeEnclRelations(computeNode, enclNodes)
+            .then(function () {
+                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
+                expect(waterline.nodes.destroy).to.not.have.been.called;
+            });
+        });
+
+        it("_removeEnclRelations should remove relations", function() {
+            return nodeApiService._removeEnclRelations(computeNode, [enclosureNode])
+            .then(function () {
+                expect(waterline.nodes.updateByIdentifier).to.have.been.calledOnce;
+            });
+        });
+
+        it("_removeEnclRelations should remove enclosure node when it has no relations", function() {
+            return nodeApiService._removeEnclRelations(computeNode, [enclosureNode1])
+            .then(function () {
+                expect(waterline.nodes.destroy).to.have.been.calledOnce;
+            });
+        });
+    });
+});


### PR DESCRIPTION
Update removing node based on @iceiilin 's PR https://github.com/RackHD/on-tasks/pull/26 
1. when removing a compute node, check the relationship within this node, if it's enclosed by an enclosure node, after remove compute node, also remove the relationship within enclosure node, when all nodes   of an enclosure are removed, remove the enclosure automatically.
2. add nodes-api-service.js to handle nodes api function.
3. add unit tests