### PR TITLE
Updating ubuntu ipxe and preseed files

### DIFF
--- a/data/profiles/install-trusty.ipxe
+++ b/data/profiles/install-trusty.ipxe
@@ -1,5 +1,5 @@
 echo Starting Ubuntu x64 installer for ${hostidentifier}
-set base-url http://<%=server%>:<%=port%>/ubuntu_trusty/install/netboot/ubuntu-installer/amd64
+set base-url http://<%=server%>:<%=port%>/ubuntu/dists/trusty/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64
 kernel ${base-url}/linux
 initrd ${base-url}/initrd.gz
 imgargs linux auto=true DEBIAN_FRONTEND=noninteractive url=http://<%=server%>:<%=port%>/api/common/templates/ubuntu-trusty-preseed hostname=<%=hostname%> log_host=<%=server%> BOOTIF=01-<%=macaddress%> interface=auto console=tty0 console=<%=comport%>,115200n8

--- a/data/templates/ubuntu-trusty-preseed
+++ b/data/templates/ubuntu-trusty-preseed
@@ -1,7 +1,6 @@
 #### Contents of the preconfiguration file (for squeeze)
 ### Localization
 d-i debian-installer/locale string en_US.UTF-8
-d-i live-installer/net-image string http://<%=server%>:<%=port%>/ubuntu_trusty/install/filesystem.squashfs
 
 # Keyboard selection.
 # Disable automatic (interactive) keymap detection.
@@ -24,15 +23,15 @@ d-i netcfg/wireless_wep string
 ### Mirror settings
 # If you select ftp, the mirror/country string does not need to be set.
 d-i mirror/country string manual
-d-i mirror/http/hostname string <%=server%>
-d-i mirror/http/directory string /ubuntu_trusty
+d-i mirror/http/hostname string <%=server%>:<%=port%>
+d-i mirror/http/directory string /ubuntu
 d-i apt-setup/restricted boolean false
 d-i mirror/http/proxy string
 d-i apt-setup/universe boolean false
 d-i apt-setup/backports boolean false
 d-i apt-setup/proposed boolean false
 d-i apt-setup/security_host string
-d-i apt-setup/local0/repository string deb http://<%=server%>:<%=port%>/ubuntu_trusty trusty main restricted universe multiverse
+d-i apt-setup/local0/repository string deb http://<%=server%>:<%=port%>/ubuntu trusty main restricted universe multiverse
 d-i apt-setup/local0/source boolean false
 d-i debian-installer/allow_unauthenticated boolean true
 


### PR DESCRIPTION
* Replaced /ubuntu_trusty (which seems to be a personal mirror a dev setup) with correct locations that will work when /ubuntu is proxying http://archive.ubuntu.com/ubuntu/
* Removed the squashfs referenced in the preseed. It is not needed, and attempting to inject one creates a fragile dependency.
* Added the port to the host string.
