### PR TITLE
adding optional KVM trigger to install KVM related packages

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -54,11 +54,11 @@ perl
 libselinux-python
 net-tools
 <% if( undefined !== kvm ) { %>
-kvm
-virt-manager
-libvirt
-libvirt-python
-python-virtinst
+    kvm
+    virt-manager
+    libvirt
+    libvirt-python
+    python-virtinst
 <% } %>
 %end
 

--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -53,6 +53,13 @@ sudo
 perl
 libselinux-python
 net-tools
+<% if( undefined !== kvm ) { %>
+kvm
+virt-manager
+libvirt
+libvirt-python
+python-virtinst
+<% } %>
 %end
 
 %pre


### PR DESCRIPTION
to support additional calls into RackHD for installing KVM packages per details at https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Virtualization/sect-Virtualization-Installing_the_virtualization_packages-Installing_KVM_packages_on_an_existing_Red_Hat_Enterprise_Linux_system.html

requires https://github.com/RackHD/on-tasks/pull/90 to be functional, but should merge cleanly regardless