### PR TITLE
Fix RHEL installtion failure do to kvm issue

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -53,7 +53,7 @@ sudo
 perl
 libselinux-python
 net-tools
-<% if( undefined !== kvm ) { %>
+<% if( typeof kvm !== 'undefined' ) { %>
     kvm
     virt-manager
     libvirt


### PR DESCRIPTION
It is found that with old centos-ks kvm setting, RHEL bootstrap will fail with kvm errors. New centos-ks can solve this problem.