### PR TITLE
esx-ks reboot delay fix for 5.5 support

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -119,4 +119,4 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 
 
 #reboot the system after host configuration
-esxcli system shutdown reboot -d 5 -r "Rebooting after first boot host configuration"
+esxcli system shutdown reboot -d 10 -r "Rebooting after first boot host configuration"


### PR DESCRIPTION
Adjusted this value since it wasn't valid and causes the first boot config not to take place unless another reboot is manually applied.

Here is an error if you manually try to run the old command on 5.5

    esxcli system shutdown reboot -d 5 -r "Rebooting after first boot host configuration"
    Invalid data constraint for parameter 'delay'. Expected integer in the range 10-4294967295