### PR TITLE
Modify apidoc about deleting active workflow

### DIFF
--- a/lib/api/nodes.js
+++ b/lib/api/nodes.js
@@ -555,10 +555,9 @@ function nodesRouterFactory (
      * @apiName node-workflows-active-delete
      * @apiGroup nodes
      * @apiParam {String} identifier node identifier
-     * @apiSuccess {json} workflow  the deleted active workflow for that node.
-     * @apiError NotFound1 The node with the <code>identifier</code> was not found.
-     * @apiError NotFound2 The node with the <code>identifier</code> does not have an
-     *                     active workflow.
+     * @apiSuccess (Success 200) {json} workflow  the deleted active workflow for that node.
+     * @apiSuccess (Success 204) empty no acitve workflow
+     * @apiError NotFound The node with the <code>identifier</code> was not found.
      * @apiErrorExample Error-Response:
      *     HTTP/1.1 404 Not Found
      *     {


### PR DESCRIPTION
https://hwjiraprd01.corp.emc.com/browse/ODR-346 complaining the inconsistent return code between operation and doc about deleting active workflow api.
Add success code 204 in apidoc, since "204 No Content: The server successfully processed the request, but is not returning any content" from wikipedia; there is no active workflow after this command, so we can view it as success, though no graph id will be returned.