### PR TITLE
Revert ac2b3983eede591bc37ad6b97f1de06d9be05781

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -9,7 +9,7 @@ keyboard 'us'
 timezone America/Los_Angeles --isUtc
 firewall --enabled --http --ssh
 selinux --permissive
-bootloader --location=mbr --driveorder=sda --append="crashkernel=auth rhgb net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --driveorder=sda --append="crashkernel=auth rhgb"
 services --enabled=NetworkManager,sshd
 network --device=<%=macaddress%> --noipv6 --activate
 
@@ -58,8 +58,6 @@ net-tools
 %post --log=/root/install-post.log
 (
 # PLACE YOUR POST DIRECTIVES HERE
-rm -f /etc/sysconfig/network-scripts/ifcfg-*
-rm -f /etc/udev/rules.d/70-persistent-net.rule
 PATH=/bin:/sbin:/usr/bin:/usr/sbin
 export PATH
 


### PR DESCRIPTION
Reverts RackHD/on-http#31

From https://github.com/RackHD/on-http/pull/31

```
well crud. -1 -1 -1 -1 -1 -1 -1
The issue that spawned this wasn't fixed by it in the real deployment. In fact, during deployment testing, the .ifname=0 (going back to trusting the old-style kernel names) showed inconsistent naming during installs: a few times eth0 got mapped to the first mez card, most other times it got mapped to the 2nd mez.

We need to revert this, since it will also mess up regression tests because of the name changes again.
```

@pengz1 @keedya @yyscamper @zyoung51 @stuart-stanley 

Redirect questions to me to @stuart-stanley, it just seems he doesn't have permissions to create the revert PR so I'm doing it for him :)