### PR TITLE
Add creating proxy function to http-service

### DIFF
--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -178,7 +178,7 @@ function httpServiceFactory(
 
         var httpProxies = configuration.get('httpProxies');
         if (httpProxies && _.isArray(httpProxies)) {
-            _.forEach(httpProxies, createHttpProxy);
+            _.forEach(httpProxies, createHttpProxy.bind(this, app));
         }
 
         if (configuration.get('httpEnabled', true)) {
@@ -263,7 +263,7 @@ function httpServiceFactory(
      * @param {Object} httpProxy - proxy parameters
      * @returns
      */
-    function createHttpProxy(httpProxy){
+    function createHttpProxy(app, httpProxy){
         try {
             var localPath = httpProxy.localPath || '/',
                 remotePath = httpProxy.remotePath || '/',

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -9,6 +9,8 @@ var onFinished = require('on-finished');
 var http = require('http');
 var https = require('https');
 var fs = require('fs');
+var proxy = require('express-http-proxy');
+var path = require('path');
 
 /**
  * Get remote address of the client.
@@ -38,19 +40,20 @@ module.exports = httpServiceFactory;
 di.annotate(httpServiceFactory, new di.Provide('Http.Server'));
 di.annotate(httpServiceFactory,
     new di.Inject(
-            'Protocol.Events',
-            'Services.Configuration',
-            'Services.Lookup',
-            'express-app',
-            'Logger',
-            'Promise',
-            'common-api-router',
-            'Events',
-            'Errors',
-            'Services.WebSocket',
-            'Http.Services.SkuPack'
-        )
-    );
+        'Protocol.Events',
+        'Services.Configuration',
+        'Services.Lookup',
+        'express-app',
+        'Logger',
+        'Promise',
+        'common-api-router',
+        'Events',
+        'Errors',
+        'Services.WebSocket',
+        'Http.Services.SkuPack',
+        '_'
+    )
+);
 
 /**
  * Factory that creates the express http service
@@ -78,7 +81,8 @@ function httpServiceFactory(
     events,
     Errors,
     wss,
-    skuService
+    skuService,
+    _
 ) {
     var logger = Logger.initialize(httpServiceFactory),
         servers = [];
@@ -172,6 +176,10 @@ function httpServiceFactory(
         app.use('/api/current', router);
         app.use('/api/1.1', router);
 
+        var httpProxies = configuration.get('httpProxies');
+        if (httpProxies && _.isArray(httpProxies)) {
+            _.forEach(httpProxies, createHttpProxy);
+        }
 
         if (configuration.get('httpEnabled', true)) {
             var httpServer = http.createServer(this);
@@ -248,6 +256,43 @@ function httpServiceFactory(
         servers = [];
         return promises;
     };
+
+    /**
+     * Creates http proxy
+     * @private
+     * @param {Object} httpProxy - proxy parameters
+     * @returns
+     */
+    function createHttpProxy(httpProxy){
+        try {
+            var localPath = httpProxy.localPath || '/',
+                remotePath = httpProxy.remotePath || '/',
+                serverAddr = httpProxy.server;
+            app.use(localPath, proxy(serverAddr, {
+                forwardPath: function (req, res) {
+                    return path.join(remotePath, require('url').parse(req.url).path);
+                },
+                decorateRequest: function (req) {
+                    //For HTTPS access
+                    req.rejectUnauthorized = false;
+                }
+            }));
+            logger.info('Create proxy succeeded',
+                {
+                    localPath: localPath,
+                    remotePath: remotePath,
+                    serverAddress: serverAddr
+                });
+        }
+        catch(e){
+            logger.error('Create proxy failed',
+                {
+                    message: e.message,
+                    parameter: httpProxy
+                }
+            );
+        }
+    }
 
     return app;
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",
     "supertest": "^0.15.0",
-    "xunit-file": "0.0.6"
+    "xunit-file": "0.0.6",
+    "nock": "~3.5.0"
   },
   "apidoc": {
     "name": "RackHD API Documentation",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ejs": "^2.0.8",
     "es6-shim": "^0.22.2",
     "express": "^4.10.7",
+    "express-http-proxy": "^0.6.0",
     "glob": "^4.3.2",
     "lodash": "^2.4.1",
     "lru-cache": "^2.5.0",

--- a/spec/lib/services/http-service-spec.js
+++ b/spec/lib/services/http-service-spec.js
@@ -8,6 +8,7 @@ var ws = require('ws');
 describe('Http.Server', function () {
     var app, server;
 
+    var nock = require('nock');
     helper.before(function () {
         return [
             dihelper.simpleWrapper(require('express')(), 'express-app'),
@@ -116,5 +117,90 @@ describe('Http.Server', function () {
         expect(function () {
             server.listen();
         }).to.throw(Error);
+    });
+
+    describe('http proxy', function () {
+        before('listen', function () {
+            var proxyConfig = [
+                {
+                    "localPath": "/local/proxy1",
+                    "server": "http://test.com",
+                    "remotePath": '/remote1'
+                },
+                {
+                    "localPath": "/local/proxy2",
+                    "server": "http://test.com"
+                },
+                {
+                    "server": "http://test.com",
+                    "remotePath": "/remote3"
+                },
+                {
+                    //this is to test whether server.listen can still run without speicfy server
+                    'localPath': '/local/proxy4',
+                    'remotePath': '/remote4'
+                },
+                {
+                    'server': 'http://test.com',
+                    'remotePath': '/remote5',
+                    'localPath': '/local/proxy5'
+                }
+            ];
+
+            nock('http://test.com')
+                .get('/').reply(200, 'Root Resource')
+                .get('/remote1/foo/bar').reply(200, 'This is Foo Bar1!')
+                .get('/remote2/foo/bar').reply(200, 'This is Foo Bar2!')
+                .get('/remote3/foo/bar').reply(200, 'This is Foo Bar3!')
+                .get('/remote4/foo/bar').reply(200, 'This is Foo Bar4!')
+                .get('/remote5/foo/bar').reply(200, 'This is Foo Bar5!');
+
+            app.use('/local/proxy5/foo/bar', function (req, res) {
+                res.send('This is local Foo Bar5!');
+            });
+
+            helper.injector.get('Services.Configuration')
+                .set('httpEnabled', true)
+                .set('httpsEnabled', false)
+                .set('httpBindPort', 8099)
+                .set('httpProxies', proxyConfig);
+            server.listen();
+        });
+
+        it('should respond to remote request via proxy', function () {
+            return helper.request('http://localhost:8099')
+                .get('/local/proxy1/foo/bar')
+                .expect(200)
+                .expect('This is Foo Bar1!');
+        });
+
+        it('should proxy to remote root path if missing remotePath', function () {
+            return helper.request('http://localhost:8099')
+                .get('/local/proxy2/remote2/foo/bar')
+                .expect(200)
+                .expect('This is Foo Bar2!');
+        });
+
+        it('should proxy to local root path if missing localPath', function () {
+            return helper.request('http://localhost:8099')
+                .get('/foo/bar')
+                .expect(200)
+                .expect('This is Foo Bar3!');
+        });
+
+        it('should favor local source over proxy', function() {
+            return helper.request('http://localhost:8099')
+                .get('/local/proxy5/foo/bar')
+                .expect('This is local Foo Bar5!');
+        });
+
+        after('close', function () {
+            server.close();
+            nock.restore();
+            //Configuration is shared globaly
+            //Should reset the configureation for other feature unit tests
+            helper.injector.get('Services.Configuration')
+                .set('httpProxies', []);
+        });
     });
 });

--- a/spec/lib/services/sku-pack-service-spec.js
+++ b/spec/lib/services/sku-pack-service-spec.js
@@ -52,12 +52,12 @@ describe("SKU Pack Service", function() {
     it('should fail to start with an invalid root', function() {
         fs.readdirAsync.rejects();
         //SKU service swallowes the exception, so it should not throw error even for invalid root
-        skuService.start('./invalid').should.not.be.rejected;
+        return skuService.start('./invalid').should.not.be.rejected;
     });
 
     it('should start with a valid root', function() {
         fs.readdirAsync.withArgs('./valid').resolves([]);
-        skuService.start('./valid').should.be.fulfilled;
+        return skuService.start('./valid').should.be.fulfilled;
     });
 
     it('should load a valid configuration file', function() {
@@ -70,7 +70,7 @@ describe("SKU Pack Service", function() {
         fs.readFileAsync.withArgs('./valid/a.js').resolves(JSON.stringify(data));
         fs.readdirAsync.withArgs('./valid/a/templates').resolves([]);
 
-        skuService.start('./valid').then(function(vals) {
+        return skuService.start('./valid').then(function(vals) {
             expect(vals.length).to.equal(1);
             expect(('a' in skuService.skuHandlers)).to.equal(true);
         });
@@ -88,7 +88,7 @@ describe("SKU Pack Service", function() {
         fs.readdirAsync.withArgs('./valid/a/templates').resolves([]);
         fs.readdirAsync.withArgs('./valid/b/templates').resolves([]);
 
-        skuService.start('./valid').then(function(vals) {
+        return skuService.start('./valid').then(function(vals) {
             expect(vals.length).to.equal(1);
             expect(('a' in skuService.skuHandlers)).to.equal(false);
             expect(('b' in skuService.skuHandlers)).to.equal(true);

--- a/spec/lib/services/sku-pack-service-spec.js
+++ b/spec/lib/services/sku-pack-service-spec.js
@@ -51,7 +51,8 @@ describe("SKU Pack Service", function() {
 
     it('should fail to start with an invalid root', function() {
         fs.readdirAsync.rejects();
-        skuService.start('./invalid').should.be.rejected;
+        //SKU service swallowes the exception, so it should not throw error even for invalid root
+        skuService.start('./invalid').should.not.be.rejected;
     });
 
     it('should start with a valid root', function() {


### PR DESCRIPTION
Implement http proxy via express-http-proxy module in http-service.js.
Proxy settings should will be input from monorail.json with key name "httpProxies";
"httpProxies" is supposed to be an array and each proxy element could include 3 items:
(1) Server info, which is a must.
(2) Local/remote paths are optional and will be root path by default if not provided.