### PR TITLE
Add module path for di injector

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ function onHttpContextFactory(di, directory) {
 
     var core = onCore(di, directory),
         helper = core.helper;
-
     return {
         expressApp: function () {
             return helper.simpleWrapper(express(), 'express-app', undefined, __dirname);
@@ -47,15 +46,15 @@ function onHttpContextFactory(di, directory) {
             helper.requireGlob(__dirname + '/lib/services/**/*.js'),
             helper.requireGlob(__dirname + '/lib/serializables/**/*.js'),
             require('./app'),
-            helper.requireWrapper('rimraf', 'rimraf'),
-            helper.requireWrapper('os-tmpdir', 'osTmpdir')
+            helper.requireWrapper('rimraf', 'rimraf', undefined, __dirname),
+            helper.requireWrapper('os-tmpdir', 'osTmpdir', undefined, __dirname)
         ]),
 
         prerequisiteInjectables: _.flattenDeep([
             onTasks.injectables,
             helper.simpleWrapper(ws, 'ws'),
             helper.simpleWrapper(ws.Server, 'WebSocketServer'),
-            helper.requireWrapper('swagger-express-mw', 'swagger')
+            helper.requireWrapper('swagger-express-mw', 'swagger', undefined, __dirname)
         ])
     };
 }

--- a/spec/lib/api/index-spec.js
+++ b/spec/lib/api/index-spec.js
@@ -16,8 +16,8 @@ describe('common-api-router', function () {
             dihelper.simpleWrapper({}, 'Task.Services.OBM'),
             dihelper.simpleWrapper({}, 'ipmi-obm-service'),
             dihelper.simpleWrapper(ws.Server, 'WebSocketServer'),
-            dihelper.requireWrapper('rimraf', 'rimraf'),
-            dihelper.requireWrapper('os-tmpdir', 'osTmpdir')
+            dihelper.requireWrapper('rimraf', 'rimraf', undefined, __dirname),
+            dihelper.requireWrapper('os-tmpdir', 'osTmpdir', undefined, __dirname)
         ];
     });
 

--- a/spec/lib/services/http-service-spec.js
+++ b/spec/lib/services/http-service-spec.js
@@ -12,12 +12,13 @@ describe('Http.Server', function () {
     helper.before(function () {
         return [
             dihelper.simpleWrapper(require('express')(), 'express-app'),
-            dihelper.simpleWrapper(require('swagger-express-mw'), 'swagger'),
+            dihelper.simpleWrapper(require('swagger-express-mw'),
+                'swagger', undefined, __dirname),
             dihelper.simpleWrapper(ws.Server, 'WebSocketServer'),
             dihelper.simpleWrapper({}, 'Task.Services.OBM'),
             dihelper.simpleWrapper({}, 'ipmi-obm-service'),
-            dihelper.requireWrapper('rimraf', 'rimraf'),
-            dihelper.requireWrapper('os-tmpdir', 'osTmpdir'),
+            dihelper.requireWrapper('rimraf', 'rimraf', undefined, __dirname),
+            dihelper.requireWrapper('os-tmpdir', 'osTmpdir', undefined, __dirname),
             helper.require('/lib/services/http-service'),
             helper.requireGlob('/lib/api/1.1/*.js'),
             helper.requireGlob('/lib/services/**/*.js'),

--- a/spec/lib/services/ws-service-spec.js
+++ b/spec/lib/services/ws-service-spec.js
@@ -12,12 +12,13 @@ describe('Services.WebSocket', function () {
     helper.before(function () {
         return [
             onHttpContext.helper.simpleWrapper(require('express')(), 'express-app'),
-            onHttpContext.helper.simpleWrapper(require('swagger-express-mw'), 'swagger'),
+            onHttpContext.helper.simpleWrapper(require('swagger-express-mw'),
+                'swagger', undefined, __dirname),
             onHttpContext.helper.simpleWrapper(WebSocket.Server, 'WebSocketServer'),
             onHttpContext.helper.simpleWrapper({}, 'Task.Services.OBM'),
             onHttpContext.helper.simpleWrapper({}, 'ipmi-obm-service'),
-            onHttpContext.helper.requireWrapper('rimraf', 'rimraf'),
-            onHttpContext.helper.requireWrapper('os-tmpdir', 'osTmpdir'),
+            onHttpContext.helper.requireWrapper('rimraf', 'rimraf', undefined, __dirname),
+            onHttpContext.helper.requireWrapper('os-tmpdir', 'osTmpdir', undefined, __dirname),
             helper.requireGlob('/lib/api/1.1/*.js'),
             helper.requireGlob('/lib/services/**/*.js'),
             helper.requireGlob('/lib/serializables/**/*.js')


### PR DESCRIPTION
Previous calls of helper.requireWrapper() didn't designate required module path, so the default ones are the path of on-core/di.js and its parent directories. Modules can be successfully injected when on-core is a real module under RackHD/on-http/node_modules/on-core, but will throw error about failure to find modules when using "npm link" in on-http to create a symbolic link of on-core to the local source code, since in the latter case, the working directory is RackHD/on-core/lib/di.js, and nodejs cannot find  modules in RackHD/on-http/node_modules.
So __dirname is added as a parameter in helper.requireWrapper() to ask di.js to find modules in current directory in on-http.