### PR TITLE
Update Dockerfile for Alpine Linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.bintray.json
+.dockerignore
+.git
+.gitignore
+.hound.yml
+.jshintrc
+.travis.yml
+build-package.bash
+debianstatic/
+Dockerfile
+Gruntfile.js
+HWIMO-*
+LICENSE
+migrate.js
+README.md
+spec/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,11 @@ ADD https://bintray.com/artifact/download/rackhd/binary/builds/initrd.img-3.16.0
 ADD https://bintray.com/artifact/download/rackhd/binary/builds/vmlinuz-3.16.0-25-generic \
     /RackHD/on-http/static/http/common/vmlinuz-3.16.0-25-generic
 
-RUN apt-get update \
-  && apt-get install -y unzip \
-  && /RackHD/on-http/install-web-ui.sh
+RUN apk add --update unzip \
+  && /RackHD/on-http/install-web-ui.sh \
+  && /RackHD/on-http/install-swagger-ui.sh
 
 EXPOSE 80
 EXPOSE 443
 
-ENTRYPOINT [ "node" ]
-CMD [ "/RackHD/on-http/index.js" ]
+CMD [ "node", "/RackHD/on-http/index.js" ]


### PR DESCRIPTION
REQUIRES: https://github.com/RackHD/on-core/pull/79
* Switched rackhd/on-core to use an alpine linux base image.
* Now installs RackHD swagger-ui.
* Use CMD instead of ENTRYPOINT for easier debugging.