### PR TITLE
renaming to RackHD API

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "xunit-file": "0.0.6"
   },
   "apidoc": {
-    "name": "Monorail API Documentation",
+    "name": "RackHD API Documentation",
     "version": "1.1.0",
-    "description": "Monorail API Documentation",
-    "title": "Monorai API Documentation",
+    "description": "RackHD API Documentation",
+    "title": "RackHD API Documentation",
     "url": "http://servername:80",
     "header": {
       "title": "About",

--- a/static/apidoc/header.md
+++ b/static/apidoc/header.md
@@ -1,2 +1,4 @@
+For more information on how to use these APIs, please also see our development
+guide documentation at http://rackhd.readthedocs.org/en/latest/development_guide.html
 
 &copy;2015, EMC, Inc.


### PR DESCRIPTION
* renaming from Monorail to RackHD API for the generated documentation
* adding a header link to our hosted, latest online documentation for a developer's guide