### PR TITLE
Fix ODR-422: DVD-ROM will be first disk during bootstrap

### DIFF
--- a/data/templates/get_driveid.js
+++ b/data/templates/get_driveid.js
@@ -27,9 +27,10 @@ function parseDriveWwid(idList) {
     });
 
     //According to SCSI-3 spec, vendor specified logic unit name string is 60
+	//Only IDE and SCSI disk will be retrieved
     var scsiLines = [], sataLines = [], wwnLines = [], requiredStrLen = 60;
     lines.forEach(function(line){
-        if ( line && !(line.match('part'))){
+        if ( line && !(line.match('part')) && line.match(/sd[a-z]$|hd[a-z]$/i)){
             var nameIndex = line.lastIndexOf('/'), idIndex = line.lastIndexOf('->');
             if (line.indexOf('scsi') === 0) {
                 scsiLines.push([line.slice(nameIndex + 1), line.slice(0, idIndex)]);

--- a/data/templates/get_driveid.js
+++ b/data/templates/get_driveid.js
@@ -193,8 +193,7 @@ function buildDriveMap(wwidData, vdData, scsiData) {
         driveIds[k].identifier = k;
         driveIds[k].linuxWwid = linuxWwid[1];
     });
-    console.log(JSON.stringify(driveIds));
-    return 0;
+    return JSON.stringify(driveIds);
 }
 
 function run() {
@@ -228,14 +227,8 @@ function run() {
                         process.exit(1);
                     }
                     scsiData = stdout2;
-                    if (buildDriveMap(wwidData, vdData, scsiData)) {
-                        console.error('build drive map failed, wwidData=' +
-                            wwidData + '\nvdData=' + vdData);
-                        process.exit(1);
-                    }
-                    else {
-                        process.exit(0);
-                    }
+                    var result = buildDriveMap(wwidData, vdData, scsiData);
+                    console.log(result);
                 });
             });
         });
@@ -246,4 +239,4 @@ function run() {
     }
 }
 
-return run();
+run();

--- a/data/templates/get_driveid.js
+++ b/data/templates/get_driveid.js
@@ -196,13 +196,16 @@ function buildDriveMap(wwidData, vdData, scsiData) {
     return JSON.stringify(driveIds);
 }
 
-function run() {
+/**
+ * Run commands and notify result via callback
+ * @param {Function} done - The callback which will be used to notify the result
+ */
+function run(done) {
     var wwidData, vdData, scsiData;
     try {
         exec(cmdDriveWwid, options, function (err0, stdout0) {
             if (err0) {
-                console.error(err0.toString());
-                process.exit(1);
+                return done(err0);
             }
             wwidData = stdout0;
             exec(cmdVdInfo, options, function (err1, stdout1) {
@@ -214,8 +217,7 @@ function run() {
                         vdData = '';
                     }
                     else {
-                        console.error(err1.toString());
-                        process.exit(1);
+                        return done(err1);
                     }
                 }
                 else {
@@ -223,20 +225,28 @@ function run() {
                 }
                 exec(cmdScsiId, options, function (err2, stdout2) {
                     if (err2) {
-                        console.error(err2.toString());
-                        process.exit(1);
+                        return done(err2);
                     }
                     scsiData = stdout2;
                     var result = buildDriveMap(wwidData, vdData, scsiData);
-                    console.log(result);
+                    return done(null, result);
                 });
             });
         });
     }
     catch (e) {
-        console.error(e.message);
-        process.exit(1);
+        return done(e);
     }
 }
 
-run();
+if (require.main === module) {
+    run(function(err, result) {
+        if (err) {
+            console.error(err.toString());
+            process.exit(1);
+        } else {
+            console.log(result);
+            process.exit(0);
+        }
+    });
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jsdoc": "^3.3.0-alpha13",
     "jshint": "^2.5.11",
     "mocha": "^2.1.0",
+    "rewire": "^2.5.1",
     "sinon": "1.16.1",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",

--- a/spec/data/templates/get_driveid-spec.js
+++ b/spec/data/templates/get_driveid-spec.js
@@ -1,0 +1,102 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var rewire = require('rewire');
+
+describe('get_driveid script', function() {
+    var getDriveId = rewire('../../../data/templates/get_driveid.js');
+
+    //Configure for case with DVD existing and VD info doesn't exist
+    var mockScsiDvd =
+        '[0:0:0:0]    disk    ATA      QEMU HARDDISK    2.2.  /dev/sda\n' +
+        '[1:0:0:0]    cd/dvd  QEMU     QEMU DVD-ROM     2.2.  /dev/sr0';
+    var mockVdInfoDvd = '';
+    var mockWwidDvd =
+        'total 0\n' +
+        'drwxr-xr-x 2 root root 80 Dec 22 07:31 ./\n' +
+        'drwxr-xr-x 3 root root 60 Dec 22 07:31 ../\n' +
+        'lrwxrwxrwx 1 root root  9 Dec 22 07:31 ata-QEMU_DVD-ROM_QM00003 -> ../../sr0\n' +
+        'lrwxrwxrwx 1 root root  9 Dec 22 07:31 ata-QEMU_HARDDISK_QM00001 -> ../../sda';
+
+    //Configure for case with SATADOM and SATA Drive
+    var mockScsiStd =
+        '[5:0:0:0]    disk    ATA      HUS724040ALA640  MFAO  /dev/sda\n' +
+        '[6:0:0:0]   disk    ATA      32GB SATA Flash  SFDE  /dev/sdb\n' +
+        '[7:2:0:0]    disk    LSI      MRROMB           4.26  /dev/sdc';
+    var mockVdInfoStd =
+        'total 0\n' +
+        'drwxr-xr-x 2 root root 360 Dec 22 10:02 ./\n' +
+        'drwxr-xr-x 5 root root 100 Dec 22 10:02 ../\n' +
+        'lrwxrwxrwx 1 root root   9 Dec 24 11:05 pci-0000:03:00.0-scsi-7:2:0:0 -> ../../sdc';
+    var mockWwidStd =
+    //jshint ignore: start
+        'total 0\n' +
+        'drwxr-xr-x 2 root root 360 Dec 22 10:02 ./\n' +
+        'drwxr-xr-x 5 root root 100 Dec 22 10:02 ../\n' +
+        'lrwxrwxrwx 1 root root   9 Dec 22 10:03 ata-32GB_SATA-Flash_Drive_B0714226900900000016 -> ../../sdb\n' +
+        'lrwxrwxrwx 1 root root  10 Dec 22 10:03 ata-32GB_SATA-Flash_Drive_B0714226900900000016-part1 -> ../../sdb1\n' +
+        'lrwxrwxrwx 1 root root   9 Dec 22 10:03 ata-HUS724040ALA640_PBJY9ZJX -> ../../sda\n' +
+        'lrwxrwxrwx 1 root root   9 Dec 24 11:05 scsi-3600163600196c0401e0c0e6511cec3c0 -> ../../sdc\n' +
+        'lrwxrwxrwx 1 root root   9 Dec 22 10:03 wwn-0x5000cca23de98340 -> ../../sda\n' +
+        'lrwxrwxrwx 1 root root   9 Dec 24 11:05 wwn-0x600163600196c0401e0c0e6511cec3c0 -> ../../sdc'; //
+    //jshint ignore: end
+
+    describe('run get driveid', function() {
+        var buildDriveMap = getDriveId.__get__('buildDriveMap');
+
+        it('should discard DVD info', function() {
+            var result = buildDriveMap(mockWwidDvd, mockVdInfoDvd, mockScsiDvd);
+            expect(result).to.deep.equal(JSON.stringify(
+                //jshint ignore: start
+                [
+                    {
+                        "scsiId":"0:0:0:0",
+                        "virtualDisk":"",
+                        "esxiWwid":"t10.ATA_____QEMU_HARDDISK________________________________________QM00001",
+                        "devName":"sda",
+                        "identifier":0,
+                        "linuxWwid":"/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001"
+                    }
+                ]
+                //jshint ignore: end
+            ));
+        });
+
+        it('should parser normal data', function() {
+            var result = buildDriveMap(mockWwidStd, mockVdInfoStd, mockScsiStd);
+            expect(result).to.deep.equal(JSON.stringify(
+                //jshint ignore: start
+                [
+                    {
+                        "scsiId":"6:0:0:0",
+                        "virtualDisk":"",
+                        "esxiWwid":"t10.ATA_____32GB_SATA2DFlash_Drive___________________B0714226900900000016",
+                        "devName":"sdb",
+                        "identifier":0,
+                        "linuxWwid":"/dev/disk/by-id/ata-32GB_SATA-Flash_Drive_B0714226900900000016"
+                    },
+                    {
+                        "scsiId":"5:0:0:0",
+                        "virtualDisk":"",
+                        "esxiWwid":"naa.5000cca23de98340",
+                        "devName":"sda",
+                        "identifier":1,
+                        "linuxWwid":"/dev/disk/by-id/ata-HUS724040ALA640_PBJY9ZJX"
+                    },
+                    {
+                        "scsiId":"7:2:0:0",
+                        "virtualDisk":"/c7/v0",
+                        "esxiWwid":"naa.600163600196c0401e0c0e6511cec3c0",
+                        "devName":"sdc",
+                        "identifier":2,
+                        "linuxWwid":"/dev/disk/by-id/scsi-3600163600196c0401e0c0e6511cec3c0"
+                    }
+                ]
+                //jshint ignore: end
+            ));
+        });
+
+    });
+});
+

--- a/spec/data/templates/get_driveid-spec.js
+++ b/spec/data/templates/get_driveid-spec.js
@@ -63,7 +63,7 @@ describe('get_driveid script', function() {
             ));
         });
 
-        it('should parser normal data', function() {
+        it('should parse normal data', function() {
             var result = buildDriveMap(mockWwidStd, mockVdInfoStd, mockScsiStd);
             expect(result).to.deep.equal(JSON.stringify(
                 //jshint ignore: start

--- a/spec/data/templates/get_driveid-spec.js
+++ b/spec/data/templates/get_driveid-spec.js
@@ -5,7 +5,15 @@
 var rewire = require('rewire');
 
 describe('get_driveid script', function() {
+    //when require/rewire the get_driveid.js, it will execute the function 'run',
+    //it may fail due to some command doesn't exist in the system, so we need to
+    //mock the child_process.exe before rewire the script.
+    var stubExec = sinon.stub(require('child_process'), 'exec');
     var getDriveId = rewire('../../../data/templates/get_driveid.js');
+
+    after(function() {
+        stubExec.restore();
+    });
 
     //Configure for case with DVD existing and VD info doesn't exist
     var mockScsiDvd =


### PR DESCRIPTION
This PR is to fix ODR-422. It is reported on vBMC that bootstrap will stopped due to DVD-ROM is the first devices in disk list.
In the PR we filter devices via device name sdx or hdx thus DVD_ROM will not be in drive list any more.

Tests were done on D51, T41, Rinjin and D51 vBMC in SH lab and passed.