### PR TITLE
Ensure the accepted exit code is an array of number in bootstrap.js

### DIFF
--- a/data/templates/bootstrap.js
+++ b/data/templates/bootstrap.js
@@ -138,7 +138,7 @@ function executeTasks(data, timeout) {
                         _task.stderr + "\n" +
                         _task.error.toString());
             console.log("ACCEPTED RESPONSES " + _task.acceptedResponseCodes);
-            if (_task.acceptedResponseCodes &&
+            if (checkValidAcceptCode(_task.acceptedResponseCodes) &&
                 _task.acceptedResponseCodes.indexOf(_task.error.code) >= 0) {
 
                 console.log("_task " + _task.cmd + " error code " + _task.error.code +
@@ -271,6 +271,24 @@ function getFile(downloadUrl, cb) {
     }).on('error', function (error) {
         cb(error);
     }).end();
+}
+
+/**
+ * Check valid accepted response code - check whether the code is an array of number
+ * @private
+ * @param code
+ */
+function checkValidAcceptCode(code) {
+    if (!(code instanceof Array)) {
+        return false;
+    }
+
+    return code.every(function(item) {
+        if (typeof item !== 'number') {
+            return false;
+        }
+        return true;
+    });
 }
 
 getTasks(5000);


### PR DESCRIPTION
As discussed in https://github.com/RackHD/on-core/pull/70, add check of accept exit code to ensure it is an array of number. Otherwise this value won't take effect in evaluating stdout. 
It can cover the case when accepted exit code is '127', and actual exit code is 1 resulting accepting this error unexpectedly.
This PR can be merged independently without impacting discovery process.