### PR TITLE
Add security definition for generate python client with auth enabled

### DIFF
--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -12,6 +12,13 @@ produces:
   # x-gzip explicitly for files once the bugs listed 
   #   in comments below are fixed by swagger team.
   - application/x-gzip
+securityDefinitions:
+  auth_token:
+    type: apiKey
+    name: authorization
+    in: header
+security:
+  - auth_token: []
 paths:
   /pollers/library:
     get:


### PR DESCRIPTION
Python client generator is now point to the monorail.yml, so add the security fields to enable auth in client code.

@RackHD/corecommitters @cgx027 