### PR TITLE
GRIP-36: SKU Pack Support

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,8 @@ di.annotate(Runner, new di.Inject(
         'Templates',
         'common-api-router',
         'fileService',
-        'Promise'
+        'Promise',
+        'Http.Services.SkuPack'
     )
 );
 function Runner(
@@ -27,7 +28,8 @@ function Runner(
     templates,
     router,
     fileService,
-    Promise
+    Promise,
+    skuPack
 ) {
 
     function start() {
@@ -42,6 +44,9 @@ function Runner(
                         root: configuration.get('httpFileServiceRoot', './static/files')
                     }
                 });
+            })
+            .then(function() {
+                return skuPack.start(configuration.get('skuPackRoot', './skupack.d'));
             })
             .then(function() {
                 return app.listen();

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -42,30 +42,6 @@ function CommonApiPresenterFactory(
 ) {
     var logger = Logger.initialize(CommonApiPresenterFactory);
 
-    // TODO: stolen from http-service could stand to be a re-usable helper.
-    /**
-     * Get remote address of the client.
-     * @private
-     * @param {req} req from express
-     * @returns {String|Undefined} either the ip of requester or undefined
-     *                             if unavailable
-     */
-    function remoteAddress(req) {
-        if (req.ip) {
-            return req.ip;
-        }
-
-        if (req._remoteAddress) {
-            return req._remoteAddress;
-        }
-
-        if (req.connection) {
-            return req.connection.remoteAddress;
-        }
-
-        return undefined;
-    }
-
     presenter.use = function serializer(name, func) {
         if (presenter._serializers.has(name)) {
             throw new Error('Serializer for ' + name + ' already registered');
@@ -229,10 +205,11 @@ function CommonApiPresenterFactory(
 
             options = options || {};
             status = status || 200;
+            var scope = self.res.locals.scope;
 
             var promises = [
-                lookupService.ipAddressToMacAddress(remoteAddress(req)),
-                templates.get(name)
+                lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
+                templates.get(name, scope)
             ];
 
             Promise.all(promises).spread(function (macaddress, template) {
@@ -246,7 +223,7 @@ function CommonApiPresenterFactory(
                             {
                                 server: configuration.get('apiServerAddress', '10.1.1.1'),
                                 port: configuration.get('apiServerPort', 80),
-                                ipaddress: remoteAddress(req),
+                                ipaddress: self.res.locals.ipAddress,
                                 netmask: configuration.get('dhcpSubnetMask', '255.255.255.0'),
                                 gateway: configuration.get('dhcpGateway', '10.1.1.1'),
                                 macaddress: macaddress
@@ -279,7 +256,7 @@ function CommonApiPresenterFactory(
             status = status || 200;
 
             var promises = [
-                lookupService.ipAddressToMacAddress(remoteAddress(req)),
+                lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
                 profiles.get(profile, true)
             ];
 
@@ -303,7 +280,7 @@ function CommonApiPresenterFactory(
                         {
                             server: configuration.get('apiServerAddress', '10.1.1.1'),
                             port: configuration.get('apiServerPort', 80),
-                            ipaddress: remoteAddress(req),
+                            ipaddress: self.res.locals.ipAddress,
                             netmask: configuration.get('dhcpSubnetMask', '255.255.255.0'),
                             gateway: configuration.get('dhcpGateway', '10.1.1.1'),
                             macaddress: macaddress

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -47,7 +47,8 @@ di.annotate(httpServiceFactory,
             'common-api-router',
             'Events',
             'Errors',
-            'Services.WebSocket'
+            'Services.WebSocket',
+            'Http.Services.SkuPack'
         )
     );
 
@@ -76,7 +77,8 @@ function httpServiceFactory(
     router,
     events,
     Errors,
-    wss
+    wss,
+    skuService
 ) {
     var logger = Logger.initialize(httpServiceFactory),
         servers = [];
@@ -86,8 +88,8 @@ function httpServiceFactory(
 
         function httpEventMiddleware(req, res, next) {
             req._startAt = process.hrtime();
-            var ipAddress = remoteAddress(req);
-            var identifier;
+            res.locals.ipAddress = remoteAddress(req);
+            res.locals.scope = ['global'];
 
             onFinished(res, function () {
                 if (!req._startAt) {
@@ -97,43 +99,43 @@ function httpServiceFactory(
                 var diff = process.hrtime(req._startAt),
                     ms = diff[0] * 1e3 + diff[1] * 1e-6;
 
-                lookupService.ipAddressToNodeId(ipAddress).then(function (nodeId) {
-                    identifier = nodeId;
-                }).catch(Errors.NotFoundError, function () {
-                    // No longer log NotFoundErrors
-                }).catch(function (error) {
-                    events.ignoreError(error);
-                }).finally(function () {
-                    var data = {
-                        ipAddress: ipAddress
-                    };
+                var data = {
+                    ipAddress: res.locals.ipAddress
+                };
 
-                    if (identifier) {
-                        data.id = identifier;
+                if (res.locals.identifier) {
+                    data.id = res.locals.identifier;
+                }
+
+                logger.silly(
+                    'http: ' + req.method +
+                    ' ' + res.statusCode +
+                    ' ' + ms.toFixed(3) +
+                    ' - ' + req.originalUrl,
+                    data
+                );
+
+                eventsProtocol.publishHttpResponse(
+                    res.locals.identifier || 'external',
+                    {
+                        address: res.locals.ipAddress,
+                        method: req.method,
+                        url: req.originalUrl,
+                        statusCode: res.statusCode,
+                        time: ms.toFixed(3)
                     }
-
-                    logger.silly(
-                        'http: ' + req.method +
-                        ' ' + res.statusCode +
-                        ' ' + ms.toFixed(3) +
-                        ' - ' + req.originalUrl,
-                        data
-                    );
-
-                    eventsProtocol.publishHttpResponse(
-                        identifier || 'external',
-                        {
-                            address: ipAddress,
-                            method: req.method,
-                            url: req.originalUrl,
-                            statusCode: res.statusCode,
-                            time: ms.toFixed(3)
-                        }
-                    );
-                });
+                );
             });
 
-            next();
+            lookupService.ipAddressToNodeId(res.locals.ipAddress).then(function (nodeId) {
+                res.locals.identifier = nodeId;
+            }).catch(Errors.NotFoundError, function () {
+                // No longer log NotFoundErrors
+            }).catch(function (error) {
+                events.ignoreError(error);
+            }).finally(function () {
+                next();
+            });
         }
 
         // CORS Support
@@ -142,6 +144,11 @@ function httpServiceFactory(
 
         // Imaging Event Middleware
         app.use(httpEventMiddleware);
+
+        // Override default static directory with sku specific handlers
+        app.use(function(req, res, next) { 
+            skuService.static(req, res, next);
+        });
 
         // Default Static Directory
         app.use(express.static('./static/http'));

--- a/lib/services/sku-pack-service.js
+++ b/lib/services/sku-pack-service.js
@@ -1,0 +1,99 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+var express = require('express');
+var path = require('path');
+
+module.exports = skuPackServiceFactory;
+di.annotate(skuPackServiceFactory, new di.Provide('Http.Services.SkuPack'));
+di.annotate(skuPackServiceFactory,
+    new di.Inject(
+        '_',
+        'Services.Waterline',
+        'Logger',
+        'FileLoader',
+        'Templates'
+    )
+);
+function skuPackServiceFactory(
+    _,
+    waterline,
+    Logger,
+    FileLoader,
+    Templates
+) {
+    var logger = Logger.initialize(skuPackServiceFactory);
+
+    function SkuPackService() {
+        this.loader = new FileLoader();
+        this.confRoot = '';
+        this.skuHandlers = {};
+    }
+
+    SkuPackService.prototype.static = function(req, res, next) {
+        var self = this;
+        if(res.locals.identifier !== undefined) {
+            waterline.nodes.needByIdentifier(res.locals.identifier).then(function(node) {
+                if(node.hasOwnProperty('sku') && self.skuHandlers.hasOwnProperty(node.sku)) {
+                    res.locals.scope.unshift(node.sku);
+                    self.skuHandlers[node.sku](req,res,next);
+                } else {
+                    next();
+                }
+            }).catch( function() {
+                next();
+            });
+        } else {
+            next();
+        }
+    };
+
+    SkuPackService.prototype.registerPack = function(name, contents) {
+        var promises = [];
+        var self = this;
+        if(path.extname(name) === '.js') {
+            var skuName = path.basename(name, '.js');
+            try {
+                var conf = JSON.parse(contents);
+                // Add the static root if it is defined
+                if(conf.hasOwnProperty('httpStaticRoot')) {
+                    // directory references are relative to the skuName directory
+                    var httpStaticRoot = path.resolve('/', conf.httpStaticRoot);
+                    httpStaticRoot = self.confRoot + '/' + skuName + httpStaticRoot;
+                    self.skuHandlers[skuName] = express.static(httpStaticRoot);
+                }
+
+                if(conf.hasOwnProperty('httpTemplateRoot')) {
+                    var httpTemplateRoot = path.resolve('/', conf.httpTemplateRoot);
+                    httpTemplateRoot = self.confRoot + '/' + skuName + httpTemplateRoot;
+                    promises.push(self.loader.getAll(httpTemplateRoot)
+                        .then(function(templates) {
+                            return _.map(templates,function(contents,name) {
+                                return Templates.put(name, contents, skuName);
+                            });
+                        }) );
+                }
+            } catch (error) {
+                logger.debug('Unable to load sku configuration for ' + skuName);
+            }
+        }
+        return promises;
+    };
+
+    SkuPackService.prototype.start = function(confRoot) {
+        var self = this;
+        self.confRoot = confRoot;
+
+        return self.loader.getAll(self.confRoot).then(function (conf) {
+            return [].concat.apply([], _.map(conf, function(contents,name) {
+                return self.registerPack(name,contents);
+            }));
+        }).catch(function() {
+            logger.debug('Unable to startup sku pack service, check conf root: ' + confRoot);
+        });
+    };
+
+    return new SkuPackService();
+}

--- a/skupack.d/README.md
+++ b/skupack.d/README.md
@@ -1,0 +1,29 @@
+# SKU Pack Configuration
+
+The SKU Pack Configuration directory consists of a set of configuration files and the directories
+which host the content referenced by the files.  The content of the directories is used by on-http
+to potentially override the files and templates that are served for nodes with SKUs.
+
+## Typical Directory Layout
+
+    .
+    |-- 5661e0b5f0e1a18e6f18b98d
+    |  |-- static
+    |  |   \-- common
+    |  |       \-- discovery.overlay.cpio.gz
+    |  \-- templates
+    |      |-- esx-ks
+    |      \-- renasar-ansible.pub
+    \-- 5661e0b5f0e1a18e6f18b98d.js
+
+## :skuid.js Contents
+
+The ":skuid.js" file specifies the location of the static root and template root for the SKU.  The 
+directory locations specified in the filewill use the skupack.d/:skuid directory as the root reference 
+for the directory names.
+
+    {
+        "httpStaticRoot": "static",
+        "httpTemplateRoot": "templates"
+    }
+

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -35,7 +35,8 @@ helper.startServer = function (overrides) {
     helper.injector.get('Services.Configuration')
         .set('httpEnabled', true)
         .set('httpsEnabled', false)
-        .set('httpBindPort', 8089);
+        .set('httpBindPort', 8089)
+        .set('skuPackRoot', 'spec/lib/services/sku-static');
 
     return helper.injector.get('app').start();
 };

--- a/spec/lib/api/nodes-spec.js
+++ b/spec/lib/api/nodes-spec.js
@@ -12,6 +12,7 @@ describe('Http.Api.Nodes', function () {
     var nodeApiService;
     var Promise;
     var Errors;
+    var lookupService;
 
     before('start HTTP server', function () {
         this.timeout(5000);
@@ -24,7 +25,6 @@ describe('Http.Api.Nodes', function () {
             sinon.stub(configuration);
 
             waterline = helper.injector.get('Services.Waterline');
-            sinon.stub(waterline.lookups);
             sinon.stub(waterline.nodes);
             sinon.stub(waterline.catalogs);
             sinon.stub(waterline.workitems);
@@ -64,6 +64,10 @@ describe('Http.Api.Nodes', function () {
 
         ObmService.prototype.identifyOn.reset();
         ObmService.prototype.identifyOff.reset();
+
+        lookupService = helper.injector.get('Services.Lookup');
+        lookupService.ipAddressToMacAddress = sinon.stub().resolves();
+        lookupService.ipAddressToNodeId = sinon.stub().resolves();
     });
 
     after('stop HTTP server', function () {

--- a/spec/lib/services/sku-pack-service-spec.js
+++ b/spec/lib/services/sku-pack-service-spec.js
@@ -1,0 +1,96 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+require('../../helper');
+
+describe("SKU Pack Service", function() {
+    var skuService;
+    var fs;
+
+    before(function() {
+        helper.setupInjector([
+            helper.require("/lib/services/sku-pack-service")
+        ]);
+
+        skuService = helper.injector.get('Http.Services.SkuPack');
+
+        fs = helper.injector.get('fs');
+        sinon.stub(fs, 'writeFileAsync');
+        sinon.stub(fs, 'readFileAsync');
+        sinon.stub(fs, 'readdirAsync');
+        sinon.stub(fs, 'statAsync');
+    });
+
+    beforeEach(function() {
+        skuService.skuHandlers = {};
+        fs.writeFileAsync.reset();
+        fs.readFileAsync.reset();
+        fs.readdirAsync.reset();
+        fs.statAsync.reset();
+    });
+
+    helper.after(function () {
+        console.log('helper.after');
+        fs.writeFileAsync.restore();
+        fs.readFileAsync.restore();
+        fs.readdirAsync.restore();
+        fs.statAsync.restore();
+    });
+
+    it('should expose the appropriate methods', function() {
+        skuService.should.have.property('start')
+            .that.is.a('function').with.length(1);
+
+        skuService.should.have.property('static')
+            .that.is.a('function').with.length(3);
+
+        skuService.should.have.property('registerPack')
+            .that.is.a('function').with.length(2);
+    });
+
+    it('should fail to start with an invalid root', function() {
+        fs.readdirAsync.rejects();
+        skuService.start('./invalid').should.be.rejected;
+    });
+
+    it('should start with a valid root', function() {
+        fs.readdirAsync.withArgs('./valid').resolves([]);
+        skuService.start('./valid').should.be.fulfilled;
+    });
+
+    it('should load a valid configuration file', function() {
+        var data = {
+            httpStaticRoot: 'static',
+            httpTemplateRoot: 'templates'
+        };
+        fs.readdirAsync.withArgs('./valid').resolves(['a.js']);
+        fs.statAsync.withArgs('./valid/a.js').resolves({ isDirectory: function() { return false; } });
+        fs.readFileAsync.withArgs('./valid/a.js').resolves(JSON.stringify(data));
+        fs.readdirAsync.withArgs('./valid/a/templates').resolves([]);
+
+        skuService.start('./valid').then(function(vals) {
+            expect(vals.length).to.equal(1);
+            expect(('a' in skuService.skuHandlers)).to.equal(true);
+        });
+    });
+
+    it('should not load an invalid configuration file', function() {
+        var data = {
+            httpStaticRoot: 'static',
+            httpTemplateRoot: 'templates'
+        };
+        fs.readdirAsync.withArgs('./valid').resolves(['a.js', 'b.js']);
+        fs.statAsync.resolves({ isDirectory: function() { return false; } });
+        fs.readFileAsync.withArgs('./valid/a.js').resolves('{invalidjson}');
+        fs.readFileAsync.withArgs('./valid/b.js').resolves(JSON.stringify(data));
+        fs.readdirAsync.withArgs('./valid/a/templates').resolves([]);
+        fs.readdirAsync.withArgs('./valid/b/templates').resolves([]);
+
+        skuService.start('./valid').then(function(vals) {
+            expect(vals.length).to.equal(1);
+            expect(('a' in skuService.skuHandlers)).to.equal(false);
+            expect(('b' in skuService.skuHandlers)).to.equal(true);
+        });
+    });
+});

--- a/spec/lib/services/sku-static/.gitignore
+++ b/spec/lib/services/sku-static/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
- Load sku pack configuration files from 'skuPackRoot'.  The config
  files provide sku specific template/static directories that will
  override the global directories if the node has a 'sku' value.
- Modify on-http to get the 'sku' specific template if a 'sku' value
  is defined for the nodeid attached to the requestor IP.
- Modify on-http to serve the 'sku' specific static root if a 'sku'
  value is defined for the nodeid attached to the requestor IP.
- Changed the express chaining to store the IP and nodeID in the first
  middleware function.