### PR TITLE
add external repo support for CoreOS installation

### DIFF
--- a/data/profiles/install-coreos.ipxe
+++ b/data/profiles/install-coreos.ipxe
@@ -1,5 +1,5 @@
 echo Starting CoreOS Stable installer
-set base-url http://<%=server%>:<%=port%>/coreos
+set base-url <%=repo%>
 # coreos.autologin <-- enable as kernel param to autologin for easier debugging
 # reference: https://coreos.com/os/docs/latest/booting-with-ipxe.html
 # JUST BOOT AND RUN COREOS

--- a/data/templates/install-coreos.sh
+++ b/data/templates/install-coreos.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 curl -O http://<%=server%>:<%=port%>/api/common/templates/pxe-cloud-config.yml
-sudo coreos-install -d <%=installDisk%> -c pxe-cloud-config.yml -b http://<%=server%>:<%=port%>/coreos
+sudo coreos-install -d <%=installDisk%> -c pxe-cloud-config.yml -b <%=repo%>
 sudo reboot


### PR DESCRIPTION
This is discussed in this link: https://github.com/RackHD/RackHD/issues/90
Since http proxy often fails for large file transmission especially in vagrant environment, so add the external repo support will provide alternative way to do CoreOS installation.

@RackHD/corecommitters @pengz1 @heckj  