### PR TITLE
Fix ODR-241/ODR-236: change vlan ID as optional value for install Cen…

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -99,7 +99,7 @@ echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/ne
         <% }); %>
       <% } else { %>
         echo "Configuring device <%=n.device%>"
-        echo "DEVICE=<%=n.device%>.<%=vid%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+        echo "DEVICE=<%=n.device%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "IPADDR=<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
@@ -122,7 +122,7 @@ echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/ne
         <% }); %>
       <% } else { %>
         echo "Configuring device <%=n.device%>"
-        echo "DEVICE=<%=n.device%>.<%=vid%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+        echo "DEVICE=<%=n.device%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "IPV6INIT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>


### PR DESCRIPTION
Fix ODR-241 & ODR-236, the vlan ID is optional value for OS installation, but the kickstart file falsely to reference it while the vlan ID is undefined.

Previously I had opened a PR (https://github.com/RackHD/on-http/pull/20)  with the same change, it has been reviewed pass, but I closed it due to duplicated commit, then the duplicated PR was closed by me due to need additional code improvement.

The same change for 1.0.0 branch has been merged: https://github.com/RackHD/on-http/pull/25

Opened this PR again to keep the master branch sync with 1.0.0.

@RackHD/corecommitters @zyoung51 @pengz1 @iceiilin @WangWinson 