### PR TITLE
add deleting all types of nodes

### DIFF
--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -32,13 +32,12 @@ function nodeApiServiceFactory(
     }
 
     /**
-     * Find nodes downstream that relate with the removing node
+     * Find target nodes that relate with the removing node
      * @param  {Object}     node
      * @param  {Object}     type
-     * @return {Promise}    array of downstream nodes
+     * @return {Promise}    array of target nodes
      */
-    NodeApiService.prototype._findDsNodes = function(node, type) {
-        // Find the enclosure nodes who enclose this compute node
+    NodeApiService.prototype._findTargetNodes = function(node, type) {
         if (!_.has(node, 'relations')) {
             return Promise.resolve();
         }
@@ -48,8 +47,8 @@ function nodeApiServiceFactory(
             return Promise.resolve();
         }
 
-        return Promise.map(relation.targets, function (dsNodeId) {
-            return waterline.nodes.needByIdentifier(dsNodeId)
+        return Promise.map(relation.targets, function (targetNodeId) {
+            return waterline.nodes.needByIdentifier(targetNodeId)
             .catch(function (err) {
                 logger.warning("Error Getting Downstream Node with type " + type,
                     { error: err });
@@ -119,63 +118,71 @@ function nodeApiServiceFactory(
     };
 
     /**
-     * Handle downstream nodes. Update relation type field and remove downstream
+     * Handle target nodes. Update relation type field and remove the target
      * node if needed.
-     * @param  {Object}     dsNodos array of downstream nodes
-     * @param  {Object}     type relation type in upstream node
-     * @param  {Object}     nodeId upstream node id
+     * @param  {Object}     targetNodos array of target nodes
+     * @param  {Object}     type relation type in the removing node
+     * @param  {Object}     nodeId removing node id
      * @return {Promise}
      */
-    NodeApiService.prototype._handleDsNodes = function(dsNodes, type, nodeId) {
+    NodeApiService.prototype._handleTargetNodes = function(targetNodes, type, nodeId) {
         var self = this;
-        var dsType = '';
+        var targetType = '';
         var delOption = null;
 
         if (Constants.NodeRelations.hasOwnProperty(type)) {
-            dsType = Constants.NodeRelations[type].mapping;
-            delOption = Constants.NodeRelations[type].delDsNodeOption;
+            targetType = Constants.NodeRelations[type].mapping;
+            delOption = Constants.NodeRelations[type].delTargetNodeOption;
         }
 
         return Promise.resolve()
         .then(function () {
             if (delOption === 'all') {
-                // Throw error when all downstream nodes need to be deleted
+                // Throw error when all target nodes need to be deleted
                 // but at least one of them have active workflow
-                return Promise.map(dsNodes, function(dsNode) {
-                    return self._delValidityCheck(dsNode.id);
+                return Promise.map(targetNodes, function(targetNode) {
+                    return self._delValidityCheck(targetNode.id);
                 });
             }
         })
         .then(function () {
-            return Promise.map(dsNodes, function (dsNode) {
+            return Promise.map(targetNodes, function (targetNode) {
+                // Delete target nodes if it is reuiqred
                 if (delOption === 'all') {
-                    return self.removeNode(dsNode, dsType);
-                } else {
-                    return self._removeRelation(dsNode, dsType, nodeId)
-                    .then(function (dsNode) {
-                        if (dsNode) {
-                            logger.debug('node updated', {id: dsNode.id, relation: dsType});
-                            if (delOption === 'whenEmpty') {
-                                return self._findEmpty(dsNode, dsType);
-                            } else {
-                                return false;
-                            }
-                        } else {
-                            return false;
-                        }
-                    })
-                    .then(function (del) {
-                        if (del === true) {
-                            return self.removeNode(dsNode, dsType);
-                        }
-                    });
+                    return self.removeNode(targetNode, targetType);
                 }
+
+                // Update relations in the target node
+                return self._removeRelation(targetNode, targetType, nodeId)
+                .then(function (targetNode) {
+
+                    // If target node is unavailable currently, don't need further process
+                    if (!targetNode) {
+                        return false;
+                    }
+
+                    logger.debug('node updated', {id: targetNode.id, relation: targetType});
+
+                    if (delOption === 'whenEmpty') {
+                        // Find out whether there is no targets in this relation type now
+                        // This target node will be deleted in the next promise if no other
+                        // target and delete option is "whenEmpty"
+                        return self._findEmpty(targetNode, targetType);
+                    } else {
+                        return false;
+                    }
+                })
+                .then(function (del) {
+                    if (del === true) {
+                        return self.removeNode(targetNode, targetType);
+                    }
+                });
             });
         });
     };
 
     /**
-     * Check whether a node has no active workflow and can be deleted
+     * Check whether a node is valid to be deleted
      * @param  {String}     nodeId
      * @return {Promise}
      */
@@ -183,6 +190,7 @@ function nodeApiServiceFactory(
         return taskGraphProtocol.getActiveTaskGraph( { target: nodeId })
         .then(function (graph) {
             if (graph) {
+                // If there is active workflow, the node cannot be deleted
                 throw new Errors.BadRequestError('Could not remove node ' + nodeId +
                     ', active workflow is running');
             }
@@ -214,10 +222,10 @@ function nodeApiServiceFactory(
                     return Promise.resolve();
                 }
 
-                // Otherwise update its downstream node
-                return self._findDsNodes(node, type)
-                .then(function (dsNodes) {
-                    return self._handleDsNodes(dsNodes, type, node.id);
+                // Otherwise update targets node in its "relationType"
+                return self._findTargetNodes(node, type)
+                .then(function (targetNodes) {
+                    return self._handleTargetNodes(targetNodes, type, node.id);
                 });
             });
         })

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -13,7 +13,8 @@ di.annotate(nodeApiServiceFactory,
         'Errors',
         'Logger',
         '_',
-        'Promise'
+        'Promise',
+        'Constants'
     )
 );
 function nodeApiServiceFactory(
@@ -22,7 +23,8 @@ function nodeApiServiceFactory(
     Errors,
     Logger,
     _,
-    Promise
+    Promise,
+    Constants
 ) {
     var logger = Logger.initialize(nodeApiServiceFactory);
 
@@ -30,64 +32,161 @@ function nodeApiServiceFactory(
     }
 
     /**
-     * Find Enclosure nodes which enclose compute node
+     * Find nodes downstream that relate with the removing node
      * @param  {Object}     node
-     * @return {Promise}
+     * @param  {Object}     type
+     * @return {Promise}    array of downstream nodes
      */
-    NodeApiService.prototype._findEnclNodes = function(node) {
+    NodeApiService.prototype._findDsNodes = function(node, type) {
         // Find the enclosure nodes who enclose this compute node
         if (!_.has(node, 'relations')) {
             return Promise.resolve();
         }
 
-        var relation = _.find(node.relations, { relationType: 'enclosedBy' });
+        var relation = _.find(node.relations, { relationType: type });
         if (!relation || !_.has(relation, 'targets') ) {
             return Promise.resolve();
         }
 
-        return Promise.map(relation.targets, function (enclNodeId) {
-            return waterline.nodes.needByIdentifier(enclNodeId)
+        return Promise.map(relation.targets, function (dsNodeId) {
+            return waterline.nodes.needByIdentifier(dsNodeId)
             .catch(function (err) {
-                logger.warning("Error Getting Enclosure Node", { error: err });
+                logger.warning("Error Getting Downstream Node with type " + type,
+                    { error: err });
                 return;
             });
         });
     };
 
     /**
-     * Remove the relations between node and enclosure node, if enclosure node
-     * doesn't enclose any nodes, this enclosure node is also removed.
-     * @param  {Object}     node
-     * @param  {Array}      enclNodes
-     * @return {Promise}
+     * Remove the relations to node in the downstram node. If the relation field is
+     * empty after removing, delete this field.
+     * @param  {Object}     node node whose relation needs to be updated
+     * @param  {String}     type relation type that needs to be updated
+     * @param  {String}     targetId id in relation type that needs to be deleted
+     * @return {Promise}    node after removing relation
      */
-    NodeApiService.prototype._removeEnclRelations = function(node, enclNodes) {
-        if (!enclNodes) {
+    NodeApiService.prototype._removeRelation = function(node, type, targetId) {
+        if (!node) {
             return Promise.resolve();
         }
 
-        // Remove the relationship between enclosure and compute node
-        return Promise.map(enclNodes, function(enclNode) {
-            if (!_.has(enclNode, 'relations')) {
-                return;
-            }
+        // Remove the relationship between node and downstram node
+        if (!_.has(node, 'relations')) {
+            return Promise.resolve();
+        }
 
-            var index = _.findIndex(enclNode.relations, { relationType: 'encloses' });
-            if (index === -1 || !_.has(enclNode.relations[index], 'targets')) {
-                return;
-            }
+        var index = _.findIndex(node.relations, { relationType: type });
+        if (index === -1 || !_.has(node.relations[index], 'targets')) {
+            return Promise.resolve();
+        }
 
-            if (_.indexOf(enclNode.relations[index].targets, node.id) !== -1) {
-                _.pull(enclNode.relations[index].targets, node.id);
+        // Remove target node id in relation field
+        if (_.indexOf(node.relations[index].targets, targetId) !== -1) {
+            _.pull(node.relations[index].targets, targetId);
+        }
+
+        // Remove the type of relation if no targets in it
+        if (node.relations[index].targets.length === 0) {
+            _.pull(node.relations, node.relations[index]);
+        }
+
+        return waterline.nodes.updateByIdentifier(node.id,
+                                                  {relations: node.relations});
+    };
+
+    /**
+     * Find out whether the specific type of relation is empty in node.
+     * @param  {Object}     node
+     * @param  {String}     type relation type
+     * @return {Bool} true if the relation is empty and the node can be deleted
+     */
+    NodeApiService.prototype._findEmpty = function(node, type) {
+        if (!node) {
+            return false;
+        }
+
+        if (!_.has(node, 'relations')) {
+            return true;
+        }
+
+        var index = _.findIndex(node.relations, { relationType: type });
+        if (index === -1 || !_.has(node.relations[index], 'targets')) {
+            return true;
+        }
+
+        return false;
+    };
+
+    /**
+     * Handle downstream nodes. Update relation type field and remove downstream
+     * node if needed.
+     * @param  {Object}     dsNodos array of downstream nodes
+     * @param  {Object}     type relation type in upstream node
+     * @param  {Object}     nodeId upstream node id
+     * @return {Promise}
+     */
+    NodeApiService.prototype._handleDsNodes = function(dsNodes, type, nodeId) {
+        var self = this;
+        var dsType = '';
+        var delOption = null;
+
+        if (Constants.NodeRelations.hasOwnProperty(type)) {
+            dsType = Constants.NodeRelations[type].mapping;
+            delOption = Constants.NodeRelations[type].delDsNodeOption;
+        }
+
+        return Promise.resolve()
+        .then(function () {
+            if (delOption === 'all') {
+                // Throw error when all downstream nodes need to be deleted
+                // but at least one of them have active workflow
+                return Promise.map(dsNodes, function(dsNode) {
+                    return self._delValidityCheck(dsNode.id);
+                });
             }
-            // If Enclosure node doesn't have enclosed nodes
-            // remove this enclosure node, else remove relationships
-            if (enclNode.relations[index].targets.length === 0) {
-                return waterline.nodes.destroy({ id: enclNode.id });
-            } else {
-                return waterline.nodes.updateByIdentifier(
-                    enclNode.id, { relations : enclNode.relations });
+        })
+        .then(function () {
+            return Promise.map(dsNodes, function (dsNode) {
+                if (delOption === 'all') {
+                    return self.removeNode(dsNode, dsType);
+                } else {
+                    return self._removeRelation(dsNode, dsType, nodeId)
+                    .then(function (dsNode) {
+                        if (dsNode) {
+                            logger.debug('node updated', {id: dsNode.id, relation: dsType});
+                            if (delOption === 'whenEmpty') {
+                                return self._findEmpty(dsNode, dsType);
+                            } else {
+                                return false;
+                            }
+                        } else {
+                            return false;
+                        }
+                    })
+                    .then(function (del) {
+                        if (del === true) {
+                            return self.removeNode(dsNode, dsType);
+                        }
+                    });
+                }
+            });
+        });
+    };
+
+    /**
+     * Check whether a node has no active workflow and can be deleted
+     * @param  {String}     nodeId
+     * @return {Promise}
+     */
+    NodeApiService.prototype._delValidityCheck = function(nodeId) {
+        return taskGraphProtocol.getActiveTaskGraph( { target: nodeId })
+        .then(function (graph) {
+            if (graph) {
+                throw new Errors.BadRequestError('Could not remove node ' + nodeId +
+                    ', active workflow is running');
             }
+            return Promise.resolve();
         });
     };
 
@@ -96,15 +195,31 @@ function nodeApiServiceFactory(
      * @param  {Object}     node
      * @return {Promise}
      */
-    NodeApiService.prototype.removeNode = function(node) {
+    NodeApiService.prototype.removeNode = function(node, srcType) {
         var self = this;
 
-        return taskGraphProtocol.getActiveTaskGraph( { target: node.id })
-        .then(function (graph) {
-            if (graph) {
-                throw new Errors.BadRequestError('Could not remove node ' + node.id +
-                    ', active workflow is running');
+        return self._delValidityCheck(node.id)
+        .then(function () {
+            if (!node.hasOwnProperty('relations')) {
+                return Promise.resolve;
             }
+
+            return Promise.map(node.relations, function(relation) {
+
+                var type = relation.relationType;
+
+                // Skip handling relationType that comes from the upstream node
+                // to avoid deleting upstream nodes more than once
+                if (srcType && (srcType === type)) {
+                    return Promise.resolve();
+                }
+
+                // Otherwise update its downstream node
+                return self._findDsNodes(node, type)
+                .then(function (dsNodes) {
+                    return self._handleDsNodes(dsNodes, type, node.id);
+                });
+            });
         })
         .then(function () {
             return Promise.settle([
@@ -115,15 +230,10 @@ function nodeApiServiceFactory(
                 waterline.nodes.destroy({ id: node.id }),
                 waterline.catalogs.destroy({ node: node.id }),
                 waterline.workitems.destroy({ node: node.id })
-                ]);
+            ]);
         })
         .then(function () {
-            return self._findEnclNodes(node);
-        })
-        .then(function (enclNodes) {
-            return self._removeEnclRelations(node, enclNodes);
-        })
-        .then(function () {
+            logger.debug('node deleted', {id: node.id, type: node.type});
             return node;
         });
     };

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -66,6 +66,7 @@ function nodeApiServiceFactory(
      * @return {Promise}    node after removing relation
      */
     NodeApiService.prototype._removeRelation = function(node, type, targetId) {
+
         if (!node) {
             return Promise.resolve();
         }
@@ -95,29 +96,6 @@ function nodeApiServiceFactory(
     };
 
     /**
-     * Find out whether the specific type of relation is empty in node.
-     * @param  {Object}     node
-     * @param  {String}     type relation type
-     * @return {Bool} true if the relation is empty and the node can be deleted
-     */
-    NodeApiService.prototype._findEmpty = function(node, type) {
-        if (!node) {
-            return false;
-        }
-
-        if (!_.has(node, 'relations')) {
-            return true;
-        }
-
-        var index = _.findIndex(node.relations, { relationType: type });
-        if (index === -1 || !_.has(node.relations[index], 'targets')) {
-            return true;
-        }
-
-        return false;
-    };
-
-    /**
      * Handle target nodes. Update relation type field and remove the target
      * node if needed.
      * @param  {Object}     targetNodos array of target nodes
@@ -128,16 +106,23 @@ function nodeApiServiceFactory(
     NodeApiService.prototype._handleTargetNodes = function(targetNodes, type, nodeId) {
         var self = this;
         var targetType = '';
-        var delOption = null;
+        var relationClass = null;
+        var needDel = false;
 
         if (Constants.NodeRelations.hasOwnProperty(type)) {
             targetType = Constants.NodeRelations[type].mapping;
-            delOption = Constants.NodeRelations[type].delTargetNodeOption;
+            relationClass = Constants.NodeRelations[type].relationClass;
+        }
+
+        if ((relationClass === 'component') &&
+            (type.indexOf('By') === -1)) {
+            // Its components need to be deleted
+            needDel = true;
         }
 
         return Promise.resolve()
         .then(function () {
-            if (delOption === 'all') {
+            if (needDel === true) {
                 // Throw error when all target nodes need to be deleted
                 // but at least one of them have active workflow
                 return Promise.map(targetNodes, function(targetNode) {
@@ -148,33 +133,15 @@ function nodeApiServiceFactory(
         .then(function () {
             return Promise.map(targetNodes, function (targetNode) {
                 // Delete target nodes if it is reuiqred
-                if (delOption === 'all') {
+                if (needDel === true) {
                     return self.removeNode(targetNode, targetType);
                 }
 
                 // Update relations in the target node
                 return self._removeRelation(targetNode, targetType, nodeId)
                 .then(function (targetNode) {
-
-                    // If target node is unavailable currently, don't need further process
-                    if (!targetNode) {
-                        return false;
-                    }
-
-                    logger.debug('node updated', {id: targetNode.id, relation: targetType});
-
-                    if (delOption === 'whenEmpty') {
-                        // Find out whether there is no targets in this relation type now
-                        // This target node will be deleted in the next promise if no other
-                        // target and delete option is "whenEmpty"
-                        return self._findEmpty(targetNode, targetType);
-                    } else {
-                        return false;
-                    }
-                })
-                .then(function (del) {
-                    if (del === true) {
-                        return self.removeNode(targetNode, targetType);
+                    if (targetNode) {
+                        logger.debug('node updated', {id: targetNode.id, relation: targetType});
                     }
                 });
             });
@@ -209,7 +176,7 @@ function nodeApiServiceFactory(
         return self._delValidityCheck(node.id)
         .then(function () {
             if (!node.hasOwnProperty('relations')) {
-                return Promise.resolve;
+                return Promise.resolve();
             }
 
             return Promise.map(node.relations, function(relation) {

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -34,23 +34,23 @@ function nodeApiServiceFactory(
     /**
      * Find target nodes that relate with the removing node
      * @param  {Object}     node
-     * @param  {Object}     type
+     * @param  {String}     type
      * @return {Promise}    array of target nodes
      */
     NodeApiService.prototype._findTargetNodes = function(node, type) {
         if (!_.has(node, 'relations')) {
-            return Promise.resolve();
+            return Promise.resolve([]);
         }
 
         var relation = _.find(node.relations, { relationType: type });
         if (!relation || !_.has(relation, 'targets') ) {
-            return Promise.resolve();
+            return Promise.resolve([]);
         }
 
         return Promise.map(relation.targets, function (targetNodeId) {
             return waterline.nodes.needByIdentifier(targetNodeId)
             .catch(function (err) {
-                logger.warning("Error Getting Downstream Node with type " + type,
+                logger.warning("Error getting target node with type " + type,
                     { error: err });
                 return;
             });
@@ -58,8 +58,10 @@ function nodeApiServiceFactory(
     };
 
     /**
-     * Remove the relations to node in the downstram node. If the relation field is
-     * empty after removing, delete this field.
+     * Remove the relations to original node in target node. If the node is invalid
+     * or doesn't have required relation, this function doesn't need to update the
+     * node info and ignore silently with Promise.resolve(). If the relation field
+     * is empty after removing, delete this field.
      * @param  {Object}     node node whose relation needs to be updated
      * @param  {String}     type relation type that needs to be updated
      * @param  {String}     targetId id in relation type that needs to be deleted
@@ -98,9 +100,9 @@ function nodeApiServiceFactory(
     /**
      * Handle target nodes. Update relation type field and remove the target
      * node if needed.
-     * @param  {Object}     targetNodos array of target nodes
-     * @param  {Object}     type relation type in the removing node
-     * @param  {Object}     nodeId removing node id
+     * @param  {Array}      targetNodes array of target nodes
+     * @param  {String}     type relation type in the removing node
+     * @param  {String}     nodeId removing node id
      * @return {Promise}
      */
     NodeApiService.prototype._handleTargetNodes = function(targetNodes, type, nodeId) {
@@ -132,7 +134,7 @@ function nodeApiServiceFactory(
         })
         .then(function () {
             return Promise.map(targetNodes, function (targetNode) {
-                // Delete target nodes if it is reuiqred
+                // Delete target nodes if it is required
                 if (needDel === true) {
                     return self.removeNode(targetNode, targetType);
                 }
@@ -158,7 +160,7 @@ function nodeApiServiceFactory(
         .then(function (graph) {
             if (graph) {
                 // If there is active workflow, the node cannot be deleted
-                throw new Errors.BadRequestError('Could not remove node ' + nodeId +
+                return Promise.reject('Could not remove node ' + nodeId +
                     ', active workflow is running');
             }
             return Promise.resolve();
@@ -168,6 +170,7 @@ function nodeApiServiceFactory(
     /**
      * Remove node related data and remove its relations with other nodes
      * @param  {Object}     node
+     * @param  {String}     srcType
      * @return {Promise}
      */
     NodeApiService.prototype.removeNode = function(node, srcType) {

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -76,48 +76,48 @@ describe("Http.Services.Api.Nodes", function () {
         this.sandbox.restore();
     });
 
-    describe("_findDsNodes", function() {
-        before("_findDsNodes before", function() {
+    describe("_findTargetNodes", function() {
+        before("_findTargetNodes before", function() {
         });
 
         beforeEach(function() {
         });
 
-        it("_findDsNodes should find related enclosure nodes", function() {
+        it("_findTargetNodes should find related enclosure nodes", function() {
             needByIdentifier.resolves(enclosureNode);
 
-            return nodeApiService._findDsNodes(computeNode, 'enclosedBy')
+            return nodeApiService._findTargetNodes(computeNode, 'enclosedBy')
             .then(function (nodes) {
                 expect(needByIdentifier).to.have.been.calledOnce;
                 expect(nodes[0]).to.equal(enclosureNode);
             });
         });
 
-        it("_findDsNodes should return nothing if cannot find enclosure node", function() {
+        it("_findTargetNodes should return nothing if cannot find enclosure node", function() {
             needByIdentifier.rejects(Errors.NotFoundError(''));
 
-            return nodeApiService._findDsNodes(computeNode, 'enclosedBy')
+            return nodeApiService._findTargetNodes(computeNode, 'enclosedBy')
             .then(function (nodes) {
                 expect(needByIdentifier).to.have.been.calledOnce;
                 expect(nodes[0]).to.equal(undefined);
             });
         });
 
-        it("_findDsNodes should return nothing if don't have relations", function() {
+        it("_findTargetNodes should return nothing if don't have relations", function() {
             var node = {
                 id: '1234abcd1234abcd1234abcd',
                 type: 'compute'
             };
 
-            return nodeApiService._findDsNodes(node, 'enclosedBy')
+            return nodeApiService._findTargetNodes(node, 'enclosedBy')
             .then(function (nodes) {
                 expect(nodes).to.equal(undefined);
             });
         });
 
-        it("_findDsNodes should return nothing if node is null", function() {
+        it("_findTargetNodes should return nothing if node is null", function() {
 
-            return nodeApiService._findDsNodes(null, 'enclosedBy')
+            return nodeApiService._findTargetNodes(null, 'enclosedBy')
             .then(function (nodes) {
                 expect(nodes).to.equal(undefined);
             });

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -8,44 +8,11 @@ describe("Http.Services.Api.Nodes", function () {
     var Errors;
     var taskGraphProtocol;
     var waterline;
-
-    var computeNode = {
-        id: '1234abcd1234abcd1234abcd',
-        name: 'computeNode',
-        relations: [
-            {
-                "relationType": "enclosedBy",
-                "targets": [
-                    "1234abcd1234abcd1234abcf"
-                ]
-            }
-        ]
-    };
-    var enclosureNode = {
-        id: '1234abcd1234abcd1234abcf',
-        name: 'enclosureNode',
-        relations: [
-            {
-                "relationType": "encloses",
-                "targets": [
-                    "1234abcd1234abcd1234abcd",
-                    "1234abcd1234abcd1234abce"
-                ]
-            }
-        ]
-    };
-    var enclosureNode1 = {
-        id: '1234abcd1234abcd1234abcf',
-        name: 'enclosureNode',
-        relations: [
-            {
-                "relationType": "encloses",
-                "targets": [
-                    "1234abcd1234abcd1234abcd"
-                ]
-            }
-        ]
-    };
+    var updateByIdentifier;
+    var needByIdentifier;
+    var getActiveTaskGraph;
+    var computeNode;
+    var enclosureNode;
 
     before("Http.Services.Api.Nodes before", function() {
         helper.setupInjector([
@@ -73,10 +40,277 @@ describe("Http.Services.Api.Nodes", function () {
     });
 
     beforeEach("Http.Services.Api.Nodes beforeEach", function() {
+        computeNode = {
+            id: '1234abcd1234abcd1234abcd',
+            type: 'compute',
+            relations: [
+                {
+                    "relationType": "enclosedBy",
+                    "targets": [
+                        "1234abcd1234abcd1234abcf"
+                    ]
+                }
+            ]
+        };
+        enclosureNode = {
+            id: '1234abcd1234abcd1234abcf',
+            type: 'enclosure',
+            relations: [
+                {
+                    "relationType": "encloses",
+                    "targets": [
+                        "1234abcd1234abcd1234abcd",
+                        "1234abcd1234abcd1234abce"
+                    ]
+                }
+            ]
+        };
+
+        needByIdentifier = this.sandbox.stub(waterline.nodes, 'needByIdentifier');
+        updateByIdentifier = this.sandbox.stub(waterline.nodes, 'updateByIdentifier');
+        getActiveTaskGraph = this.sandbox.stub(taskGraphProtocol, 'getActiveTaskGraph');
+
     });
 
     afterEach("Http.Services.Api.Nodes afterEach", function() {
         this.sandbox.restore();
+    });
+
+    describe("_findDsNodes", function() {
+        before("_findDsNodes before", function() {
+        });
+
+        beforeEach(function() {
+        });
+
+        it("_findDsNodes should find related enclosure nodes", function() {
+            needByIdentifier.resolves(enclosureNode);
+
+            return nodeApiService._findDsNodes(computeNode, 'enclosedBy')
+            .then(function (nodes) {
+                expect(needByIdentifier).to.have.been.calledOnce;
+                expect(nodes[0]).to.equal(enclosureNode);
+            });
+        });
+
+        it("_findDsNodes should return nothing if cannot find enclosure node", function() {
+            needByIdentifier.rejects(Errors.NotFoundError(''));
+
+            return nodeApiService._findDsNodes(computeNode, 'enclosedBy')
+            .then(function (nodes) {
+                expect(needByIdentifier).to.have.been.calledOnce;
+                expect(nodes[0]).to.equal(undefined);
+            });
+        });
+
+        it("_findDsNodes should return nothing if don't have relations", function() {
+            var node = {
+                id: '1234abcd1234abcd1234abcd',
+                type: 'compute'
+            };
+
+            return nodeApiService._findDsNodes(node, 'enclosedBy')
+            .then(function (nodes) {
+                expect(nodes).to.equal(undefined);
+            });
+        });
+
+        it("_findDsNodes should return nothing if node is null", function() {
+
+            return nodeApiService._findDsNodes(null, 'enclosedBy')
+            .then(function (nodes) {
+                expect(nodes).to.equal(undefined);
+            });
+        });
+
+    });
+
+    describe("_removeRelation", function() {
+        before("_removeRelation before", function() {
+        });
+
+        beforeEach(function() {
+            updateByIdentifier.resolves();
+        });
+
+        it("_removeRelation should fail if enclosure node is null", function() {
+            return nodeApiService._removeRelation(null, 'encloses', computeNode.id)
+            .then(function () {
+                expect(updateByIdentifier).to.not.have.been.called;
+            });
+        });
+
+        it("_removeRelation should fail if relation type of enclosure node is null", function() {
+            var enclNodes = [
+                {
+                    id: '1234abcd1234abcd1234abcd',
+                    type: 'enclNode'
+                }
+            ];
+
+            return nodeApiService._removeRelation(enclNodes, 'encloses', computeNode.id)
+            .then(function () {
+                expect(updateByIdentifier).to.not.have.been.called;
+            });
+        });
+
+        it("_removeRelation should fail if relationType is incorrect", function() {
+            var enclNodes = [
+                {
+                    id: '1234abcd1234abcd1234abcd',
+                    type: 'compute',
+                    relations: [
+                        {
+                            "relationType": "enclosedBy",
+                        }
+                    ]
+                }
+            ];
+
+            return nodeApiService._removeRelation(enclNodes, 'encloses', computeNode.id)
+            .then(function () {
+                expect(updateByIdentifier).to.not.have.been.called;
+            });
+        });
+
+        it("_removeRelation should fail if don't have targets", function() {
+            var enclNodes = [
+                {
+                    id: '1234abcd1234abcd1234abcd',
+                    type: 'enclosure',
+                    relations: [
+                        {
+                            "relationType": "encloses"
+                        }
+                    ]
+                }
+            ];
+
+            return nodeApiService._removeRelation(enclNodes, 'encloses', computeNode.id)
+            .then(function () {
+                expect(updateByIdentifier).to.not.have.been.called;
+            });
+        });
+
+        it("_removeRelation should remove related id", function() {
+            var enclRelationAfter = _.cloneDeep(enclosureNode.relations);
+            _.pull(enclRelationAfter[0].targets, computeNode.id);
+
+            return nodeApiService._removeRelation(enclosureNode, 'encloses', computeNode.id)
+            .then(function () {
+                expect(updateByIdentifier).to.have.been
+                    .calledWith(enclosureNode.id,
+                                {relations: enclRelationAfter});
+            });
+        });
+
+        it("_removeRelation should remove one relation when no target", function() {
+            var enclNode = {
+                id: '1234abcd1234abcd1234abcf',
+                type: 'enclosure',
+                relations: [
+                    {
+                        "relationType": "encloses",
+                        "targets": [
+                            "1234abcd1234abcd1234abcd",
+                        ]
+                    },
+                    {
+                        "relationType": "clusterBy",
+                        "targets": [
+                            "aaa",
+                        ]
+                    }
+                ]
+            };
+            var enclRelationAfter = _.cloneDeep(enclNode.relations);
+            _.pull(enclRelationAfter, enclRelationAfter[0]);
+            return nodeApiService._removeRelation(enclNode, 'encloses', computeNode.id)
+            .then(function () {
+                expect(updateByIdentifier)
+                   .to.have.been.calledWith(enclNode.id,
+                                            {relations: enclRelationAfter});
+            });
+        });
+
+        it("_removeRelation should remain empty relation field when no relation", function() {
+            var enclNode = {
+                id: '1234abcd1234abcd1234abcf',
+                type: 'enclosure',
+                relations: [
+                    {
+                        "relationType": "encloses",
+                        "targets": [
+                            "1234abcd1234abcd1234abcd",
+                        ]
+                    }
+                ]
+            };
+            var enclRelationAfter = [];
+            return nodeApiService._removeRelation(enclNode, 'encloses', computeNode.id)
+            .then(function () {
+                expect(updateByIdentifier)
+                    .to.have.been.calledWith(enclNode.id,
+                                             {relations: enclRelationAfter});
+            });
+        });
+    });
+
+    describe("_findEmpty", function() {
+        before("_findEmpty before", function() {
+        });
+
+        beforeEach(function() {
+        });
+
+        it("_findEmpty should return false if no sub node", function() {
+
+            return expect(nodeApiService._findEmpty(null, 'enclosedBy')).to.equal(false);
+        });
+
+        it("_findEmpty should return true if no relation field", function() {
+            var enclNodes = {
+                id: '1234abcd1234abcd1234abcd',
+                type: 'enclNode'
+            };
+
+            return expect(nodeApiService._findEmpty(enclNodes, 'encloses')).to.equal(true);
+        });
+
+        it("_findEmpty should return true if the specefic relation is empty", function() {
+            var enclNodes = {
+                id: '1234abcd1234abcd1234abcd',
+                type: 'enclNode',
+                relations: [
+                    {
+                        "relationType": "powerBy",
+                        "targets": [
+                            "1234abcd1234abcd1234abcd",
+                        ]
+                    }
+                ]
+            };
+
+            return expect(nodeApiService._findEmpty(enclNodes, 'encloses')).to.equal(true);
+        });
+
+        it("_findEmpty should return false if the specefic relation isn't empty", function() {
+            var enclNodes = {
+                id: '1234abcd1234abcd1234abcd',
+                type: 'enclNode',
+                relations: [
+                    {
+                        "relationType": "encloses",
+                        "targets": [
+                            "1234abcd1234abcd1234abcd",
+                        ]
+                    }
+                ]
+            };
+
+            return expect(nodeApiService._findEmpty(enclNodes, 'encloses')).to.equal(false);
+        });
+
     });
 
     describe("removeNode", function() {
@@ -90,162 +324,182 @@ describe("Http.Services.Api.Nodes", function () {
             this.sandbox.stub(waterline.catalogs, 'destroy').resolves();
         });
 
-        it("removeNode should fail when a workflow is running", function() {
-            this.sandbox.stub(taskGraphProtocol, 'getActiveTaskGraph').resolves('true');
-            return expect(nodeApiService.removeNode(computeNode))
-                   .to.be.rejectedWith(Errors.BadRequestError);
-        });
-
-        it("removeNode should remove one node", function() {
-            this.sandbox.stub(taskGraphProtocol, 'getActiveTaskGraph').resolves('');
-            this.sandbox.stub(nodeApiService, '_findEnclNodes').resolves();
-            this.sandbox.stub(nodeApiService, '_removeEnclRelations').resolves();
-
-            return nodeApiService.removeNode(computeNode)
-            .then(function (node) {
-                expect(waterline.lookups.update).to.have.been.calledOnce;
-                expect(waterline.nodes.destroy).to.have.been.calledOnce;
-                expect(waterline.catalogs.destroy).to.have.been.calledOnce;
-                expect(waterline.workitems.destroy).to.have.been.calledOnce;
-                expect(nodeApiService._findEnclNodes).to.have.been.calledOnce;
-                expect(nodeApiService._removeEnclRelations).to.have.been.calledOnce;
-                expect(node).to.equal(computeNode);
-            });
-        });
-    });
-    describe("_findEnclNodes", function() {
-        before("_findEnclNodes before", function() {
-        });
-
-        beforeEach(function() {
-        });
-
-        it("_findEnclNodes should find related enclosure nodes", function() {
-            this.sandbox.stub(waterline.nodes, 'needByIdentifier').resolves(enclosureNode);
-
-            return nodeApiService._findEnclNodes(computeNode)
-            .then(function (nodes) {
-                expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
-                expect(nodes[0]).to.equal(enclosureNode);
-            });
-        });
-
-        it("_findEnclNodes should return nothing if cannot find enclosure node", function() {
-            this.sandbox.stub(waterline.nodes, 'needByIdentifier').rejects(Errors.NotFoundError(''));
-
-            return nodeApiService._findEnclNodes(computeNode)
-            .then(function (nodes) {
-                expect(waterline.nodes.needByIdentifier).to.have.been.calledOnce;
-                expect(nodes[0]).to.equal(undefined);
-            });
-        });
-
-        it("_findEnclNodes should return nothing if don't have relations", function() {
-            var node = {
-                id: '1234abcd1234abcd1234abcd',
-                name: 'computeNode'
+        it("removeNode should not delete downstream node when no constants defined", function() {
+            var noopNode = {
+                id: '1234abcd1234abcd1234abce',
+                type: 'noop',
+                relations: [
+                    {
+                        "relationType": "noops",
+                        "targets": [
+                            "1234abcd1234abcd1234abcd"
+                        ]
+                    }
+                ]
+            };
+            var computeNodeBefore = _.cloneDeep(computeNode);
+            computeNodeBefore.relations[0] = {
+                "relationType": "noopedBy",
+                "targets": ["1234abcd1234abcd1234abce"]
             };
 
-            return nodeApiService._findEnclNodes(node)
-            .then(function (nodes) {
-                expect(nodes).to.equal(undefined);
+            getActiveTaskGraph.resolves('');
+            needByIdentifier.resolves(noopNode);
+
+            return nodeApiService.removeNode(computeNodeBefore)
+            .then(function (node){
+                expect(node).to.equal(computeNodeBefore);
+                expect(updateByIdentifier).to.not.have.been.called;
+                expect(waterline.nodes.destroy).to.have.been.calledOnce;
+                expect(waterline.nodes.destroy).to.have.been
+                    .calledWith({id: computeNodeBefore.id});
             });
         });
 
-        it("_findEnclNodes should return nothing if node is null", function() {
+        it("removeNode should delete compute node", function() {
+            var enclNodeAfter = _.cloneDeep(enclosureNode);
+            _.pull(enclNodeAfter.relations[0].targets, '1234abcd1234abcd1234abcd');
 
-            return nodeApiService._findEnclNodes(null)
-            .then(function (nodes) {
-                expect(nodes).to.equal(undefined);
-            });
-        });
-
-    });
-
-    describe("_removeEnclRelations", function() {
-        before("_removeEnclRelations before", function() {
-        });
-
-        beforeEach(function() {
-            this.sandbox.stub(waterline.nodes, 'updateByIdentifier').resolves();
-            this.sandbox.stub(waterline.nodes, 'destroy').resolves();
-        });
-
-        it("_removeEnclRelations should fail if enclosure node is null", function() {
-            return nodeApiService._removeEnclRelations(computeNode, null)
-            .then(function () {
-                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
-                expect(waterline.nodes.destroy).to.not.have.been.called;
-            });
-        });
-
-        it("_removeEnclRelations should fail if enclosure node is null", function() {
-            var enclNodes = [
-                {
-                    id: '1234abcd1234abcd1234abcd',
-                    name: 'computeNode'
-                }
-            ];
-
-            return nodeApiService._removeEnclRelations(computeNode, enclNodes)
-            .then(function () {
-                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
-                expect(waterline.nodes.destroy).to.not.have.been.called;
-            });
-        });
-
-        it("_removeEnclRelations should fail if relationType is incorrect", function() {
-            var enclNodes = [
-                {
-                    id: '1234abcd1234abcd1234abcd',
-                    name: 'computeNode',
-                    relations: [
-                        {
-                            "relationType": "enclosedBy",
-                        }
-                    ]
-                }
-            ];
-
-            return nodeApiService._removeEnclRelations(computeNode, enclNodes)
-            .then(function () {
-                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
-                expect(waterline.nodes.destroy).to.not.have.been.called;
-            });
-        });
-
-        it("_removeEnclRelations should fail if don't have targets", function() {
-            var enclNodes = [
-                {
-                    id: '1234abcd1234abcd1234abcd',
-                    name: 'computeNode',
-                    relations: [
-                        {
-                            "relationType": "encloses"
-                        }
-                    ]
-                }
-            ];
-
-            return nodeApiService._removeEnclRelations(computeNode, enclNodes)
-            .then(function () {
-                expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
-                expect(waterline.nodes.destroy).to.not.have.been.called;
-            });
-        });
-
-        it("_removeEnclRelations should remove relations", function() {
-            return nodeApiService._removeEnclRelations(computeNode, [enclosureNode])
-            .then(function () {
-                expect(waterline.nodes.updateByIdentifier).to.have.been.calledOnce;
-            });
-        });
-
-        it("_removeEnclRelations should remove enclosure node when it has no relations", function() {
-            return nodeApiService._removeEnclRelations(computeNode, [enclosureNode1])
-            .then(function () {
+            getActiveTaskGraph.resolves('');
+            needByIdentifier.resolves(enclosureNode);
+            updateByIdentifier.resolves(enclNodeAfter);
+            return nodeApiService.removeNode(computeNode)
+            .then(function (node){
+                expect(node).to.equal(computeNode);
                 expect(waterline.nodes.destroy).to.have.been.calledOnce;
             });
         });
+
+        it("removeNode should delete enclosure node when no compute node target", function() {
+            var enclNode = {
+                id: '1234abcd1234abcd1234abcf',
+                type: 'enclosure',
+                relations: [
+                    {
+                        "relationType": "encloses",
+                        "targets": [
+                            "1234abcd1234abcd1234abcd"
+                        ]
+                    }
+                ]
+            };
+            var enclNodeAfter = _.cloneDeep(enclNode);
+            delete enclNodeAfter.relations;
+
+            getActiveTaskGraph.resolves('');
+            needByIdentifier.resolves(enclNode);
+            updateByIdentifier.resolves(enclNodeAfter);
+
+            return nodeApiService.removeNode(computeNode)
+            .then(function (node){
+                expect(node).to.equal(computeNode);
+                expect(waterline.nodes.destroy).to.have.been.calledTwice;
+                expect(waterline.nodes.destroy).to.have.been.calledWith({id: computeNode.id});
+                expect(waterline.nodes.destroy).to.have.been.calledWith({id: enclNode.id});
+            });
+        });
+
+        it("removeNode should delete compute node when deleting enlosure", function() {
+            var computeNode2 = {
+                id: '1234abcd1234abcd1234abce',
+                type: 'compute',
+                relations: [
+                    {
+                        "relationType": "enclosedBy",
+                        "targets": [
+                            "1234abcd1234abcd1234abcf"
+                        ]
+                    }
+                ]
+            };
+            var computeNodeAfter = _.cloneDeep(computeNode);
+            var computeNode2After = _.cloneDeep(computeNode2);
+            delete computeNodeAfter.relations;
+            delete computeNode2After.relations;
+
+            getActiveTaskGraph.resolves('');
+            needByIdentifier.withArgs(computeNode.id).resolves(computeNode);
+            needByIdentifier.withArgs(computeNode2.id).resolves(computeNode2);
+            updateByIdentifier.withArgs(computeNode.id).resolves(computeNodeAfter);
+            updateByIdentifier.withArgs(computeNode2.id).resolves(computeNode2After);
+
+            return nodeApiService.removeNode(enclosureNode)
+            .then(function (node){
+                expect(node).to.equal(enclosureNode);
+                expect(waterline.nodes.destroy).to.have.been.calledThrice;
+                expect(waterline.nodes.destroy).to.have.been.calledWith({id: computeNode.id});
+                expect(waterline.nodes.destroy).to.have.been.calledWith({id: computeNode2.id});
+                expect(waterline.nodes.destroy).to.have.been.calledWith({id: enclosureNode.id});
+            });
+        });
+
+        it("removeNode should not delete compute node when deleting cluster", function() {
+            var clusterNode = {
+                id: '1234abcd1234abcd1234abce',
+                type: 'cluster',
+                relations: [
+                    {
+                        "relationType": "cluster",
+                        "targets": [
+                            "1234abcd1234abcd1234abcd"
+                        ]
+                    }
+                ]
+            };
+            var computeNodeBefore = _.cloneDeep(computeNode);
+            computeNodeBefore.relations[1] = {
+                "relationType": "clusterBy",
+                "targets": ["1234abcd1234abcd1234abce"]
+            };
+
+            getActiveTaskGraph.resolves('');
+            needByIdentifier.withArgs(computeNodeBefore.id).resolves(computeNodeBefore);
+            updateByIdentifier.withArgs(computeNodeBefore.id).resolves(computeNode);
+
+            return nodeApiService.removeNode(clusterNode)
+            .then(function (node){
+                expect(node).to.equal(clusterNode);
+                expect(waterline.nodes.destroy).to.have.been.calledOnce;
+                expect(waterline.nodes.destroy).to.have.been.calledWith({id: clusterNode.id});
+                expect(updateByIdentifier).to.have.been
+                    .calledWith(computeNode.id,
+                                {relations: computeNode.relations});
+            });
+        });
+
+        it("removeNode should not delete enlosure when active workflow", function() {
+            var computeNode2 = {
+                id: '1234abcd1234abcd1234abce',
+                type: 'compute',
+                relations: [
+                    {
+                        "relationType": "enclosedBy",
+                        "targets": [
+                            "1234abcd1234abcd1234abcf"
+                        ]
+                    }
+                ]
+            };
+            var computeNodeAfter = _.cloneDeep(computeNode);
+            var computeNode2After = _.cloneDeep(computeNode2);
+            delete computeNodeAfter.relations;
+            delete computeNode2After.relations;
+
+            getActiveTaskGraph.resolves('');
+            getActiveTaskGraph.withArgs({target: computeNode2.id}).resolves('1');
+            needByIdentifier.withArgs(computeNode.id).resolves(computeNode);
+            needByIdentifier.withArgs(computeNode2.id).resolves(computeNode2);
+            updateByIdentifier.withArgs(computeNode.id).resolves(computeNodeAfter);
+            updateByIdentifier.withArgs(computeNode2.id).resolves(computeNode2After);
+
+            return nodeApiService.removeNode(enclosureNode)
+            .catch(function (err){
+                expect(err.name).to.equal('BadRequestError');
+                expect(waterline.nodes.destroy).to.not.have.been.called;
+                expect(updateByIdentifier).to.not.have.been.called;
+            });
+        });
+
     });
+
 });


### PR DESCRIPTION
Implement full function about deleting nodes and update its related ones based on "relations" field in nodes/ document. It is invoked by ODR-314 (https://hwjiraprd01.corp.emc.com/browse/ODR-314) requiring removing compute nodes in an enclosure when user asks to delete that enclosure node.

Currently there is only (enclosedBy, encloses) relation in node, but it is easily extensible to cover other relations such as (powers, powerBy) or (compute node use dae, dae used by compute node). When deleting one node, RackHD should also delete or update its corresponding nodes in different conditions.

There are 3 types of operations to deal with corresponding (I call it "target node" in code and here) nodes:
* delete all target nodes. 
   e.g. delete enclosure node -> delete compute node as well
* delete target nodes when it doesn't have other targets in this relation. 
   e.g. delete compute node -> delete enclosure node if this enclosure doesn't have other compute node
* update relation in target node. 
   e.g. delete compute node -> update relations in pdu node

This PR covers all cases above. constants.js in on-core defines mapping table and supported target operations. node-api-service in this PR reads this setting and manipulates database. The required nodes will be deleted only after all its target nodes have been processed successfully.

related PR:
https://github.com/RackHD/on-core/pull/55

