### PR TITLE
Update ks start file to include driveId option for bootstrap

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -9,7 +9,11 @@ keyboard 'us'
 timezone America/Los_Angeles --isUtc
 firewall --enabled --http --ssh
 selinux --permissive
-bootloader --location=mbr --driveorder=sda --append="crashkernel=auth rhgb"
+<% if (version === "6.5") { %>
+  bootloader --location=mbr --driveorder=<%=driveId%> --append="crashkernel=auth rhgb"
+<% } else { %>
+  bootloader --location=mbr --driveorder=<%=driveId%> --boot-drive=<%=driveId%> --append="crashkernel=auth rhgb"
+<% } %>
 services --enabled=NetworkManager,sshd
 network --device=<%=macaddress%> --noipv6 --activate
 

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -1,6 +1,10 @@
 accepteula
 clearpart --alldrives --overwritevmfs
-install --firstdisk --overwritevmfs
+<% if (driveId === "firstdisk") { %>
+  install --firstdisk --overwritevmfs
+<% } else { %>
+  install --disk=<%=driveId%> --overwritevmfs
+<% } %>
 rootpw <%=rootPlainPassword%>
 
 # Search the networkDevices and set the first vmnic# (if defined) up.


### PR DESCRIPTION
Update ks file to include driveId option for bootstrap.
For esx, we add driveId with default value "firstdisk". If no driveId is assigned, --firstdisk value will be used in ks. Other wise --drive value will be enabled.
For centos, driveId defautl is sda if no driveId is assgined. However since 6.5 doesn't have --boot-drive value, we need to judge if centos/rhel version is 6.5
This PR is related to https://github.com/RackHD/on-tasks/pull/69.