### PR TITLE
Clean jshint errors

### DIFF
--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -16,8 +16,7 @@ di.annotate(nodesRouterFactory, new di.Inject(
         'Services.Configuration',
         'Task.Services.OBM',
         'Logger',
-        '_',
-        'Errors'
+        '_'
     )
 );
 
@@ -29,8 +28,7 @@ function nodesRouterFactory (
     configuration,
     ObmService,
     Logger,
-    _,
-    Errors
+    _
 ) {
     var router = express.Router();
 

--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -6,69 +6,70 @@ var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var nodes = injector.get('Http.Services.Api.Nodes');
 
-var nodesGetAll = controller(function(req, res) {
+var nodesGetAll = controller(function(req) {
     return nodes.getAllNodes(req.query);
 });
 
-var nodesPost = controller({success: 201}, function(req, res) {
+var nodesPost = controller({success: 201}, function(req) {
     return nodes.postNode(req.body);
 });
 
-var nodesGetById = controller(function(req, res) {
+var nodesGetById = controller(function(req) {
     return nodes.getNodeById(req.swagger.params.identifier.value);
 });
 
-var nodesPatchById = controller(function(req, res) {
+var nodesPatchById = controller(function(req) {
     return nodes.patchNodeById(req.swagger.params.identifier.value, req.body);
 });
 
-var nodesDelById = controller(function(req, res) {
+var nodesDelById = controller(function(req) {
     return nodes.delNodeById(req.swagger.params.identifier.value);
 });
 
-var nodesGetObmById = controller(function(req, res) {
+var nodesGetObmById = controller(function(req) {
     return nodes.getNodeObmById(req.swagger.params.identifier.value);
 });
 
-var nodesPostObmById = controller({success: 201}, function(req, res) {
+var nodesPostObmById = controller({success: 201}, function(req) {
     return nodes.postNodeObmById(req.swagger.params.identifier.value, req.body);
 });
 
-var nodesPostObmIdById = controller(function(req, res) {
+var nodesPostObmIdById = controller(function(req) {
     return nodes.postNodeObmIdById(req.swagger.params.identifier.value, req.body);
 });
 
-var nodesGetCatalogById = controller(function(req, res) {
+var nodesGetCatalogById = controller(function(req) {
     return nodes.getNodeCatalogById(req.swagger.params.identifier.value);
 });
 
-var nodesGetCatalogSourceById = controller(function(req, res) {
+var nodesGetCatalogSourceById = controller(function(req) {
     return nodes.getNodeCatalogSourceById(req.swagger.params.identifier.value,
                                           req.swagger.params.source.value);
 });
 
-var nodesGetPollersById = controller(function(req, res) {
+var nodesGetPollersById = controller(function(req) {
     return nodes.getPollersByNodeId(req.swagger.params.identifier.value);
 });
 
-var nodesGetWorkflowById = controller(function(req, res) {
+var nodesGetWorkflowById = controller(function(req) {
     return nodes.getNodeWorkflowById(req.swagger.params.identifier.value);
 });
 
-var nodesPostWorkflowById = controller({success: 201}, function(req, res) {
+var nodesPostWorkflowById = controller({success: 201}, function(req) {
     //TODO(heckj): how are we assigning a nodes to a workflow - through
     // options? Merge in req.params.identifier?
     var config = _.defaults(req.query || {}, req.body || {});
     return nodes.setNodeWorkflow(req.swagger.params.identifier.value,
-                                 req.swagger.params.name.value || req.swagger.params.body.value.name,
+                                 req.swagger.params.name.value ||
+                                     req.swagger.params.body.value.name,
                                  config.options);
 });
 
-var nodesGetActiveWorkflowById = controller(function(req, res) {
+var nodesGetActiveWorkflowById = controller(function(req) {
     return nodes.getActiveNodeWorkflowById(req.swagger.params.identifier.value);
 });
 
-var nodesDelActiveWorkflowById = controller(function(req, res) {
+var nodesDelActiveWorkflowById = controller(function(req) {
     return nodes.delActiveWorkflowById(req.swagger.params.identifier.value);
 });
 

--- a/lib/api/2.0/pollers.js
+++ b/lib/api/2.0/pollers.js
@@ -36,7 +36,7 @@ var pollersLibGet = controller(function() {
  *       "error": "Not Found"
  *     }
  */
-var pollersLibByIdGet = controller(function(req, res) {
+var pollersLibByIdGet = controller(function(req) {
     return pollers.getPollerLibById(req.swagger.params.identifier.value);
 });
 
@@ -48,7 +48,7 @@ var pollersLibByIdGet = controller(function(req, res) {
  * @apiGroup pollers
  * @apiSuccess {json} pollers list of pollers or an empty object if there are none.
  */
-var pollersGet = controller(function(req, res) {
+var pollersGet = controller(function(req) {
     return pollers.getPollers(req.query);
 });
 
@@ -67,7 +67,7 @@ var pollersGet = controller(function(req, res) {
  *       "error": "Not Found"
  *     }
  */
-var pollersIdGet = controller(function(req, res) {
+var pollersIdGet = controller(function(req) {
     return pollers.getPollersById(req.swagger.params.identifier.value);
 });
 
@@ -99,7 +99,7 @@ var pollersIdGet = controller(function(req, res) {
  *   }
  * }
  */
-var pollersPost = controller({success: 201}, function(req, res) {
+var pollersPost = controller({success: 201}, function(req) {
     return pollers.postPollers(req.body);
 });
 
@@ -118,7 +118,7 @@ var pollersPost = controller({success: 201}, function(req, res) {
  *       "error": "Not Found"
  *     }
  */
-var pollersPatch = controller(function(req, res) {
+var pollersPatch = controller(function(req) {
     return pollers.patchPollersById(req.swagger.params.identifier.value, req.body);
 });
 
@@ -137,7 +137,7 @@ var pollersPatch = controller(function(req, res) {
  *       "error": "Not Found"
  *     }
  */
-var pollersPausePatch = controller(function(req, res) {
+var pollersPausePatch = controller(function(req) {
     return pollers.patchPollersByIdPause(req.swagger.params.identifier.value);
 });
 
@@ -156,7 +156,7 @@ var pollersPausePatch = controller(function(req, res) {
  *       "error": "Not Found"
  *     }
  */
-var pollersResumePatch = controller(function(req, res) {
+var pollersResumePatch = controller(function(req) {
     return pollers.patchPollersByIdResume(req.swagger.params.identifier.value);
 });
 
@@ -175,7 +175,7 @@ var pollersResumePatch = controller(function(req, res) {
  *       "error": "Not Found"
  *     }
  */
-var pollersDelete = controller({success: 204}, function(req, res) {
+var pollersDelete = controller({success: 204}, function(req) {
     return pollers.deletePollersById(req.swagger.params.identifier.value);
 });
 
@@ -194,7 +194,7 @@ var pollersDelete = controller({success: 204}, function(req, res) {
  *       "error": "Not Found"
  *     }
  */
-var pollersDataGet = controller(function(req, res) {
+var pollersDataGet = controller(function(req) {
     return pollers.getPollersByIdData(req.swagger.params.identifier.value);
 });
 
@@ -213,7 +213,7 @@ var pollersDataGet = controller(function(req, res) {
  *       "error": "Not Found"
  *     }
  */
-var pollersCurrentDataGet = controller(function(req, res) {
+var pollersCurrentDataGet = controller(function(req) {
     return pollers.getPollersByIdDataCurrent(req.swagger.params.identifier.value);
 });
 

--- a/lib/api/redfish-1.0/chassis.js
+++ b/lib/api/redfish-1.0/chassis.js
@@ -183,10 +183,10 @@ function getThermal(req, res) {
         var tempList = [], 
             fanList = [];
         _.forEach(sdrData,function(sdr) {
-            if (sdr['sensorType'] === 'Temperature') {
+            if (sdr.sensorType === 'Temperature') {
                 tempList.push(sdr);
             }
-            if (sdr['sensorType'] === 'Fan' ) {
+            if (sdr.sensorType === 'Fan' ) {
                 fanList.push(sdr);
             }
         });
@@ -218,10 +218,10 @@ function getPower(req, res) {
         var voltageList = [], 
             wattsList = [];
         _.forEach(sdrData,function(sdr) {
-            if (sdr['sensorType'] === 'Voltage') {
+            if (sdr.sensorType === 'Voltage') {
                 voltageList.push(sdr);
             }
-            if (sdr['sensorReadingUnits'] === 'Watts') {
+            if (sdr.sensorReadingUnits === 'Watts') {
                 wattsList.push(sdr);
             }
         });

--- a/lib/api/redfish-1.0/service-root.js
+++ b/lib/api/redfish-1.0/service-root.js
@@ -2,7 +2,8 @@
 
 'use strict';
 
-var injector = (typeof helper !== 'undefined') ? helper.injector : require('../../../index.js').injector;
+var injector = (typeof helper !== 'undefined') ? helper.injector :
+        require('../../../index.js').injector;
 var redfish = injector.get('Http.Api.Services.Redfish');
 
 module.exports = {

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -6,9 +6,8 @@ var injector = require('../../../index.js').injector;
 var redfish = injector.get('Http.Api.Services.Redfish');
 var waterline = injector.get('Services.Waterline');
 var taskProtocol = injector.get('Protocol.Task');
-var Errors = injector.get('Errors');
-var Promise = injector.get('Promise');
-var _ = injector.get('_');
+var Promise = injector.get('Promise');    // jshint ignore:line
+var _ = injector.get('_');                // jshint ignore:line
 var nodeApi = injector.get('Http.Services.Api.Nodes');
 
 module.exports = {
@@ -417,11 +416,11 @@ function doReset(req,res) {
             throw new Error(result.error);
         }
 
-        if(!_.has(map, payload.reset_type))  {
+        if(!_.has(map, payload.reset_type))  {    // jshint ignore:line
             throw new Error('value not found in map');
         }
         return nodeApi.setNodeWorkflowById(identifier, {
-            name: map[payload.reset_type]
+            name: map[payload.reset_type]    // jshint ignore:line
         });
     })
     .then(function(data) {

--- a/lib/fittings/json_error_handler.js
+++ b/lib/fittings/json_error_handler.js
@@ -3,8 +3,8 @@
 var util = require('util');
 var http = require('http');
 
-module.exports = function create(fittingDef, bagpipes) {
-    return function error_handler(context, next) {
+module.exports = function create() {
+    return function error_handler(context, next) {    // jshint ignore:line
         if (!util.isError(context.error)) { return next(); }
 
         var err = context.error;

--- a/lib/fittings/swagger_render.js
+++ b/lib/fittings/swagger_render.js
@@ -4,9 +4,9 @@
 
 var injector = require('../../index.js').injector;
 
-module.exports = function create(fittingDef, bagpipes) {
+module.exports = function create(fittingDef) {
     var swag = injector.get('Http.Services.Swagger');
-    return function swagger_render(context, next) {
+    return function swagger_render(context, next) {    // jshint ignore:line
         if (!context.response.headersSent) {
             var status = context.request.swagger.options.success || 200;
             var templateNameKey = fittingDef.templateNameKey;
@@ -15,7 +15,8 @@ module.exports = function create(fittingDef, bagpipes) {
             if (template === undefined) {
                 context.response.status(status).json(context.response.body);
             } else {
-                swag.renderer(template, context.response.body, next).then(function (renderedOutput) {
+                swag.renderer(template, context.response.body, next)
+                .then(function (renderedOutput) {
                     context.response.status(status).json(renderedOutput);
                 });
             }

--- a/lib/fittings/swagger_serdes.js
+++ b/lib/fittings/swagger_serdes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var path = require('path');
-var _ = require('lodash');
+var _ = require('lodash');    // jshint ignore:line
 
 module.exports = function create(fittingDef, bagpipes) {
     var swaggerNodeRunner = bagpipes.config.swaggerNodeRunner;


### PR DESCRIPTION
clean all the jshint errors for on-http

vagrant@rackhd-demo:~/src/on-http$ ./node_modules/.bin/jshint -c .jshintrc lib index.js || true
lib/api/1.1/northbound/nodes.js: line 33, col 5, 'Errors' is defined but never used.

lib/api/2.0/nodes.js: line 9, col 44, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 13, col 58, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 17, col 45, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 21, col 47, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 25, col 45, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 29, col 48, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 33, col 65, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 37, col 51, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 41, col 52, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 45, col 58, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 50, col 52, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 54, col 53, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 63, col 101, Line is too long.
lib/api/2.0/nodes.js: line 58, col 70, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 67, col 59, 'res' is defined but never used.
lib/api/2.0/nodes.js: line 71, col 59, 'res' is defined but never used.

lib/api/2.0/pollers.js: line 39, col 50, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 51, col 43, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 70, col 45, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 102, col 60, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 121, col 45, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 140, col 50, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 159, col 51, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 178, col 62, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 197, col 47, 'res' is defined but never used.
lib/api/2.0/pollers.js: line 216, col 54, 'res' is defined but never used.

lib/api/redfish-1.0/chassis.js: line 186, col 20, ['sensorType'] is better written in dot notation.
lib/api/redfish-1.0/chassis.js: line 189, col 20, ['sensorType'] is better written in dot notation.
lib/api/redfish-1.0/chassis.js: line 221, col 20, ['sensorType'] is better written in dot notation.
lib/api/redfish-1.0/chassis.js: line 224, col 20, ['sensorReadingUnits'] is better written in dot notation.

lib/api/redfish-1.0/service-root.js: line 5, col 105, Line is too long.

lib/api/redfish-1.0/systems.js: line 10, col 5, Redefinition of 'Promise'.
lib/api/redfish-1.0/systems.js: line 11, col 5, Redefinition of '_'.
lib/api/redfish-1.0/systems.js: line 420, col undefined, Identifier 'reset_type' is not in camel case.
lib/api/redfish-1.0/systems.js: line 424, col undefined, Identifier 'reset_type' is not in camel case.
lib/api/redfish-1.0/systems.js: line 9, col 5, 'Errors' is defined but never used.

lib/fittings/json_error_handler.js: line 7, col undefined, Identifier 'error_handler' is not in camel case.
lib/fittings/json_error_handler.js: line 6, col 46, 'bagpipes' is defined but never used.
lib/fittings/json_error_handler.js: line 6, col 34, 'fittingDef' is defined but never used.

lib/fittings/swagger_render.js: line 9, col undefined, Identifier 'swagger_render' is not in camel case.
lib/fittings/swagger_render.js: line 18, col 101, Line is too long.
lib/fittings/swagger_render.js: line 7, col 46, 'bagpipes' is defined but never used.

lib/fittings/swagger_serdes.js: line 4, col 5, Redefinition of '_'.

44 errors
vagrant@rackhd-demo:~/src/on-http$
