### PR TITLE
Adds web ui install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,11 @@ node_modules
 .idea
 
 # static images
+static/ansible/
 static/files/
 static/http/
-static/tftp/
 static/smb/
-static/ansible/
+static/tftp/
+static/web-ui/
+
 build/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -184,4 +184,3 @@ function prepareGrunt(grunt) {
     // By default, lint and run all tests.
     grunt.registerTask('default', ['jshint', 'coverage', 'swagger']);
 }
-

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Note: requires MongoDB and RabbitMQ to be running to start correctly.
 
     sudo node index.js
 
+ * http://127.0.0.1/ui -- RackHD Web UI
+ * http://127.0.0.1/docs -- RackHD Docs
+
 ## Config
 
 The `fileService` requires a "fileService" key which holds keys mapping backend

--- a/install-web-ui.sh
+++ b/install-web-ui.sh
@@ -1,0 +1,10 @@
+# Copyright 2015, EMC, Inc.
+
+cd ./static
+
+rm -rf web-ui
+curl -L -o on-web-ui-gh-pages.zip https://github.com/RackHD/on-web-ui/archive/gh-pages.zip
+
+unzip on-web-ui-gh-pages.zip
+rm on-web-ui-gh-pages.zip
+mv on-web-ui-gh-pages web-ui

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -171,6 +171,9 @@ function httpServiceFactory(
             )
         );
 
+        // UI Directory
+        app.use('/ui', express.static('./static/web-ui'));
+
         // Mount API Routers
         app.use('/api/common', router);
         app.use('/api/current', router);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "doc": "./node_modules/.bin/jsdoc lib -r -d docs",
     "test": "./node_modules/.bin/mocha $(find spec -name '*-spec.js') -R spec --require spec/helper.js",
+    "install": "./install-web-ui.sh",
     "apidoc": "./node_modules/.bin/apidoc -i lib -f '.*\\.js$' -o build/apidoc",
     "apidoc-swagger": "./node_modules/.bin/apidoc-swagger --verbose -i lib -f '.*\\.js$' -o build/apidoc-swagger"
   },


### PR DESCRIPTION
Github provides a nice ability to download a zip file for any branch. Since the UI is hosted on `gh-pages` it can be used to install the UI for `on-http`. I created a script that will download and extract the UI and serve it at `/ui`. This script will get automatically run with `npm install`.