### PR TITLE
[redfish] Validate objects using odata.type if it is supplied

### DIFF
--- a/lib/services/redfish-validator-service.js
+++ b/lib/services/redfish-validator-service.js
@@ -83,11 +83,44 @@ function redfishValidatorFactory(
 
     RedfishValidator.prototype.validate = function(obj, schemaName)  {
         return Promise.all(ready).then(function() {
-            var basename = schemaName.split('#')[0];
-            if (!_.has(schemaNsMap, basename))  {
-                return Promise.reject(schemaName + ' is not loaded');
+            var basename;
+
+            // If a schemaName is specified, then validate against that
+            if(schemaName) {
+                basename = schemaName.split('#')[0];
+                if (!_.has(schemaNsMap, basename))  {
+                    return Promise.reject(schemaName + ' is not loaded');
+                }
+                return tv4.validateResult(obj, tv4.getSchema(schemaNsMap[basename] + schemaName));
             }
-            return tv4.validateResult(obj, tv4.getSchema(schemaNsMap[basename] + schemaName));
+        }).then(function(result) {
+            // Validate against all @odata.type fields declared
+            var objResults = _(getObjectsWithKey(obj, '@odata.type'))
+                .map(function(item) {
+                    if(_.has(schemaTitle, item['@odata.type']))  {
+                        schemaName = schemaTitle[item['@odata.type']];
+                        return tv4.validateResult(item, tv4.getSchema(schemaName));
+                    } 
+                })
+                .unshift(result)
+                .compact()
+                .value();
+
+            return _.transform(objResults, function(result, item) {
+                if(result.valid === undefined) {
+                    result.valid = item.valid;
+                } else {
+                    result.valid = item.valid ? result.valid : item.valid;
+                }
+                if(item.error) {
+                    result.error = result.error || [];
+                    result.error.push(item.error);
+                }
+                if(item.missing) {
+                    result.missing = result.missing || [];
+                    result.missing.push.apply(result.missing, item.missing);
+                }
+            });
         });
     };
 
@@ -127,6 +160,23 @@ function redfishValidatorFactory(
             identifier: identifier
         };
     };
+
+    function getObjectsWithKey(obj_, keys) {
+        var res = [];
+        var match = _.intersection(_.keys(obj_), _.isArray(keys) ? keys : [keys]);
+
+        if (!_.isEmpty(match)) {
+            res.push(obj_);
+        }
+
+        _.forEach(obj_, function(v) {
+            if (typeof v === "object" && (v = getObjectsWithKey(v, keys)).length) {
+                res.push.apply(res, v);
+            }
+        });
+
+        return res;
+    }
 
     return new RedfishValidator();
 }

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -388,8 +388,8 @@ describe('Redfish Systems Root', function () {
         taskProtocol.requestPollerCache.resolves([{
             sel: [{
                 logId: 'abcd',
-                value: '52',
-                sensorType: 'Thermal',
+                value: 'Assert',
+                sensorType: 'Temperature',
                 event: 'thermal event'
             }]
         }]);

--- a/spec/lib/services/redfish-validator-service-spec.js
+++ b/spec/lib/services/redfish-validator-service-spec.js
@@ -1,0 +1,105 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+require('../../helper');
+
+describe("Redfish Validator Service", function() {
+    var validator;
+    var template;
+    var _;
+    var testObj = {
+        '@odata.context': '/redfish/v1/$metadata#Systems',
+        '@odata.id': '/redfish/v1/Systems/',
+        '@odata.type': '#ComputerSystemCollection.ComputerSystemCollection',
+        Oem: {},
+        Name: 'Computer System Collection',
+        'Members@odata.count': 1,
+        Members: [ 
+            {
+                '@odata.id': '/redfish/v1/Systems/56c5ce6b283abbcb6c2b6037'
+            }
+        ]
+    };
+
+    before(function() {
+        helper.setupInjector([
+            helper.require("/lib/services/redfish-validator-service"),
+            dihelper.simpleWrapper(function() { arguments[1](); }, 'rimraf')
+        ]);
+        validator = helper.injector.get('Http.Api.Services.Redfish');
+        template = helper.injector.get('Templates');
+        _ = helper.injector.get('_');
+
+        sinon.stub(template, "get").resolves({contents: JSON.stringify(testObj)});
+    });
+
+    beforeEach(function() {
+        template.get.reset();
+    });
+
+    helper.after(function () {
+        template.get.restore();
+    });
+
+    it('should have an empty missing', function(done) {
+        expect(validator.missing()).to.be.empty;
+        done();
+    });
+
+    it('should validate an object against a valid schema', function() {
+        var schemaName = 'ComputerSystemCollection.json#/definitions/ComputerSystemCollection';
+        return validator.validate(testObj, schemaName)
+            .then(function(result) {
+                expect(result.error).to.be.empty;
+                expect(result.missing).to.be.empty;
+                expect(result.valid).to.be.true;
+            });
+    });
+
+    it('should fail an invalid object with a valid schema', function() {
+        var obj = _.merge({}, testObj, { extraParam: 'bad' });
+        var schemaName = 'ComputerSystemCollection.json#/definitions/ComputerSystemCollection';
+        return validator.validate(obj, schemaName)
+            .then(function(result) {
+                expect(result.error).have.length(2);
+                expect(result.missing).to.be.empty;
+                expect(result.valid).to.be.false;
+            });
+    });
+
+    it('should validate an object', function() {
+        return validator.validate(testObj)
+            .then(function(result) {
+                expect(result.error).to.be.empty;
+                expect(result.missing).to.be.empty;
+                expect(result.valid).to.be.true;
+            });
+    });
+
+    it('should fail an invalid object with a valid schema', function() {
+        var obj = _.merge({}, testObj, { extraParam: 'bad' });
+        return validator.validate(obj)
+            .then(function(result) {
+                expect(result.error).to.have.length(1);
+                expect(result.missing).to.be.empty;
+                expect(result.valid).to.be.false;
+            });
+    });
+
+    it('should get and render without validation', function() {
+        return validator.get('templateName', {})
+            .then(function(result) {
+                expect(result).to.deep.equal(testObj);
+            });
+    });
+
+    it('should get and render with validation', function() {
+        return validator.render('templateName', null, {})
+            .then(function(result) {
+                expect(result).to.deep.equal(testObj);
+            });
+    });
+
+
+});


### PR DESCRIPTION
- The object is parsed and all objects within that contain an
  'odata.type' are extracted.  Each odata.type is looked up in
  the schema dataset and then the object is validated against
  the schema.