### PR TITLE
Change ipxe's undionly.kpxe to syslinux's undionly.kkpxe

### DIFF
--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -2,7 +2,7 @@ iseq ${platform} efi && goto is_efi || goto not_efi
 
 :not_efi
 set 209:string http://<%=server%>:<%=port%>/api/common/templates/esx-pxelinux-cfg
-chain tftp://<%=server%>/undionly.kpxe
+chain tftp://<%=server%>/undionly.kkpxe
 boot
 
 :is_efi

--- a/data/profiles/install-esx60.ipxe
+++ b/data/profiles/install-esx60.ipxe
@@ -1,2 +1,2 @@
 set 209:string http://<%=server%>:<%=port%>/api/common/templates/esx60-pxelinux-cfg
-chain tftp://<%=server%>/undionly.kpxe
+chain tftp://<%=server%>/undionly.kkpxe


### PR DESCRIPTION
it's the same with master's PR https://github.com/RackHD/on-http/pull/91 , it's for 1.1 release
undionly.kpxe from ipxe is not the original gPXE undionly.kkpxe from syslinux which has been validated for installing ESXi on multiple platforms, correct it here. This will fix the chainload failure issue when installing ESXi OS