### PR TITLE
Create 2.0 and redfish 1.0 API client libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,13 @@ before_deploy:
  - sudo apt-get install -y maven
  - git clone --branch v2.1.4 https://github.com/swagger-api/swagger-codegen.git
  - pushd ./swagger-codegen && mvn package && popd
- - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i build/apidoc-swagger/swagger.json -o python-client -l python --additional-properties packageName=on_http
+ - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i build/apidoc-swagger/swagger.json -o on-http-api1.1 -l python --additional-properties packageName=on_http
+ - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail-2.0.yaml -o on-http-api2.0 -l python --additional-properties packageName=on_http_api2_0
+ - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/redfish.yaml -o on-http-redfish-1.0 -l python --additional-properties packageName=on_http_redfish_1_0
+ - ./build-package.bash python-client "${TRAVIS_BRANCH}" "on-http-api1.1"
+ - ./build-package.bash python-client "${TRAVIS_BRANCH}" "on-http-api2.0"
+ - ./build-package.bash python-client "${TRAVIS_BRANCH}" "on-http-redfish-1.0"
  - ./build-package.bash on-http "${TRAVIS_BRANCH}"
- - ./build-package.bash python-client "${TRAVIS_BRANCH}"
  - mkdir deb && cp -a *.deb deb/
 
 deploy:

--- a/debianstatic/python-client/changelog.in
+++ b/debianstatic/python-client/changelog.in
@@ -1,4 +1,4 @@
-python-on-http (1.1-1) unstable; urgency=low
+python-{{name}} (1.1-1) unstable; urgency=low
 
   * Initial release
 

--- a/debianstatic/python-client/control.in
+++ b/debianstatic/python-client/control.in
@@ -1,11 +1,11 @@
-Source: python-on-http
-Section: http
+Source: python-{{name}}
+Section: {{name}}
 Priority: optional
 Maintainer: Joseph Longever <joseph.longever@emc.com>
 Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.4
 
-Package: python-on-http
+Package: python-{{name}}
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, python2.7 
-Description: Python client library for RackHD on-http service.
+Description: Python client library for RackHD {{name}} API bindings

--- a/debianstatic/python-client/postinst
+++ b/debianstatic/python-client/postinst
@@ -1,3 +1,0 @@
-#!/bin/sh
-echo "Installing python-on-http client library..."
-cd /var/renasar/python-client && python setup.py -q install sdist

--- a/debianstatic/python-client/postinst.in
+++ b/debianstatic/python-client/postinst.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Installing python-{{name}} client library..."
+cd /var/renasar/{{name}} && python setup.py -q install sdist

--- a/debianstatic/python-client/python-on-http.dirs
+++ b/debianstatic/python-client/python-on-http.dirs
@@ -1,1 +1,0 @@
-/var/renasar

--- a/debianstatic/python-client/python-on-http.install
+++ b/debianstatic/python-client/python-on-http.install
@@ -1,1 +1,0 @@
-python-client /var/renasar

--- a/debianstatic/python-client/python-{{name}}.dirs.in
+++ b/debianstatic/python-client/python-{{name}}.dirs.in
@@ -1,0 +1,1 @@
+/var/renasar/

--- a/debianstatic/python-client/python-{{name}}.install.in
+++ b/debianstatic/python-client/python-{{name}}.install.in
@@ -1,0 +1,1 @@
+{{name}} /var/renasar/

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -2012,9 +2012,7 @@ definitions:
       OemPrivileges:
         description: The OEM privileges that this role includes.
         items:
-          type:
-            - string
-            - 'null'
+          type: string
         readOnly: false
         type: array
         x-longDescription: 'The value of this property shall be the OEM privileges that this role includes. For pre-defined roles, this property shall be readOnly. For custom roles some implementations may not allow writing this property.'
@@ -2433,16 +2431,12 @@ definitions:
       Message:
         description: 'This property decodes from EntryType:  If it is Event then it is a message string.  Otherwise, it is SEL or Oem specific.  In most cases, this will be the actual Log Entry.'
         readOnly: true
-        type:
-          - string
-          - 'null'
+        type: string
         x-longDescription: 'The value of this property shall be the Message property of the event if the EntryType is Event, the Description if EntryType is SEL and OEM Specific if the EntryType is OEM.'
       MessageArgs:
         description: The values of this property shall be any arguments for the message.
         items:
-          type:
-            - string
-            - 'null'
+          type: string
         readOnly: true
         type: array
         x-longDescription: This contains message arguments to be substituted into the message included or in the message looked up via a registry.
@@ -5007,9 +5001,7 @@ definitions:
       MessageArgs:
         description: This array of message arguments are substituted for the arguments in the message when looked up in the message registry.
         items:
-          type:
-            - string
-            - 'null'
+          type: string
         type: array
         x-longDescription: This property shall contain the message substitution arguments for the specific message referenced by the MessageId and shall only be included if the MessageId is present.
       MessageId:
@@ -5023,9 +5015,7 @@ definitions:
       RelatedProperties:
         description: This is an array of properties described by the message.
         items:
-          type:
-            - string
-            - 'null'
+          type: string
         type: array
         x-longDescription: 'This property shall contain an array of JSON Pointers indicating the properties described by the message, if appropriate for the message.'
       Resolution:


### PR DESCRIPTION
- Templatize python-client debian files.
- Generate debian packages for v2.0 and redfish API clients.
- Fixed redfish swagger type definitions.

Note:  The 2.0 and redfish client libraries will be pushed to pypi after more testing.  Currently these packages are uploaded manually.

@RackHD/corecommitters @zyoung51 @brianparry @geoff-reid @keedya @tannoa2 @uppalk1 