### PR TITLE
Update monorail.yml definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,11 @@ after_success:
 
 before_deploy:
  - npm run apidoc
- - npm run apidoc-swagger
  - npm prune --production
  - sudo apt-get install -y maven
  - git clone --branch v2.1.5 https://github.com/swagger-api/swagger-codegen.git
  - pushd ./swagger-codegen && mvn package && popd
- - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i build/apidoc-swagger/swagger.json -o on-http-api1.1 -l python --additional-properties packageName=on_http
+ - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail.yml -o on-http-api1.1 -l python --additional-properties packageName=on_http_api1_0
  - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail-2.0.yaml -o on-http-api2.0 -l python --additional-properties packageName=on_http_api2_0
  - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/redfish.yaml -o on-http-redfish-1.0 -l python --additional-properties packageName=on_http_redfish_1_0
  - ./build-package.bash python-client "${TRAVIS_BRANCH}" "on-http-api1.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_deploy:
  - sudo apt-get install -y maven
  - git clone --branch v2.1.5 https://github.com/swagger-api/swagger-codegen.git
  - pushd ./swagger-codegen && mvn package && popd
- - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail.yml -o on-http-api1.1 -l python --additional-properties packageName=on_http_api1_0
+ - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail.yml -o on-http-api1.1 -l python --additional-properties packageName=on_http_api1_1
  - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail-2.0.yaml -o on-http-api2.0 -l python --additional-properties packageName=on_http_api2_0
  - java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/redfish.yaml -o on-http-redfish-1.0 -l python --additional-properties packageName=on_http_redfish_1_0
  - ./build-package.bash python-client "${TRAVIS_BRANCH}" "on-http-api1.1"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "doc": "./node_modules/.bin/jsdoc lib/api/1.1/northbound -r -d docs",
     "test": "./node_modules/.bin/mocha $(find spec -name '*-spec.js') -R spec --require spec/helper.js",
     "install": "./install-web-ui.sh && ./install-swagger-ui.sh",
-    "apidoc": "./node_modules/.bin/apidoc -i lib/api/1.1/northbound -f '.*\\.js$' -o build/apidoc",
-    "apidoc-swagger": "./node_modules/.bin/apidoc-swagger --verbose -i lib/api/1.1/northbound -f '.*\\.js$' -o build/apidoc-swagger"
+    "apidoc": "./node_modules/.bin/apidoc -i lib/api/1.1/northbound -f '.*\\.js$' -o build/apidoc"
   },
   "repository": {
     "type": "git",
@@ -47,7 +46,6 @@
   },
   "devDependencies": {
     "apidoc": "^0.12.1",
-    "apidoc-swagger": "git+https://github.com/jlongever/apidoc-swagger.git",
     "chai": "^2.0.0",
     "chai-as-promised": "^4.2.0",
     "coveralls": "^2.11.4",

--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -627,7 +627,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   
-
   /workflows/library:
     get:
       summary: |
@@ -641,6 +640,50 @@ paths:
         200:
           description: |
             List all workflows available to run
+          schema: 
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  
+  /workflows/library/{injectableName}:
+    get:
+      summary: |
+        List all workflows available to run
+      description: |
+        List all workflows available to run
+      parameters:
+        - name: injectableName
+          in: path
+          required: true
+          type: string
+      tags:
+        - workflow
+        - get
+      responses:
+        200:
+          description: |
+            List all workflows available to run
+          schema: 
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+
+  /workflows/tasks/library:
+    get:
+      summary: |
+        List workflow tasks library
+      description: |
+        List workflow tasks library
+      tags:
+        - workflow
+        - get
+      responses:
+        200:
+          description: |
+            List workflow tasks library
           schema: 
             type: object
         default:
@@ -673,6 +716,11 @@ paths:
         Add tasks to task library
       description: |
         Add tasks to task library
+      parameters:
+        - name: body
+          in: body
+          required: false
+          type: object
       tags:
         - workflow
         - task
@@ -692,6 +740,32 @@ paths:
           description: Upload failed
           schema:
             $ref: '#/definitions/Error'
+
+  /workflows/{instanceId}:
+    get:
+      summary: |
+        Fetch workflow by instance ID
+      description: |
+        Fetch workflow by instance ID
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+      tags:
+        - workflow
+        - get
+      responses:
+        200:
+          description: |
+            Fetch workflows
+          schema: 
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
   /workflows:
     get:
       summary: |
@@ -716,6 +790,11 @@ paths:
         define new workflow
       description: |
         define new workflow
+      parameters:
+        - name: body
+          in: body
+          required: false
+          type: object
       tags:
         - workflow
         - put
@@ -842,10 +921,19 @@ paths:
         - name: identifier
           in: path
           description: |
-            Mac addresses and unique aliases to identify the node by, |
-            expect a string or an array of strings.
+            The node unique identifier
           required: true
           type: string
+        - name: name
+          in: query
+          description: |
+            The injectable Graph name
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: false
+          type: object
       tags:
         - nodes
         - workflow
@@ -879,6 +967,10 @@ paths:
             expect a string or an array of strings.
           required: true
           type: string
+        - name: body
+          in: body
+          required: false
+          type: object
       tags:
         - nodes
         - dhcp
@@ -1326,9 +1418,15 @@ paths:
   /lookups:
     get:
       summary: |
-        find all
+        find all or by query parameter
       description: |
-        find all
+        find all or by query parameter
+      parameters:
+        - name: q
+          in: query
+          description: query object to pass through to waterline.
+          required: false
+          type: string
       tags:
         - lookups
         - get
@@ -1379,6 +1477,62 @@ paths:
           description: id of thing to lookup
           required: true
           type: string
+      tags:
+        - lookups
+        - get
+      responses:
+        200:
+          description: array of all
+          schema:
+            type: array
+            items: 
+              type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: |
+        delete lookup id
+      description: |
+        delete lookup id
+      parameters:
+        - name: id
+          in: path
+          description: id to delete
+          required: true
+          type: string
+      tags:
+        - lookups
+        - get
+      responses:
+        200:
+          description: array of all
+          schema:
+            type: array
+            items: 
+              type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    patch:
+      summary: |
+        patch lookup id
+      description: |
+        patch lookup id
+      parameters:
+        - name: id
+          in: path
+          description: id to patch
+          required: true
+          type: string
+        - name: body
+          in: body
+          description: |
+            object patches to apply.
+          required: true
+          type: object
       tags:
         - lookups
         - get
@@ -1549,6 +1703,11 @@ paths:
         patch/update server configuration
       description: |
         Patch/update server configurationm and then return the patched configuration.
+      parameters:
+        - name: body
+          in: body
+          required: true
+          type: object
       tags:
         - config
         - patch


### PR DESCRIPTION
Generate 1.1 API client library from YAML definitions, remove apidoc-swagger dependency

@RackHD/corecommitters @WangWinson 
This removes the apidoc-swagger dependency and generates 1.1 client code from static/monorail.yml.  This keeps us consistent,  and probably should have been done this way originally;  it will also account for recent workflow api changes.   Once this goes in I can update pypi and submit the relative RackHD integration script changes, which are ready to go. 