### PR TITLE
Remove sudo and package dependencies from travis file (so we can have…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
-sudo: required
 language: node_js
 node_js:
   - "0.10"
 services:
  - mongodb
  - rabbitmq
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq snmp
 after_success:
  - ./node_modules/.bin/istanbul cover -x "**/spec/**" ./node_modules/.bin/_mocha --report lcovonly -- $(find spec -name '*-spec.js') -R spec --require spec/helper.js
  - cat ./coverage/lcov.info | node_modules/.bin/coveralls


### PR DESCRIPTION
… travis containers)

Our unit tests here shouldn't require sudo or apt updates, so remove them in order to support new travis containerized infrastructure.