### PR TITLE
install os only clear partition for target disk, not all

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -10,9 +10,9 @@ timezone America/Los_Angeles --isUtc
 firewall --enabled --http --ssh
 selinux --permissive
 <% if (version === "6.5") { %>
-  bootloader --location=mbr --driveorder=<%=driveId%> --append="crashkernel=auth rhgb"
+  bootloader --location=mbr --driveorder=<%=installDisk%> --append="crashkernel=auth rhgb"
 <% } else { %>
-  bootloader --location=mbr --driveorder=<%=driveId%> --boot-drive=<%=driveId%> --append="crashkernel=auth rhgb"
+  bootloader --location=mbr --driveorder=<%=installDisk%> --boot-drive=<%=installDisk%> --append="crashkernel=auth rhgb"
 <% } %>
 services --enabled=NetworkManager,sshd
 network --device=<%=macaddress%> --noipv6 --activate
@@ -32,8 +32,7 @@ rootpw --iscrypted <%=rootEncryptedPassword%>
 
 # Disk Partitioning
 zerombr
-clearpart --all --initlabel
-#clearpart --all --initlabel --drives=sda
+clearpart --all --drives=<%=installDisk%>
 autopart
 # END of Disk Partitioning
 

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -1,9 +1,10 @@
 accepteula
-clearpart --alldrives --overwritevmfs
-<% if (driveId === "firstdisk") { %>
+<% if (installDisk === "firstdisk") { %>
+  clearpart --firstdisk --overwritevmfs
   install --firstdisk --overwritevmfs
 <% } else { %>
-  install --disk=<%=driveId%> --overwritevmfs
+  clearpart --drives=<%=installDisk%> --overwritevmfs
+  install --disk=<%=installDisk%> --overwritevmfs
 <% } %>
 rootpw <%=rootPlainPassword%>
 


### PR DESCRIPTION
For ESXi/RHEL/CentOS installation, previously we will clear all disks partition, so the compute node can only install one OS. With this fix, user can install different OS in different disk, the kickstart file will only clear the target drive partition (not all), so different OS can coexist.

@RackHD/corecommitters @iceiilin @sunnyqianzhang @pengz1 @WangWinson 