### PR TITLE
Fix docs typos and descriptions

### DIFF
--- a/lib/api/files.js
+++ b/lib/api/files.js
@@ -22,7 +22,7 @@ function filesRouterFactory (Logger, configuration, fileService, assert) {
     var logger = Logger.initialize(filesRouterFactory);
 
     /**
-     * @api {get} /api/1.1/files/:identifier GET /:identifier
+     * @api {get} /api/1.1/files/:uuid GET /:uuid
      * @apiVersion 1.1.0
      * @apiDescription get a file referenced by a BSON ID
      * @apiName files-get

--- a/lib/api/pollers.js
+++ b/lib/api/pollers.js
@@ -326,7 +326,7 @@ function pollerRouterFactory (waterline, rest, taskProtocol, Constants, Promise,
      * @api {get} /api/1.1/pollers/:identifier/data/current GET /:identifier/data/current
      * @apiVersion 1.1.0
      * @apiDescription Get only the most recent data entry for the specific poller.
-     * @apiName poller-get-data
+     * @apiName poller-get-data-current
      * @apiGroup pollers
      * @apiParam {String} identifier (ip address or NodeId) for the data from a poller
      * @apiError NotFound1 The <code>identifier</code> could not be found.

--- a/lib/api/profiles.js
+++ b/lib/api/profiles.js
@@ -63,7 +63,7 @@ function profilesRouterFactory (
 
 
     /**
-     * @api {get} /api/1.1/profiles/library PUT
+     * @api {put} /api/1.1/profiles/library PUT
      * @apiVersion 1.1.0
      * @apiDescription put a single profile
      * @apiName profile-library-service-put

--- a/lib/api/tasks.js
+++ b/lib/api/tasks.js
@@ -36,7 +36,7 @@ function tasksRouterFactory (
     });
 
     /**
-     * @api {patch} /api/1.1/tasks/bootstrap.js GET
+     * @api {get} /api/1.1/tasks/bootstrap.js GET
      * @apiVersion 1.1.0
      * @apiDescription used internally by the system - get tasks bootstrap.js
      * @apiName tasks-bootstrap-get
@@ -70,7 +70,7 @@ function tasksRouterFactory (
     });
 
     /**
-     * @api {patch} /api/1.1/tasks/:identifier GET /:id
+     * @api {get} /api/1.1/tasks/:identifier GET /:id
      * @apiVersion 1.1.0
      * @apiDescription used internally by the system - get specific task
      * @apiName task-get
@@ -103,6 +103,21 @@ function tasksRouterFactory (
             next('route');
         });
     });
+
+    /**
+     * @api {post} /api/1.1/tasks/:identifier POST /:id
+     * @apiVersion 1.1.0
+     * @apiDescription used internally by the system - post specific task
+     * @apiName task-post
+     * @apiGroup tasks
+     * @apiParam {String} identifier of tasks, must cast to ObjectId
+     * @apiError NotFound There is no tasks with the <code>identifier</code>
+     * @apiErrorExample Error-Response:
+     *     HTTP/1.1 404 Not Found
+     *     {
+     *       "error": "Not Found"
+     *     }
+     */
 
     router.post('/tasks/:identifier', parserMiddleware, function (req, res) {
         taskProtocol.respondCommands(req.params.identifier, req.body);

--- a/lib/api/templates.js
+++ b/lib/api/templates.js
@@ -70,7 +70,7 @@ function templatesRouterFactory (
 
 
     /**
-     * @api {get} /api/1.1/templates/library PUT
+     * @api {put} /api/1.1/templates/library PUT
      * @apiVersion 1.1.0
      * @apiDescription put a single templates
      * @apiName template-library-service-put

--- a/lib/api/workflows.js
+++ b/lib/api/workflows.js
@@ -34,7 +34,7 @@ function workflowsRouterFactory (taskgraphRunner, rest, waterline, _) {
     }));
 
     /**
-     * @api {get} /api/1.1/workflows PUT /
+     * @api {put} /api/1.1/workflows PUT /
      * @apiVersion 1.1.0
      * @apiDescription define a new workflow
      * @apiName workflows-define
@@ -52,7 +52,7 @@ function workflowsRouterFactory (taskgraphRunner, rest, waterline, _) {
     }));
 
     /**
-     * @api {get} /api/1.1/workflows/tasks PUT /tasks
+     * @api {put} /api/1.1/workflows/tasks PUT /tasks
      * @apiVersion 1.1.0
      * @apiDescription add a task to the tasks library
      * @apiName workflowTasks-define

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "version": "1.1.0",
     "description": "RackHD API Documentation",
     "title": "RackHD API Documentation",
-    "url": "http://servername:80",
+    "url": "http://servername:8080",
     "header": {
       "title": "About",
       "filename": "static/apidoc/header.md"


### PR DESCRIPTION
Fix some descriptions and typos during review the docs http://servername:8080/docs.
1. correct some method names in docs
2. supplement description for post /tasks/:identifier
3. duplicated name 'poller-get-data' which lead to API missing when generating API docs. rename one 'poller-get-data' to 'poller-get-data-current'
4. fix the port number from 80 to 8080 in docs

@RackHD/rackhd_dev 