### PR TITLE
Clarify query parameter types

### DIFF
--- a/lib/api/lookups.js
+++ b/lib/api/lookups.js
@@ -19,11 +19,11 @@ function lookupsRouterFactory (waterline, rest) {
     var router = express.Router();
 
     /**
-     * @api {get} /api/1.1/lookups/?q=term GET /?q=term
+     * @api {get} /api/1.1/lookups GET /?q=
      * @apiVersion 1.1.0
      * @apiDescription get list of lookups
      * @apiName lookups-get
-     * @apiParam {String} q Query term to lookup by node, macAddress, or ipAddress.
+     * @apiParam {query} q Query term to lookup by node, macAddress, or ipAddress.
      * @apiGroup lookups
      * @apiSuccess {json} lookups List of all lookups or if there are none an empty object.
      */
@@ -35,7 +35,7 @@ function lookupsRouterFactory (waterline, rest) {
     }));
 
     /**
-     * @api {post} /api/1.1/lookups/?ids= POST /
+     * @api {post} /api/1.1/lookups POST /
      * @apiVersion 1.1.0
      * @apiDescription create a lookup
      * @apiName lookups-post

--- a/lib/api/nodes.js
+++ b/lib/api/nodes.js
@@ -54,7 +54,7 @@ function nodesRouterFactory (
 
 
     /**
-     * @api {post} /api/1.1/nodes/?identifiers= POST /
+     * @api {post} /api/1.1/nodes POST /
      * @apiVersion 1.1.0
      * @apiDescription create a node
      * @apiName nodes-post

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "apidoc": "^0.12.1",
-    "apidoc-swagger": "^0.2.2",
+    "apidoc-swagger": "git+https://github.com/jlongever/apidoc-swagger.git",
     "chai": "^2.0.0",
     "chai-as-promised": "^4.2.0",
     "coveralls": "^2.11.4",


### PR DESCRIPTION
Fork apidoc-swagger until query input types are supported

@RackHD/corecommitters @RackHD/rackhd_dev 

