### PR TITLE
Workflow related API fixes

### DIFF
--- a/data/templates/redfish.1.0.0.computersystem.1.0.0.json
+++ b/data/templates/redfish.1.0.0.computersystem.1.0.0.json
@@ -27,7 +27,9 @@
     "MemorySummary": {
         <% var memsize = 0; %>
         <% dmi.data['Memory Device'].forEach(function(dev) { %>
-        <%     memsize = memsize + parseInt(dev.Size.split(' ')[0]); %>
+        <%     var size = dev.Size.split(' ')[0]; %>
+        <%     size = isNaN(size) ? 0 : size; %>
+        <%     memsize = memsize + parseInt(size); %>
         <% }); %>
         <% memsize = memsize / 1024; %>
         "TotalSystemMemoryGiB": <%= memsize %>,

--- a/lib/api/1.1/northbound/workflows.js
+++ b/lib/api/1.1/northbound/workflows.js
@@ -104,34 +104,25 @@ function workflowsRouterFactory (
     }));
 
     /**
-     * @api {get} /api/1.1/workflows/library GET /library
+     * @api {get} /api/1.1/workflows/library/:injectableName GET /library/:injectableName
      * @apiVersion 1.1.0
-     * @apiDescription get list of workflows possible to run
-     * @apiName workflows-library
-     * @apiSuccess {json} workflows list of workflows that are possible to run
-     * @apiGroup workflows
-     */
-
-    router.get('/workflows/library', rest(function () {
-        return workflowApiService.getGraphDefinitions();
-    }));
-
-    /**
-     * @api {get} /api/1.1/workflows/library/:identifier GET /library/:identifier
-     * @apiVersion 1.1.0
-     * @apiDescription get a specific workflow from the library
-     * @apiParam {String} identifier of workflow, must cast to ObjectId
+     * @apiDescription get a specific workflow definition from the library. To get all
+     *                 known workflow definitions, use the '*' wildcard (GET /library/*)
+     * @apiParam {String} injectableName of workflow definition
      * @apiName workflows-library-item
-     * @apiSuccess {json} workflow the workflow that have the <code>identifier</code>
+     * @apiSuccess {json} workflow the workflow that have the <code>injectableName</code>
      * @apiGroup workflows
      */
 
-    router.get('/workflows/library/:identifier', rest(function (req) {
-        return workflowApiService.getGraphDefinitions(req.params.identifier)
+    router.get('/workflows/library/:injectableName', rest(function (req) {
+        if (req.params.injectableName === '*') {
+            return workflowApiService.getGraphDefinitions();
+        }
+        return workflowApiService.getGraphDefinitions(req.params.injectableName)
         .then(function(graphs) {
             if (_.isEmpty(graphs)) {
                 throw new Errors.NotFoundError(
-                    'Could not find graph definition for ' + req.params.identifier);
+                    'Could not find graph definition for ' + req.params.injectableName);
             } else {
                 return graphs[0];
             }
@@ -144,9 +135,9 @@ function workflowsRouterFactory (
      * @apiDescription get a specific workflow
      * @apiName workflow-get
      * @apiGroup workflows
-     * @apiParam {String} identifier of workflow, must cast to ObjectId
-     * @apiSuccess {json} workflow the workflow that have the <code>identifier</code>
-     * @apiError NotFound There is no workflow with <code>identifier</code>
+     * @apiParam {String} instanceId of workflow, must be a uuid v4
+     * @apiSuccess {json} workflow the workflow that have the <code>instanceId</code>
+     * @apiError NotFound There is no workflow with <code>instanceId</code>
      * @apiErrorExample Error-Response:
      *     HTTP/1.1 404 Not Found
      *     {
@@ -154,8 +145,8 @@ function workflowsRouterFactory (
      *     }
      */
 
-    router.get('/workflows/:identifier', rest(function (req) {
-        return waterline.graphobjects.needByIdentifier(req.params.identifier);
+    router.get('/workflows/:instanceId', rest(function (req) {
+        return waterline.graphobjects.needOne({ instanceId: req.params.instanceId });
     }));
 
     return router;

--- a/lib/api/redfish-1.0/task-service.js
+++ b/lib/api/redfish-1.0/task-service.js
@@ -7,6 +7,7 @@ var redfish = injector.get('Http.Api.Services.Redfish');
 var waterline = injector.get('Services.Waterline');
 var Promise = injector.get('Promise'); // jshint ignore:line
 var _ = injector.get('_');  // jshint ignore:line
+var Constants = injector.get('Constants');
 var moment = require('moment');
 
 module.exports = {
@@ -17,23 +18,22 @@ module.exports = {
 };
 
 var dataFactory = function(identifier, dataName) {
-    var statusMap = {
-        'valid': 'Running',
-        'succeeded': 'Completed',
-        'cancelled': 'Killed',
-        'failed':  'Exception'
-    };
+    var statusMap = {};
+    statusMap[Constants.Task.States.Pending] = 'Running';
+    statusMap[Constants.Task.States.Succeeded] = 'Completed';
+    statusMap[Constants.Task.States.Cancelled] = 'Killed';
+    statusMap[Constants.Task.States.Failed] = 'Exception';
 
     switch(dataName)  {
         case 'graphObjects':
             return Promise.map(waterline.graphobjects.find({}), function(graph) {
-                return { 
+                return {
                     state: statusMap[graph._status],
                     id: graph.id,
                     status: 'OK',
                     startTime: moment.utc(graph.createdAt).format(),
-                    endTime: (graph._status !== 'valid') ? 
-                        moment.utc(graph.updatedAt).format() : 
+                    endTime: (graph._status !== Constants.Task.States.Pending) ?
+                        moment.utc(graph.updatedAt).format() :
                         '',
                     name: graph.name,
                     systemId: graph.node
@@ -58,7 +58,7 @@ function taskServiceRoot(req, res) {
                 }
             });
             options.graphs = graphs;
-            return redfish.render('redfish.1.0.0.taskservice.1.0.0.json', 
+            return redfish.render('redfish.1.0.0.taskservice.1.0.0.json',
                  'TaskService.1.0.0.json#/definitions/TaskService',
                   options);
     }).then(function(output) {
@@ -79,7 +79,7 @@ function listTasks(req, res) {
     Promise.all([ dataFactory('', 'graphObjects') ])
         .spread(function(graphs) {
             options.graphs = graphs;
-            return redfish.render('redfish.1.0.0.taskcollection.json', 
+            return redfish.render('redfish.1.0.0.taskcollection.json',
                  'TaskCollection.json#/definitions/TaskCollection',
                   options);
     }).then(function(output) {
@@ -105,7 +105,7 @@ function getTask(req, res) {
             });
             options.graph = options.graphs[0];
 
-            return redfish.render('redfish.1.0.0.task.1.0.0.json', 
+            return redfish.render('redfish.1.0.0.task.1.0.0.json',
                  'Task.1.0.0.json#/definitions/Task',
                   options);
     }).then(function(output) {
@@ -131,7 +131,7 @@ function getSystemTasks(req, res) {
                 options.graphs = _.filter(graphs, function(graph) {
                     return graph.systemId === identifier;
                 });
-                return redfish.render('redfish.1.0.0.taskcollection.json', 
+                return redfish.render('redfish.1.0.0.taskcollection.json',
                         'TaskCollection.json#/definitions/TaskCollection',
                         options);
             });

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -8,7 +8,6 @@ module.exports = nodeApiServiceFactory;
 di.annotate(nodeApiServiceFactory, new di.Provide('Http.Services.Api.Nodes'));
 di.annotate(nodeApiServiceFactory,
     new di.Inject(
-        'Protocol.TaskGraphRunner',
         'Http.Services.Api.Workflows',
         'Services.Waterline',
         'Errors',
@@ -22,7 +21,6 @@ di.annotate(nodeApiServiceFactory,
     )
 );
 function nodeApiServiceFactory(
-    taskGraphProtocol,
     workflowApiService,
     waterline,
     Errors,
@@ -164,7 +162,7 @@ function nodeApiServiceFactory(
      * @return {Promise}
      */
     NodeApiService.prototype._delValidityCheck = function(nodeId) {
-        return taskGraphProtocol.getActiveTaskGraph( { target: nodeId })
+        return workflowApiService.findActiveGraphForTarget(nodeId)
         .then(function (graph) {
             if (graph) {
                 // If there is active workflow, the node cannot be deleted

--- a/lib/services/redfish-validator-service.js
+++ b/lib/services/redfish-validator-service.js
@@ -52,7 +52,7 @@ function redfishValidatorFactory(
         // add the redfishV1 schema if someone defined schemaConfig but left it out
         if( !_.some(schemaConfig, function(config) {
                 return config.namespace.indexOf('http://redfish.dmtf.org/schemas/v1/') === 0;
-            })) 
+            }))
         {
             logger.warning('Adding Redfish V1 schema missing from schemaConfig');
             schemaConfig.push.apply(schemaConfig, redfishV1);
@@ -100,7 +100,7 @@ function redfishValidatorFactory(
                     if(_.has(schemaTitle, item['@odata.type']))  {
                         schemaName = schemaTitle[item['@odata.type']];
                         return tv4.validateResult(item, tv4.getSchema(schemaName));
-                    } 
+                    }
                 })
                 .unshift(result)
                 .compact()
@@ -146,7 +146,7 @@ function redfishValidatorFactory(
                     .then(function(result) {
                         if(result.error) {
                             throw new Error(result.error);
-                        } 
+                        }
                         return output;
                     });
             });

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -129,6 +129,9 @@ function workflowApiServiceFactory(
         return this.createGraph(definition)
         .then(function() {
             return taskGraphStore.persistGraphDefinition(definition);
+        })
+        .then(function(definition) {
+            return definition.injectableName;
         });
     };
 

--- a/spec/lib/api/1.1/workflows-spec.js
+++ b/spec/lib/api/1.1/workflows-spec.js
@@ -41,7 +41,7 @@ describe('Http.Api.Workflows', function () {
         waterline.graphobjects = {
             find: sinon.stub().resolves([]),
             findByIdentifier: sinon.stub().resolves(),
-            needByIdentifier: sinon.stub().resolves()
+            needOne: sinon.stub().resolves()
         };
         waterline.lookups = {
             // This method is for lookups only and it
@@ -70,21 +70,21 @@ describe('Http.Api.Workflows', function () {
     describe('GET /workflows/:id', function () {
         it('should return a single persisted graph', function () {
             var graph = { name: 'foobar' };
-            waterline.graphobjects.needByIdentifier.resolves(graph);
+            waterline.graphobjects.needOne.resolves(graph);
 
             return helper.request().get('/api/1.1/workflows/12345')
             .expect('Content-Type', /^application\/json/)
             .expect(200, graph)
             .expect(function () {
-                expect(waterline.graphobjects.needByIdentifier).to.have.been.calledOnce;
-                expect(waterline.graphobjects.needByIdentifier)
-                .to.have.been.calledWith('12345');
+                expect(waterline.graphobjects.needOne).to.have.been.calledOnce;
+                expect(waterline.graphobjects.needOne)
+                    .to.have.been.calledWith({ instanceId: '12345' });
             });
         });
 
         it('should return a 404 if not found', function () {
             var Errors = helper.injector.get('Errors');
-            waterline.graphobjects.needByIdentifier.rejects(new Errors.NotFoundError('test'));
+            waterline.graphobjects.needOne.rejects(new Errors.NotFoundError('test'));
 
             return helper.request().get('/api/1.1/workflows/12345')
             .expect('Content-Type', /^application\/json/)
@@ -127,12 +127,12 @@ describe('Http.Api.Workflows', function () {
         });
     });
 
-    describe('GET /workflows/library', function () {
+    describe('GET /workflows/library/*', function () {
         it('should retrieve the graph library', function () {
             var graph = { name: 'foobar' };
             workflowApiService.getGraphDefinitions.resolves([graph]);
 
-            return helper.request().get('/api/1.1/workflows/library')
+            return helper.request().get('/api/1.1/workflows/library/*')
             .expect('Content-Type', /^application\/json/)
             .expect(200, [graph]);
         });

--- a/spec/lib/api/redfish-1.0/task-service-spec.js
+++ b/spec/lib/api/redfish-1.0/task-service-spec.js
@@ -8,8 +8,10 @@ describe('Redfish TaskService', function () {
     var validator;
     var waterline;
     var Promise;
+    var Constants;
     var template;
     var fs;
+    var graph;
 
     // Skip reading the entry from Mongo and return the entry directly
     function redirectGet(entry) {
@@ -22,6 +24,8 @@ describe('Redfish TaskService', function () {
     before('start HTTP server', function () {
         this.timeout(5000);
         return helper.startServer([]).then(function () {
+            Constants = helper.injector.get('Constants');
+
             template = helper.injector.get('Templates');
             sinon.stub(template, "get", redirectGet);
 
@@ -37,8 +41,17 @@ describe('Redfish TaskService', function () {
 
             var nodeFs = helper.injector.get('fs');
             fs = Promise.promisifyAll(nodeFs);
+        })
+        .then(function() {
+            graph = {
+                id: '566afe8a7e7b8f3751b951a5',
+                _status: Constants.Task.States.Pending,
+                createdAt: '2016-01-21T17:51:23.395Z',
+                updatedAt: '2016-01-21T17:52:23.395Z',
+                name: 'isc-dhcp leases poller',
+                node: 'abcdefg'
+            };
         });
-
     });
 
     beforeEach('set up mocks', function () {
@@ -68,7 +81,7 @@ describe('Redfish TaskService', function () {
         validator.validate.restore();
         validator.render.restore();
         template.get.restore();
-        
+
         function restoreStubs(obj) {
             _(obj).methods().forEach(function (method) {
                 if (obj[method] && obj[method].restore) {
@@ -81,15 +94,6 @@ describe('Redfish TaskService', function () {
         restoreStubs(waterline.nodes);
         return helper.stopServer();
     });
-
-    var graph = {
-        id: '566afe8a7e7b8f3751b951a5',
-        _status: 'valid',
-        createdAt: '2016-01-21T17:51:23.395Z',
-        updatedAt: '2016-01-21T17:52:23.395Z',
-        name: 'isc-dhcp leases poller',
-        node: 'abcdefg'
-    };
 
     it('should return a valid task service root', function () {
         waterline.graphobjects.find.resolves([graph]);

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -139,7 +139,7 @@ describe('Http.Services.Api.Workflows', function () {
     });
 
     it('should persist a graph definition', function () {
-        store.persistGraphDefinition.resolves();
+        store.persistGraphDefinition.resolves({ injectableName: 'test' });
         this.sandbox.stub(workflowApiService, 'createGraph').resolves();
         return workflowApiService.defineTaskGraph(graphDefinition)
         .then(function() {


### PR DESCRIPTION
More smoke test fixes:

- Missed one occurrence of replacing the deprecated way to check for an active graph for a node.
- Making some changes to the workflow library routes. These routes *already* do not work (https://github.com/RackHD/RackHD/issues/89), but tests have passed with false positives so far because the `/workflows/library` route gets redirected to the `/workflows/<id>` route. Previously, this route improperly returned a 200 no matter what. Because it was changed to return a 404 on failure to find a workflow, a bunch of the false positive tests are now failing as they should be.

I think this may be controversial in regards to the `/workflows/library/*` addition/change, but I'm kind of at a loss for what to do. I don't want to continue with the current broken behavior just to keep incorrect tests passing.

Resolves https://github.com/RackHD/RackHD/issues/89

@RackHD/corecommitters @jlongever @heckj @VulpesArtificem