### PR TITLE
Add 2.0 API pollers routes

### DIFF
--- a/lib/api/2.0/pollers.js
+++ b/lib/api/2.0/pollers.js
@@ -1,0 +1,233 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var pollers = injector.get('Http.Services.Api.Pollers');
+
+
+/**
+ * @api {get} /api/2.0/pollers/library GET /library
+ * @apiVersion 2.0.0
+ * @apiDescription get list of possible pollers services
+ * @apiName pollers-library-get
+ * @apiGroup pollers
+ * @apiSuccess {json} pollers list of the available library pollers.
+ */
+var pollersLibGet = controller(function() {
+    return pollers.getPollerLib();
+});
+
+/**
+ * @api {get} /api/2.0/pollers/library/:identifier GET /library/:identifier
+ * @apiVersion 2.0.0
+ * @apiDescription get a single poller
+ * @apiName pollers-library-service-get
+ * @apiGroup pollers
+ * @apiParam {String} identifier String representation of the ObjectId
+ * @apiParamExample {String} Identifier-Example:
+ *      "ipmi"
+ * @apiSuccess {json} poller the specfied poller library
+ * @apiError NotFound There is no poller in the library with <code>identifier</code>
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersLibByIdGet = controller(function(req, res) {
+    return pollers.getPollerLibById(req.swagger.params.identifier.value);
+});
+
+/**
+ * @api {get} /api/2.0/pollers GET /
+ * @apiVersion 2.0.0
+ * @apiDescription get a list of all pollers
+ * @apiName pollers-get
+ * @apiGroup pollers
+ * @apiSuccess {json} pollers list of pollers or an empty object if there are none.
+ */
+var pollersGet = controller(function(req, res) {
+    return pollers.getPollers(req.query);
+});
+
+/**
+ * @api {get} /api/2.0/pollers/:identifier GET /:identifier
+ * @apiVersion 2.0.0
+ * @apiDescription Get specifics of the specified poller.
+ * @apiName poller-get
+ * @apiGroup pollers
+ * @apiParam {String} identifier String representation of the ObjectId
+ * @apiSuccess {json} poller the poller with the <code>id</code>
+ * @apiError identifierNotFound The <code>identifier</code> could not be found.
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersIdGet = controller(function(req, res) {
+    return pollers.getPollersById(req.swagger.params.identifier.value);
+});
+
+/**
+ * @api {post} /api/2.0/pollers POST /
+ * @apiVersion 2.0.0
+ * @apiDescription create a poller
+ * @apiName pollers-create
+ * @apiGroup pollers
+ * @apiError E_VALIDATION invalid Attributes.
+ * @apiErrorExample E_VALIDATION:
+ * {
+ *   "error": "E_VALIDATION",
+ *   "status": 400,
+ *   "summary": "1 attributes are invalid",
+ *   "model": "workitems",
+ *   "invalidAttributes": {
+ *       "pollInterval": [
+ *           {
+ *               "rule": "integer",
+ *               "message":
+ *                   "`undefined` should be a integer (instead of \"null\", which is a object)"
+ *           },
+ *           {
+ *               "rule": "required",
+ *               "message": "\"required\" validation rule failed for input: null"
+ *           }
+ *       ]
+ *   }
+ * }
+ */
+var pollersPost = controller({success: 201}, function(req, res) {
+    return pollers.postPollers(req.body);
+});
+
+/**
+ * @api {patch} /api/2.0/pollers/:identifier PATCH /:identifier
+ * @apiVersion 2.0.0
+ * @apiDescription update a poller
+ * @apiName pollers-update
+ * @apiGroup pollers
+ * @apiParam {String} identifier String representation of the ObjectId
+ * @apiSuccess {json} poller the patched poller with the <code>id</code>
+ * @apiError NotFound The <code>identifier</code> could not be found.
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersPatch = controller(function(req, res) {
+    return pollers.patchPollersById(req.swagger.params.identifier.value, req.body);
+});
+
+/**
+ * @api {patch} /api/2.0/pollers/:identifier PATCH /:identifier
+ * @apiVersion 2.0.0
+ * @apiDescription update a poller
+ * @apiName pollers-update
+ * @apiGroup pollers
+ * @apiParam {String} identifier String representation of the ObjectId
+ * @apiSuccess {json} poller the patched poller with the <code>id</code>
+ * @apiError NotFound The <code>identifier</code> could not be found.
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersPausePatch = controller(function(req, res) {
+    return pollers.patchPollersByIdPause(req.swagger.params.identifier.value);
+});
+
+/**
+ * @api {patch} /api/2.0/pollers/:identifier/resume PATCH /:identifier/resume
+ * @apiVersion 2.0.0
+ * @apiDescription resume a paused poller
+ * @apiName pollers-resume
+ * @apiGroup pollers
+ * @apiParam {String} identifier String representation of the ObjectId
+ * @apiSuccess {json} poller the unpaused poller with the <code>id</code>
+ * @apiError NotFound The <code>identifier</code> could not be found.
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersResumePatch = controller(function(req, res) {
+    return pollers.patchPollersByIdResume(req.swagger.params.identifier.value);
+});
+
+/**
+ * @api {delete} /api/2.0/pollers/:identifier DELETE /:id
+ * @apiVersion 2.0.0
+ * @apiDescription Delete all pollers of specified device.
+ * @apiName poller-delete
+ * @apiGroup pollers
+ * @apiParam {String} identifier String representation of the ObjectId
+ * @apiSuccess {nothing} nothing it doesn't return anything if Successful
+ * @apiError NotFound The <code>identifier</code> could not be found.
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersDelete = controller({success: 204}, function(req, res) {
+    return pollers.deletePollersById(req.swagger.params.identifier.value);
+});
+
+/**
+ * @api {get} /api/2.0/pollers/:identifier/data GET /:identifier/data
+ * @apiVersion 2.0.0
+ * @apiDescription Get data for the specific poller.
+ * @apiName poller-get-data
+ * @apiGroup pollers
+ * @apiParam {String} identifier (ip address or NodeId) for the data from a poller
+ * @apiError NotFound1 The <code>identifier</code> could not be found.
+ * @apiError NotFound2 There is no data for the poller with the <code>identifier</code>.
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersDataGet = controller(function(req, res) {
+    return pollers.getPollersByIdData(req.swagger.params.identifier.value);
+});
+
+/**
+ * @api {get} /api/2.0/pollers/:identifier/data/current GET /:identifier/data/current
+ * @apiVersion 2.0.0
+ * @apiDescription Get only the most recent data entry for the specific poller.
+ * @apiName poller-get-data-current
+ * @apiGroup pollers
+ * @apiParam {String} identifier (ip address or NodeId) for the data from a poller
+ * @apiError NotFound1 The <code>identifier</code> could not be found.
+ * @apiError NotFound2 There is no data for the poller with the <code>identifier</code>.
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "error": "Not Found"
+ *     }
+ */
+var pollersCurrentDataGet = controller(function(req, res) {
+    return pollers.getPollersByIdDataCurrent(req.swagger.params.identifier.value);
+});
+
+
+module.exports = {
+    pollersLibGet: pollersLibGet,
+    pollersLibByIdGet: pollersLibByIdGet,
+    pollersGet: pollersGet,
+    pollersIdGet: pollersIdGet,
+    pollersPost: pollersPost,
+    pollersPatch: pollersPatch,
+    pollersDelete: pollersDelete,
+    pollersDataGet: pollersDataGet,
+    pollersCurrentDataGet: pollersCurrentDataGet,
+    pollersPausePatch: pollersPausePatch,
+    pollersResumePatch: pollersResumePatch
+};

--- a/lib/api/serdes/pollers.js
+++ b/lib/api/serdes/pollers.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var injector = require('../../../index').injector;
+var serializer = injector.get('Http.Services.Swagger').serializer;
+var deserializer = injector.get('Http.Services.Swagger').deserializer;
+
+var pollersSerializer = serializer('Serializables.V2.Pollers');
+var pollersDeserializer = deserializer('Serializables.V2.Pollers');
+
+module.exports = {
+    pollersLibGet: pollersSerializer,
+    pollersLibByIdGet: pollersSerializer,
+    pollersGet: pollersSerializer,
+    pollersIdGet: pollersSerializer,
+    pollersPost: pollersDeserializer,
+    pollersPatch: pollersDeserializer,
+    pollersDelete: pollersDeserializer,
+    pollersDataGet: pollersSerializer,
+    pollersCurrentDataGet: pollersSerializer,
+    pollersPausePatch: pollersSerializer,
+    pollersResumePatch: pollersSerializer
+};
+

--- a/lib/serializables/v2/pollers.js
+++ b/lib/serializables/v2/pollers.js
@@ -1,0 +1,79 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = PollersFactory;
+
+di.annotate(PollersFactory, new di.Provide('Serializables.V2.Pollers'));
+di.annotate(PollersFactory,
+    new di.Inject(
+        'Serializable',
+        'Services.Waterline',
+        'Constants',
+        '_'
+    )
+);
+
+function PollersFactory (Serializable, waterline, Constants, _) {
+    function Pollers (defaults) {
+        Serializable.call(
+            this,
+            Pollers.schema,
+            defaults
+        );
+    }
+
+    Pollers.schema = {
+        id: 'Serializables.V2.Pollers',
+        type: 'object',
+        properties: {
+            config: {
+                type: 'object'
+            },
+            type: {
+                type: 'string'
+            },
+            pollInterval: {
+                type: 'integer'
+            },
+            paused: {
+                type: 'boolean'
+            }
+        },
+        required: [ 'config', 'type', 'pollInterval' ]
+    };
+
+    Serializable.register(PollersFactory, Pollers);
+
+    var pollerWorkItems = {
+        ipmi: Constants.WorkItems.Pollers.IPMI,
+        snmp: Constants.WorkItems.Pollers.SNMP
+    };
+
+    Pollers.prototype.deserialize = function(target) {
+        var poller = target;
+        if (poller) {
+            if (poller.type) {
+                poller.name = pollerWorkItems[poller.type];
+            }
+            poller = _.pick(poller, 'name', 'node', 'config', 'pollInterval', 'paused');
+            this.defaults(target);
+        }
+        return this;
+    };
+
+    Pollers.prototype.serialize = function(target) {
+        var poller = target;
+        if (poller) {
+            poller.type = _.findKey(pollerWorkItems, function(workItem) {
+                return workItem === poller.name;
+            });
+            delete poller.name;
+        }
+        return waterline.workitems.deserialize(poller);
+    };
+
+    return Pollers;
+}

--- a/lib/services/pollers-api-service.js
+++ b/lib/services/pollers-api-service.js
@@ -1,0 +1,127 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = pollerApiServiceFactory;
+di.annotate(pollerApiServiceFactory, new di.Provide('Http.Services.Api.Pollers'));
+di.annotate(pollerApiServiceFactory,
+    new di.Inject(
+        'Services.Waterline',
+        'Protocol.Task'
+    )
+);
+
+function pollerApiServiceFactory(
+    waterline,
+    taskProtocol
+) {
+
+    function PollerApiService() {
+    }
+
+    var pollerLibrary = [
+        {
+            name: 'ipmi',
+            node: true,
+            config: [
+                {
+                    key: 'host',
+                    type: 'string'
+                },
+                {
+                    key: 'user',
+                    type: 'string',
+                    defaultsTo: 'admin'
+                },
+                {
+                    key: 'password',
+                    type: 'string',
+                    defaultsTo: 'admin'
+                },
+                {
+                    key: 'alerts',
+                    type: 'json',
+                    required: false
+                }
+            ]
+        },
+        {
+            name: 'snmp',
+            config: [
+                {
+                    key: 'host',
+                    type: 'string',
+                    required: true
+                },
+                {
+                    key: 'communityString',
+                    type: 'string',
+                    required: true
+                },
+                {
+                    key: 'extensionMibs',
+                    type: 'string[]'
+                }
+            ]
+        }
+    ];
+    /**
+
+     */
+    PollerApiService.prototype.getPollerLib = function() {
+        return pollerLibrary;
+    };
+
+    /**
+
+     */
+
+    PollerApiService.prototype.getPollerLibById = function(id) {
+        return _.detect(pollerLibrary, { name: id });
+    };
+
+    PollerApiService.prototype.getPollers = function(query) {
+        return waterline.workitems.find(query);
+    };
+
+    PollerApiService.prototype.getPollersById = function(id) {
+        return waterline.workitems.needByIdentifier(id);
+    };
+
+
+    PollerApiService.prototype.postPollers = function(poller) {
+        return waterline.workitems.create(poller);
+    };
+
+
+    PollerApiService.prototype.patchPollersById = function(id, poller) {
+        return waterline.workitems.updateByIdentifier(id, poller);
+    };
+
+
+    PollerApiService.prototype.patchPollersByIdPause = function(id) {
+        return waterline.workitems.updateByIdentifier(id, { paused: true });
+    };
+
+
+    PollerApiService.prototype.patchPollersByIdResume = function(id) {
+        return waterline.workitems.updateByIdentifier(id, { paused: false });
+    };
+
+
+    PollerApiService.prototype.deletePollersById = function(id){
+        return waterline.workitems.destroyByIdentifier(id);
+    };
+
+    PollerApiService.prototype.getPollersByIdData = function(id) {
+        return taskProtocol.requestPollerCache(id);
+    };
+
+    PollerApiService.prototype.getPollersByIdDataCurrent = function(id) {
+        return taskProtocol.requestPollerCache(id, { latestOnly: true });
+    };
+
+    return new PollerApiService();
+}

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -22,9 +22,10 @@ function swaggerFactory(
     injector
 ) {
     function _processError(err) {
-        if (!util.isError(err) && err instanceof Error) {
+        if (!util.isError(err) && err instanceof Object) {
             var status = err.status;
-            err = new Error(err);
+            var message = (err instanceof Error) ? err : err.message;
+            err = new Error(message);
             if (status) { err.status = status; }
         }
         return err;

--- a/spec/lib/services/swagger-api-service-spec.js
+++ b/spec/lib/services/swagger-api-service-spec.js
@@ -84,7 +84,7 @@ describe('Services.Http.Swagger', function() {
             var res = {
                 headersSent: false
             };
-            var mockError = {message: 'mock error'};
+            var mockError = new Error('mock error');
 
             expect(controller).to.be.a('function');
             mockController.rejects(mockError);
@@ -156,9 +156,7 @@ describe('Services.Http.Swagger', function() {
             var res = {
                 body: mockData
             };
-            var mockError = {
-                message: 'serialize error'
-            };
+            var mockError = new Error('serializer error');
             MockSerializable.prototype.serialize.rejects(mockError);
 
             expect(serializer).to.be.a('function');
@@ -175,9 +173,7 @@ describe('Services.Http.Swagger', function() {
             var res = {
                 body: mockData
             };
-            var mockError = {
-                message: 'serialize error'
-            };
+            var mockError = new Error('serializer error');
             MockSerializable.prototype.serialize.resolves(mockData);
             MockSerializable.prototype.validateAsModel.rejects(mockError);
 
@@ -252,10 +248,10 @@ describe('Services.Http.Swagger', function() {
                 body: mockData
             };
             var res = {};
+            var mockError = new Error('deserializer error');
 
             expect(deserializer).to.be.a('function');
             MockSerializable.prototype.validate.rejects(mockError);
-            //MockSerializable.prototype.deserialize.resolves(mockData);
             return deserializer(req, res, mockNext).then(function() {
                 expect(mockNext).to.be.calledWith(mockError);
             });
@@ -272,6 +268,7 @@ describe('Services.Http.Swagger', function() {
                 body: mockData
             };
             var res = {};
+            var mockError = new Error('deserializer error');
 
             expect(deserializer).to.be.a('function');
             MockSerializable.prototype.validate.resolves(mockData);

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -38,9 +38,9 @@ paths:
   /swagger:
     x-swagger-pipe: swagger_raw
   /pollers/library:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: pollers
     get:
-      operationId: unimplemented
+      operationId: pollersLibGet
       summary: |
         get list of possible library pollers
       description: |
@@ -59,9 +59,9 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /pollers/library/{identifier}:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: pollers
     get:
-      operationId: unimplemented
+      operationId: pollersLibByIdGet
       summary: |
         get a single library poller
       description: |
@@ -92,9 +92,10 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /pollers:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: pollers
     get:
-      operationId: unimplemented
+      x-swagger-serializer: pollers
+      operationId: pollersGet
       summary: |
         get list of all pollers
       description: |
@@ -113,7 +114,8 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     post:
-      operationId: getVersions
+      x-swagger-deserializer: pollers
+      operationId: pollersPost
       summary: |
         create a poller
       description: |
@@ -132,9 +134,10 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /pollers/{identifier}:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: pollers
     get:
-      operationId: unimplemented
+      x-swagger-serializer: pollers
+      operationId: pollersIdGet
       summary: |
         Get specifics of the specified poller
       description: |
@@ -165,7 +168,8 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     patch:
-      operationId: unimplemented
+      x-swagger-deserializer: pollers
+      operationId: pollersPatch
       summary: |
         patch specifics of the specified poller
       description: |
@@ -196,7 +200,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      operationId: unimplemented
+      operationId: pollersDelete
       summary: |
         delete the specified poller
       description: |
@@ -224,14 +228,115 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /pollers/{identifier}/pause:
+    x-swagger-router-controller: pollers
+    patch:
+      x-swagger-serializer: pollers
+      operationId: pollersPausePatch
+      summary: |
+        pause the specified poller
+      description: |
+        pause the specified poller
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            poller identifier
+          required: true
+          type: string
+      tags:
+        - pollers
+        - patch
+      responses:
+        200:
+          description: |
+            Specifics of the paused poller
+          schema:
+            type: object
+        404:
+          description: |
+            There is no poller with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pollers/{identifier}/resume:
+    x-swagger-router-controller: pollers
+    patch:
+      x-swagger-serializer: pollers
+      operationId: pollersResumePatch
+      summary: |
+        resume the specified poller
+      description: |
+        resume the specified poller
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            poller identifier
+          required: true
+          type: string
+      tags:
+        - pollers
+        - patch
+      responses:
+        200:
+          description: |
+            Specifics of the resumed poller
+          schema:
+            type: object
+        404:
+          description: |
+            There is no poller with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /pollers/{identifier}/data:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: pollers
     get:
-      operationId: unimplemented
+      operationId: pollersDataGet
       summary: |
         Get data for the specific poller
       description: |
         Get data for the specific poller
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            identifier (ip address or NodeId) for the data from a poller
+          required: true
+          type: string
+      tags:
+        - templates
+        - get
+      responses:
+        200:
+          description: |
+            data for poller
+          schema:
+            type: object
+        404:
+          description: |
+            There is no poller with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pollers/{identifier}/data/current:
+    x-swagger-router-controller: pollers
+    get:
+      operationId: pollersCurrentDataGet
+      summary: |
+        Get latest data for the specific poller
+      description: |
+        Get latest data for the specific poller
       parameters:
         - name: identifier
           in: path


### PR DESCRIPTION
This change includes the following methods/routes.  @srinia6 will be submitting a follow-on PR with unit tests for these routes.

* GET /pollers/library
* GET /pollers/library/{identifier}
* GET /pollers
* GET /pollers/{identifier}
* POST /pollers
* PATCH /pollers/{identifier}
* DELETE /pollers/{identifier}
* PATCH /pollers/{identifier}/pause
* PATCH /pollers/{identifier}/resume
* GET /pollers/{identifier}/data
* GET /pollers/{identifier}/data/current