### PR TITLE
VEY-230: Add switch configurationa nd vmnic configuration to esx-ks

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -6,7 +6,30 @@ accepteula
 <% } %>
 install --firstdisk --overwritevmfs
 rootpw <%=rootPlainPassword%>
-network --bootproto=dhcp --device=vmnic0
+
+# Search the networkDevices and set the first vmnic# (if defined) up.
+# If no vmnic# device is specified in the networkDevices, then we fallback
+# to setting vmnic0 up as dhcp
+<% if( undefined !== networkDevices ) { %>
+  <% need_default = networkDevices.every(function(n) { %>
+    <% if( n.device.substring(0,5) === 'vmnic' ) { %>
+      <% if(typeof n.ipv4 !== 'undefined') { %>
+        <% ipopts = '--ip=' + n.ipv4.ipAddr + ' --gateway=' + n.ipv4.gateway + ' --netmask=' + n.ipv4.netmask %>
+        <% if (typeof n.ipv4.vlanId !== 'undefined' ) { %>
+          <% ipopts += ' --vlandid=' + n.ipv4.vlanId[0] %>
+        <% } %>
+        network --bootproto=static --device=<%=n.device%> <%=ipopts%>
+      <% } else { %>
+        network --bootproto=dhcp --device=<%=n.device%>
+      <% } %>
+      <% return false; %>
+    <% } %>
+    <% return true; %>
+  <% }); %>
+  <% if (need_default) { %>
+    network --bootproto=dhcp --device=vmnic0
+  <% } %>
+<% } %>
 reboot
 
 %firstboot --interpreter=busybox
@@ -70,17 +93,29 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
   <% }); %>
 <% } %>
 
-#signify ORA the installation completed
-/usr/bin/wget --spider http://<%=server%>:<%=port%>/api/common/templates/renasar-ansible.pub
+<% if ( typeof switchDevices !== 'undefined' ) { %>
+  <% switchDevices.forEach(function(n) { %>
+    esxcli network vswitch standard add -v "<%=n.switchName%>"
+    <% if( undefined !== n.uplinks ) { %>
+      <% n.uplinks.forEach(function(s) { %>
+        currsw=`esxcli --debug --formatter=csv network vswitch standard list | grep <%=s%> | awk -F, '{print $9}'`
+        if [ "$currsw" != "" ]; then
+          esxcli network vswitch standard uplink remove -v $currsw -u <%=s%>
+        fi
+        esxcli network vswitch standard uplink add -v <%=n.switchName%> -u <%=s%>
+      <% }); %>
+    <% } %>
+  <% }); %>
+<% } %>
 
 <% vmkid = 0 %>
 <% if( undefined !== networkDevices ) { %>
   <% networkDevices.forEach(function(n) { %>
-    <% if( undefined != n.ipv4 ) { %>
-      <% if( undefined != n.ipv4.vlanId ) { %>
+    <% if( undefined !== n.ipv4 ) { %>
+      <% if( undefined !== n.ipv4.vlanId ) { %>
         <% n.ipv4.vlanId.forEach(function(vid) { %>
           <% vmkname = 'vmk' + vmkid++ %>
-          esxcli network vswitch standard portgroup add -p <%=n.device%>.<%=vid%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
+          esxcli network vswitch standard portgroup add -p <%=n.device%>.<%=vid%> -v "<%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>"
           esxcli network ip interface remove -i <%=vmkname%>
           esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>.<%=vid%>
           esxcli network ip interface ipv4 set -i <%=vmkname%> -I <%=n.ipv4.ipAddr%> -N <%=n.ipv4.netmask%> -t static
@@ -96,8 +131,8 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
         esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%> 
       <% } %>
     <% } %>
-    <% if( undefined != n.ipv6 ) { %>
-      <% if( undefined != n.ipv6.vlanId ) { %>
+    <% if( undefined !== n.ipv6 ) { %>
+      <% if( undefined !== n.ipv6.vlanId ) { %>
         <% n.ipv6.vlanId.forEach(function(vid) { %>
           <% vmkname = 'vmk' + vmkid++ %>
           esxcli network vswitch standard portgroup add -p <%=n.device%>.<%=vid%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
@@ -114,9 +149,24 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
         esxcli network ip interface ipv6 address add -i <%=vmkname%> -I <%=n.ipv6.ipAddr%>
       <% } %>
     <% } %>
+    <% if( (undefined === n.ipv6) && (undefined === n.ipv4) ) { %>
+      <% vmkname = 'vmk' + vmkid++ %>
+      esxcli network vswitch standard portgroup add -p <%=n.device%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
+      esxcli network ip interface remove -i <%=vmkname%>
+      esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>
+      esxcli network ip interface ipv4 set -i <%=vmkname%> -t dhcp
+    <% } %>
   <% }); %>
 <% } %>
 
+<% if( typeof postInstallCommands !== 'undefined' ) { %>
+  <% postInstallCommands.forEach(function(n) { %>
+    <%=n%>
+  <% }); %>
+<% } %>
+
+#signify ORA the installation completed
+/usr/bin/wget --spider http://<%=server%>:<%=port%>/api/common/templates/renasar-ansible.pub
 
 #reboot the system after host configuration
 esxcli system shutdown reboot -d 5 -r "Rebooting after first boot host configuration"


### PR DESCRIPTION
- Defining a 'vmnic#' device name in networkDevices will select which vmnic is
  bound to vSwitch0 during initial install.
- 'esxSwitchName' parameter can be specified in networkDevices objects to
  control which vSwitch the port group is bound to.  This example would put
  the pg-name portgroup on vSwitch1 and put vmk# in the pg-name portgroup with
  the proper IP settings:
        {
        "device": "pg-name",
        "esxSwitchName": "vSwitch1",
        "ipv4": {
            "netmask": "255.255.255.0",
            "ipAddr": "172.31.128.10",
            "gateway": "172.31.128.1"
          }
      }
- 'switchDevices' parameter is added to create vswitches and control what uplinks
  are on the switch.  if 'uplink' is not specified, then the switch is created with
  no uplinks (internal switch)

  This would create vSwitch1 with vmnic1 as an uplink, and create "internal name" with no uplinks:
     "switchDevices" : [{ "switchName": "vSwitch1", "uplinks": [ "vmnic1" ] }, { "switchName": "internal name" }],

- 'postInstallCommands' parameter is added to run additional commands during the post-installation
  step of the workflow.

  For example, to create a specific vmk50 on portgroup vmnic0 using dhcp:
  "postInstallCommands": [ "esxcli network ip interface add -i vmk50 -p vmnic0", "esxcli network ip interface ipv4 set -i vmk50 -t dhcp" ]