### PR TITLE
Feature/node tagging

### DIFF
--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -425,16 +425,47 @@ function nodesRouterFactory (
         return nodeApiService.delActiveWorkflowById(req.params.identifier);
     }, { renderOptions: { success: 204 } }));
 
-    router.get('/nodes/:identifier/tags', rest(function(req) {
+    /**
+     * @api {get} /api/1.1/nodes/:identifier/tags GET /:id/tags
+     * @apiVersion 1.1.0
+     * @apiDescription Retrieve the tags on the node
+     * @apiName get-node-tags
+     * @apiGroup nodes
+     * @apiParam {String} identifier node identifier
+     * @apiSuccess (Success 200) {json} tags  the list of tags for that node.
+     * @apiError NotFound The node with the <code>identifier</code> was not found.
+     */
+     router.get('/nodes/:identifier/tags', rest(function(req) {
         return nodeApiService.getTagsById(req.params.identifier);
     }));
 
+    /**
+     * @api {patch} /api/1.1/nodes/:identifier/tags PATCH /:id/tags
+     * @apiVersion 1.1.0
+     * @apiDescription Add tags to a node
+     * @apiName patch-node-tags
+     * @apiGroup nodes
+     * @apiParam {String} identifier node identifier
+     * @apiSuccess (Success 200) {json} tags  the list of tags for that node.
+     * @apiError NotFound The node with the <code>identifier</code> was not found.
+     */
     router.patch('/nodes/:identifier/tags', rest(function (req) {
         if(req.body.tags) {
             return nodeApiService.addTagsById(req.params.identifier, req.body.tags);
         }
     }));
 
+    /**
+     * @api {delete} /api/1.1/nodes/:identifier/tags/:name DELETE /:id/tags/:name
+     * @apiVersion 1.1.0
+     * @apiDescription Delete tag from a node
+     * @apiName del-node-tag
+     * @apiGroup nodes
+     * @apiParam {String} identifier node identifier
+     * @apiParam {String} Name of tag to remove
+     * @apiSuccess (Success 204) Empty
+     * @apiError NotFound The node with the <code>identifier</code> was not found.
+     */
     router.delete('/nodes/:identifier/tags/:name', rest(function(req) {
         return nodeApiService.removeTagsById(req.params.identifier, req.params.name);
     }));

--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -425,6 +425,19 @@ function nodesRouterFactory (
         return nodeApiService.delActiveWorkflowById(req.params.identifier);
     }, { renderOptions: { success: 204 } }));
 
+    router.get('/nodes/:identifier/tags', rest(function(req) {
+        return nodeApiService.getTagsById(req.params.identifier);
+    }));
+
+    router.patch('/nodes/:identifier/tags', rest(function (req) {
+        if(req.body.tags) {
+            return nodeApiService.addTagsById(req.params.identifier, req.body.tags);
+        }
+    }));
+
+    router.delete('/nodes/:identifier/tags/:name', rest(function(req) {
+        return nodeApiService.removeTagsById(req.params.identifier, req.params.name);
+    }));
 
     return router;
 }

--- a/lib/api/1.1/northbound/router.js
+++ b/lib/api/1.1/northbound/router.js
@@ -34,6 +34,7 @@ function northApiFactory (injector) {
         router.use(injector.get(require('./templates')));
         router.use(injector.get(require('./workflows')));
         router.use(injector.get(require('./versions')));
+        router.use(injector.get(require('./tags')));
     };
 
     router.unMountAllRouters = function(){

--- a/lib/api/1.1/northbound/tags.js
+++ b/lib/api/1.1/northbound/tags.js
@@ -27,14 +27,40 @@ function tagsRouterFactory (
 ) {
     var router = express.Router();
 
+    /**
+     * @api {get} /api/1.1/tags GET /
+     * @apiVersion 1.1.0
+     * @apiDescription Retrieve a list of tags with rules
+     * @apiName get-tags
+     * @apiGroup tags
+     * @apiSuccess (Success 200) {json} The list of tags
+     */
     router.get('/tags', rest(function (req) {
         return Tags.findTags(req.query);
     }));
 
+    /**
+     * @api {get} /api/1.1/tags/:name GET /:name
+     * @apiVersion 1.1.0
+     * @apiDescription Retrieve information about a tag with rules
+     * @apiName get-tags-named
+     * @apiGroup tags
+     * @apiParam {String} Name of tag
+     * @apiSuccess (Success 200) {json} Information about the tag name
+     * @apiError NotFound The tag with the <code>name</code> was not found.
+     */
     router.get('/tags/:name', rest(function (req) {
         return Tags.getTag(req.params.identifier);
     }));
 
+    /**
+     * @api {post} /api/1.1/tags POST /
+     * @apiVersion 1.1.0
+     * @apiDescription Create a tag with rules
+     * @apiName post-tags
+     * @apiGroup tags
+     * @apiSuccess (Success 200) {json} Information about the tag created
+     */
     router.post('/tags', parser.json(), rest(function (req) {
         return Tags.findTags({name: req.body.name})
             .then(function(tag) {
@@ -50,15 +76,41 @@ function tagsRouterFactory (
             });
     }, { renderOptions: { success: 201 } }));
 
-
+    /**
+     * @api {delete} /api/1.1/tags/:name DELETE /:name
+     * @apiVersion 1.1.0
+     * @apiDescription Delete the tag named
+     * @apiName delete-tags-named
+     * @apiGroup tags
+     * @apiParam {String} Name of tag
+     * @apiSuccess (Success 204) Empty
+     */
     router.delete('/tags/:name', rest(function(req) {
         return Tags.destroyTag(req.params.identifier);
     }, { renderOptions: {success: 204} }));
 
+    /**
+     * @api {get} /api/1.1/tags/:name/nodes GET /:name/nodes
+     * @apiVersion 1.1.0
+     * @apiDescription Retrieve a list of nodes with the specified tag
+     * @apiName get-nodes-with-tag
+     * @apiGroup tags
+     * @apiParam {String} Name of tag
+     * @apiSuccess (Success 200) {json} List of nodes
+     */
     router.get('/tags/:name/nodes', rest(function (req) {
         return Nodes.getNodesByTag(req.params.name);
     }));
 
+    /**
+     * @api {post} /api/1.1/tags/:name/nodes/workflows POST /:name/nodes/workflows
+     * @apiVersion 1.1.0
+     * @apiDescription Initiate a workflow on the nodes with the specified tag
+     * @apiName post-workflow-to-nodes-with-tag
+     * @apiGroup tags
+     * @apiParam {String} Name of tag
+     * @apiSuccess (Success 200) {json} List of workflow status
+     */
     router.post('/tags/:name/nodes/workflows', rest(function(req) {
         return Promise.map(Nodes.getNodesByTag(req.params.name), function(node) {
             return Nodes.setNodeWorkflow(node.id, req.query.name, req.body.options);

--- a/lib/api/1.1/northbound/tags.js
+++ b/lib/api/1.1/northbound/tags.js
@@ -1,0 +1,69 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+var di = require('di'),
+    express = require('express'),
+    parser = require('body-parser');
+
+module.exports = tagsRouterFactory;
+
+di.annotate(tagsRouterFactory, new di.Provide('Http.Api.Tags'));
+di.annotate(tagsRouterFactory, new di.Inject(
+        'Http.Services.Api.Tags',
+        'Http.Services.Api.Nodes',
+        'Http.Services.RestApi',
+        '_',
+        'Promise'
+    )
+);
+
+function tagsRouterFactory (
+    Tags,
+    Nodes, 
+    rest, 
+    _, 
+    Promise
+) {
+    var router = express.Router();
+
+    router.get('/tags', rest(function (req) {
+        return Tags.findTags(req.query);
+    }));
+
+    router.get('/tags/:name', rest(function (req) {
+        return Tags.getTag(req.params.identifier);
+    }));
+
+    router.post('/tags', parser.json(), rest(function (req) {
+        return Tags.findTags({name: req.body.name})
+            .then(function(tag) {
+                if(_.isEmpty(tag)) {
+                    return Tags.createTag(req.body)
+                        .then(function() {
+                            return Tags.regenerateTags();
+                        });
+                }
+            })
+            .then(function() {
+                return req.body;
+            });
+    }, { renderOptions: { success: 201 } }));
+
+
+    router.delete('/tags/:name', rest(function(req) {
+        return Tags.destroyTag(req.params.identifier);
+    }, { renderOptions: {success: 204} }));
+
+    router.get('/tags/:name/nodes', rest(function (req) {
+        return Nodes.getNodesByTag(req.params.name);
+    }));
+
+    router.post('/tags/:name/nodes/workflows', rest(function(req) {
+        return Promise.map(Nodes.getNodesByTag(req.params.name), function(node) {
+            return Nodes.setNodeWorkflow(node.id, req.query.name, req.body.options);
+        });
+    }, { renderOptions: { success: 202 } }));
+
+    return router;
+}

--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -68,6 +68,20 @@ var nodesDelActiveWorkflowById = controller({success: 204}, function(req) {
     return nodes.delActiveWorkflowById(req.swagger.params.identifier.value);
 });
 
+var nodesGetTagsById = controller(function(req, res) {
+    return nodes.getTagsById(req.swagger.params.identifier.value);
+});
+
+var nodesDelTagById = controller(function(req, res) {
+    return nodes.removeTagsById(req.swagger.params.identifier.value, 
+                                req.swagger.params.tagName.value);
+});
+
+var nodesPatchTagById = controller(function(req, res) {
+    return nodes.addTagsById(req.swagger.params.identifier.value, 
+                             req.swagger.params.body.value.tags);
+});
+
 module.exports = {
     nodesGetAll: nodesGetAll,
     nodesPost: nodesPost,
@@ -83,5 +97,8 @@ module.exports = {
     nodesGetWorkflowById: nodesGetWorkflowById,
     nodesPostWorkflowById: nodesPostWorkflowById,
     nodesGetActiveWorkflowById: nodesGetActiveWorkflowById,
-    nodesDelActiveWorkflowById: nodesDelActiveWorkflowById
+    nodesDelActiveWorkflowById: nodesDelActiveWorkflowById,
+    nodesGetTagsById: nodesGetTagsById,
+    nodesDelTagById: nodesDelTagById,
+    nodesPatchTagById: nodesPatchTagById
 };

--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -68,16 +68,16 @@ var nodesDelActiveWorkflowById = controller({success: 204}, function(req) {
     return nodes.delActiveWorkflowById(req.swagger.params.identifier.value);
 });
 
-var nodesGetTagsById = controller(function(req, res) {
+var nodesGetTagsById = controller(function(req) {
     return nodes.getTagsById(req.swagger.params.identifier.value);
 });
 
-var nodesDelTagById = controller(function(req, res) {
+var nodesDelTagById = controller(function(req) {
     return nodes.removeTagsById(req.swagger.params.identifier.value, 
                                 req.swagger.params.tagName.value);
 });
 
-var nodesPatchTagById = controller(function(req, res) {
+var nodesPatchTagById = controller(function(req) {
     return nodes.addTagsById(req.swagger.params.identifier.value, 
                              req.swagger.params.body.value.tags);
 });

--- a/lib/api/2.0/tags.js
+++ b/lib/api/2.0/tags.js
@@ -6,13 +6,13 @@ var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var nodes = injector.get('Http.Services.Api.Nodes');
 var tags = injector.get('Http.Services.Api.Tags');
-var _ = injector.get('_');
+var _ = injector.get('_'); // jshint ignore:line
 
-var getAllTags = controller(function(req, res) {
+var getAllTags = controller(function(req) {
     return tags.findTags(req.query);
 });
 
-var createTag = controller({success: 201}, function(req,res) {
+var createTag = controller({success: 201}, function(req) {
     return tags.findTags({name: req.swagger.params.body.value.name}).then(function(tag) {
         if(_.isEmpty(tag)) {
             return tags.createTag(req.swagger.params.body.value).then(function() {
@@ -24,19 +24,19 @@ var createTag = controller({success: 201}, function(req,res) {
     });
 });
 
-var getTag = controller(function(req,res) {
+var getTag = controller(function(req) {
     return tags.getTag(req.swagger.params.tagName.value);
 });
 
-var deleteTag = controller({success: 204}, function(req,res) {
+var deleteTag = controller({success: 204}, function(req) {
     return tags.destroyTag(req.swagger.params.tagName.value);
 });
 
-var getNodesByTag = controller(function(req, res) {
+var getNodesByTag = controller(function(req) {
     return nodes.getNodesByTag(req.swagger.params.tagName.value);
 });
 
-var postWorkflowById = controller({success: 202}, function(req, res) {
+var postWorkflowById = controller({success: 202}, function(req) {
     return nodes.getNodesByTag(req.swagger.params.tagName.value).map(function(node) {
         return nodes.setNodeWorkflow(node.id,
             req.swagger.params.name.value || req.swagger.params.body.value.name,

--- a/lib/api/2.0/tags.js
+++ b/lib/api/2.0/tags.js
@@ -1,0 +1,54 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var nodes = injector.get('Http.Services.Api.Nodes');
+var tags = injector.get('Http.Services.Api.Tags');
+var _ = injector.get('_');
+
+var getAllTags = controller(function(req, res) {
+    return tags.findTags(req.query);
+});
+
+var createTag = controller({success: 201}, function(req,res) {
+    return tags.findTags({name: req.swagger.params.body.value.name}).then(function(tag) {
+        if(_.isEmpty(tag)) {
+            return tags.createTag(req.swagger.params.body.value).then(function() {
+                return tags.regenerateTags();
+            });
+        }
+    }).then(function() {
+        return req.swagger.params.body.value;
+    });
+});
+
+var getTag = controller(function(req,res) {
+    return tags.getTag(req.swagger.params.tagName.value);
+});
+
+var deleteTag = controller({success: 204}, function(req,res) {
+    return tags.destroyTag(req.swagger.params.tagName.value);
+});
+
+var getNodesByTag = controller(function(req, res) {
+    return nodes.getNodesByTag(req.swagger.params.tagName.value);
+});
+
+var postWorkflowById = controller({success: 202}, function(req, res) {
+    return nodes.getNodesByTag(req.swagger.params.tagName.value).map(function(node) {
+        return nodes.setNodeWorkflow(node.id,
+            req.swagger.params.name.value || req.swagger.params.body.value.name,
+            req.swagger.params.body.value.options);
+    });
+});
+
+module.exports = {
+    getAllTags: getAllTags,
+    createTag: createTag,
+    getTag: getTag,
+    deleteTag: deleteTag,
+    getNodesByTag: getNodesByTag,
+    postWorkflowById: postWorkflowById
+};

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -17,7 +17,8 @@ di.annotate(nodeApiServiceFactory,
         'Constants',
         'Task.Services.OBM',
         'Services.Configuration',
-        'ipmi-obm-service'
+        'ipmi-obm-service',
+        'Assert'
     )
 );
 function nodeApiServiceFactory(
@@ -30,7 +31,8 @@ function nodeApiServiceFactory(
     Constants,
     ObmService,
     configuration,
-    ipmiObmServiceFactory
+    ipmiObmServiceFactory,
+    assert
 ) {
     var logger = Logger.initialize(nodeApiServiceFactory);
 
@@ -458,6 +460,81 @@ function nodeApiServiceFactory(
             } else {
                 return;
             }
+        });
+    };
+
+    /**
+     * Add the tags to the specified node
+     * @param  {String}     id
+     * @param  {Array}      tags
+     * @return {Promise}
+     */
+    NodeApiService.prototype.addTagsById = function(id, tags) {
+        return Promise.resolve().then(function() {
+            assert.ok(Array.isArray(tags), 'tags must be an array');
+            assert.isMongoId(id, 'the id must be a valid mongo id');
+        })
+        .then(function() {
+            return waterline.nodes.needByIdentifier(id);
+        })
+        .then(function () {
+            return waterline.nodes.addTags(id, tags);
+        })
+        .then(function() {
+            return tags;
+        });
+    };
+
+    /**
+     * Remove the tag from the specified node
+     * @param  {String}     id
+     * @param  {String}     tagName
+     * @return {Promise}
+     */
+    NodeApiService.prototype.removeTagsById = function(id, tagName) {
+        return Promise.resolve().then(function() {
+            assert.string(tagName, 'tag must be a string');
+            assert.isMongoId(id, 'the id must be a valid mongo id');
+        })
+        .then(function() {
+            return waterline.nodes.needByIdentifier(id);
+        })
+        .then(function () {
+            return waterline.nodes.remTags(id, tagName);
+        })
+        .then(function() {
+            return tagName;
+        });
+    };
+
+    /**
+     * Get a list of tags applied to the specified id
+     * @param  {String}     id
+     * @return {Promise}    Resolves to an array of tags
+     */
+    NodeApiService.prototype.getTagsById = function(id) {
+        return Promise.resolve().then(function() {
+            assert.isMongoId(id, 'the id must be a valid mongo id');
+        })
+        .then(function() {
+            return waterline.nodes.needByIdentifier(id);
+        })
+        .then(function (node) {
+            return node.tags;
+        });
+    };
+
+    /**
+     * Get a list of nodes with the tagName applied to them
+     * @param  {String}     tagName
+     * @return {Promise}    Resolves to an array of nodes
+     */
+    NodeApiService.prototype.getNodesByTag = function(tagName) {
+        return Promise.resolve().then(function() {
+            assert.string(tagName, 'tag must be a string');
+        })
+        .then(function() {
+            return waterline.nodes.findByTag(tagName);
         });
     };
 

--- a/lib/services/tags-api-service.js
+++ b/lib/services/tags-api-service.js
@@ -1,0 +1,53 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = tagApiServiceFactory;
+
+di.annotate(tagApiServiceFactory, new di.Provide('Http.Services.Api.Tags'));
+di.annotate(tagApiServiceFactory,
+    new di.Inject(
+        'Services.Waterline',
+        'Protocol.TaskGraphRunner',
+        'Promise'
+    )
+);
+
+function tagApiServiceFactory(
+    waterline,
+    taskGraphProtocol,
+    Promise
+) {
+    function TagApiService() {
+    }
+
+    TagApiService.prototype.findTags = function(query) {
+        return waterline.tags.find(query);
+    };
+
+    TagApiService.prototype.getTag = function(name) {
+        return waterline.tags.findOne({name: name});
+    };
+
+    TagApiService.prototype.destroyTag = function(name) {
+        return waterline.tags.destroy({name: name});
+    };
+
+    TagApiService.prototype.createTag = function(options) {
+        return waterline.tags.create(options);
+    };
+
+    TagApiService.prototype.regenerateTags = function(node) {
+        node = node ? {id: node} : {};
+        return Promise.map(waterline.nodes.find(node), function(node) {
+            return taskGraphProtocol.runTaskGraph(
+                'Graph.GenerateTags',
+                { defaults: { nodeId: node.id }}
+            );
+        });
+    };
+
+    return new TagApiService();
+}

--- a/spec/lib/api/1.1/nodes-spec.js
+++ b/spec/lib/api/1.1/nodes-spec.js
@@ -12,6 +12,7 @@ describe('Http.Api.Nodes', function () {
     var Promise;
     var Constants;
     var Errors;
+    var nodesApi;
 
     before('start HTTP server', function () {
         this.timeout(5000);
@@ -38,6 +39,7 @@ describe('Http.Api.Nodes', function () {
             Promise = helper.injector.get('Promise');
             Constants = helper.injector.get('Constants');
             Errors = helper.injector.get('Errors');
+            nodesApi = helper.injector.get('Http.Services.Api.Nodes');
         });
 
     });
@@ -747,4 +749,47 @@ describe('Http.Api.Nodes', function () {
                 .expect(404);
         });
     });
+    describe('Tag support', function() {
+        before(function() {
+            sinon.stub(nodesApi, 'getTagsById').resolves([]);
+            sinon.stub(nodesApi, 'addTagsById').resolves([]);
+            sinon.stub(nodesApi, 'removeTagsById').resolves([]);
+        });
+
+        after(function() {
+            nodesApi.getTagsById.restore();
+            nodesApi.addTagsById.restore();
+            nodesApi.removeTagsById.restore();
+        });
+
+        it('should call getTagsById', function() {
+            return helper.request().get('/api/1.1/nodes/123/tags')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function() {
+                    expect(nodesApi.getTagsById).to.have.been.calledWith('123');
+                });
+        });
+
+        it('should call addTagsById', function() {
+            return helper.request().patch('/api/1.1/nodes/123/tags')
+                .send({ tags: ['tag', 'name']})
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function() {
+                    expect(nodesApi.addTagsById).to.have.been.calledWith('123', ['tag', 'name']);
+                });
+        });
+
+        it('should call removeTagsById', function() {
+            return helper.request().delete('/api/1.1/nodes/123/tags/name')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function() {
+                    expect(nodesApi.removeTagsById).to.have.been.calledWith('123', 'name');
+                });
+        });
+
+    });
+
 });

--- a/spec/lib/api/1.1/tags-spec.js
+++ b/spec/lib/api/1.1/tags-spec.js
@@ -1,0 +1,116 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Tags', function () {
+    var taskGraphProtocol;
+    var waterline;
+    var input = {
+            name: 'tag-name',
+            rules: [
+                {
+                    path: 'dmi.dmi.base_board.manufacturer',
+                    contains: 'Intel'
+                },
+                {
+                    path: 'dmi.memory.total',
+                    equals: '32946864kB'
+                }
+            ]
+        };
+    var node = {
+        id: 1,
+        name: 'test-node'
+    };
+
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        taskGraphProtocol = {
+            runTaskGraph: sinon.stub()
+        };
+        helper.setupInjector([
+            helper.require("/lib/services/sku-pack-service"),
+            dihelper.simpleWrapper(function() { arguments[1](); }, 'rimraf')
+        ]);
+        return helper.startServer([
+            dihelper.simpleWrapper(taskGraphProtocol, 'Protocol.TaskGraphRunner')
+        ]).then(function() {
+            waterline = helper.injector.get('Services.Waterline');
+            sinon.stub(waterline.nodes, "find");
+            sinon.stub(waterline.tags, "find");
+            sinon.stub(waterline.tags, "findOne");
+            sinon.stub(waterline.tags, "destroy");
+        });
+    });
+
+    beforeEach('reset stubs', function () {
+        waterline.nodes.find.reset();
+        waterline.tags.find.reset();
+        waterline.tags.destroy.reset();
+        waterline.tags.findOne.reset();
+        waterline.nodes.find.resolves([node]);
+        waterline.tags.find.resolves([input]);
+        waterline.tags.findOne.resolves(input);
+        waterline.tags.destroy.resolves();
+        taskGraphProtocol.runTaskGraph.reset();
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer().then(function() {
+            waterline.nodes.find.restore();
+            waterline.tags.find.restore();
+            waterline.tags.destroy.restore();
+            waterline.tags.findOne.restore();
+        });
+    });
+
+    it('should return an empty array from GET /tags', function () {
+        waterline.tags.find.resolves([]);
+        return helper.request().get('/api/1.1/tags')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200, []);
+    });
+
+
+    it('should return the correct properties', function() {
+        waterline.tags.find.resolves([]);
+        return helper.request().post('/api/1.1/tags')
+        .send(input)
+        .expect('Content-Type', /^application\/json/)
+        .expect(201)
+        .then(function (req) {
+            var tag = req.body;
+            expect(tag).to.have.property('name').that.equals(input.name);
+            expect(tag).to.have.property('rules').that.deep.equals(input.rules);
+            expect(taskGraphProtocol.runTaskGraph).to.have.been.calledOnce;
+            expect(taskGraphProtocol.runTaskGraph).to.have.been.calledWith('Graph.GenerateTags');
+            expect(taskGraphProtocol.runTaskGraph.firstCall.args[1])
+                .to.have.deep.property('defaults.nodeId', node.id);
+        });
+    });
+
+    it('should contain the tag in GET /tags', function () {
+        return helper.request().get('/api/1.1/tags')
+        .expect('Content-Type', /^application\/json/)
+        .expect(200, [input]);
+    });
+
+    it('should return a tag from GET /tags/:id', function () {
+        return helper.request().get('/api/1.1/tags/tag-name')
+        .expect('Content-Type', /^application\/json/)
+        .expect(200, input)
+        .then(function() {
+            expect(waterline.tags.findOne).to.have.been.called;
+        });
+    });
+
+    it('should destroy a tag', function() {
+        return helper.request().delete('/api/1.1/tags/tag-name')
+        .expect(204)
+        .then(function() {
+            expect(waterline.tags.destroy).to.have.been.called;
+        });
+    });
+});
+

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -12,6 +12,7 @@ describe('Http.Api.Nodes', function () {
     var Promise;
     var Constants;
     var Errors;
+    var nodesApi;
 
     before('start HTTP server', function () {
         this.timeout(5000);
@@ -38,6 +39,7 @@ describe('Http.Api.Nodes', function () {
             Promise = helper.injector.get('Promise');
             Constants = helper.injector.get('Constants');
             Errors = helper.injector.get('Errors');
+            nodesApi = helper.injector.get('Http.Services.Api.Nodes');
         });
 
     });
@@ -677,5 +679,48 @@ describe('Http.Api.Nodes', function () {
             return helper.request().delete('/api/2.0/nodes/123/workflows/active')
                 .expect(404);
         });
+    });
+
+    describe('Tag support', function() {
+        before(function() {
+            sinon.stub(nodesApi, 'getTagsById').resolves([]);
+            sinon.stub(nodesApi, 'addTagsById').resolves([]);
+            sinon.stub(nodesApi, 'removeTagsById').resolves([]);
+        });
+
+        after(function() {
+            nodesApi.getTagsById.restore();
+            nodesApi.addTagsById.restore();
+            nodesApi.removeTagsById.restore();
+        });
+
+        it('should call getTagsById', function() {
+            return helper.request().get('/api/2.0/nodes/123/tags')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function() {
+                    expect(nodesApi.getTagsById).to.have.been.calledWith('123');
+                });
+        });
+
+        it('should call addTagsById', function() {
+            return helper.request().patch('/api/2.0/nodes/123/tags')
+                .send({ tags: ['tag', 'name']})
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function() {
+                    expect(nodesApi.addTagsById).to.have.been.calledWith('123', ['tag', 'name']);
+                });
+        });
+
+        it('should call removeTagsById', function() {
+            return helper.request().delete('/api/2.0/nodes/123/tags/name')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function() {
+                    expect(nodesApi.removeTagsById).to.have.been.calledWith('123', 'name');
+                });
+        });
+
     });
 });

--- a/spec/lib/api/2.0/tags-spec.js
+++ b/spec/lib/api/2.0/tags-spec.js
@@ -1,0 +1,144 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Tags', function () {
+    var configuration;
+    var lookupService;
+    var taskGraphProtocol;
+    var Promise;
+    var Errors;
+    var nodesApi;
+    var tagsApi;
+
+    before('start HTTP server', function () {
+        this.timeout(10000);
+        return helper.startServer([
+        ]).then(function () {
+            configuration = helper.injector.get('Services.Configuration');
+            lookupService = helper.injector.get('Services.Lookup');
+            lookupService.ipAddressToMacAddress = sinon.stub().resolves();
+            lookupService.ipAddressToNodeId = sinon.stub().resolves();
+            sinon.stub(configuration);
+
+            taskGraphProtocol = helper.injector.get('Protocol.TaskGraphRunner');
+            sinon.stub(taskGraphProtocol);
+
+            Promise = helper.injector.get('Promise');
+            Errors = helper.injector.get('Errors');
+            nodesApi = helper.injector.get('Http.Services.Api.Nodes');
+            tagsApi = helper.injector.get('Http.Services.Api.Tags');
+        });
+
+    });
+
+    beforeEach('reset stubs', function () {
+        function resetStubs(obj) {
+            _(obj).methods().forEach(function (method) {
+                if (obj[method] && obj[method].reset) {
+                  obj[method].reset();
+                }
+            }).value();
+        }
+
+        resetStubs(configuration);
+        resetStubs(lookupService);
+        resetStubs(taskGraphProtocol);
+
+        lookupService = helper.injector.get('Services.Lookup');
+        lookupService.ipAddressToMacAddress = sinon.stub().resolves();
+        lookupService.ipAddressToNodeId = sinon.stub().resolves();
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    var input = {
+        name: 'tag-name',
+        rules: [
+            {
+                path: 'dmi.dmi.base_board.manufacturer',
+                contains: 'Intel'
+            },
+            {
+                path: 'dmi.memory.total',
+                equals: '32946864kB'
+            }
+        ]
+    };
+
+    describe('2.0 Tags', function() {
+        before(function() {
+            sinon.stub(tagsApi, 'findTags');
+            sinon.stub(tagsApi, 'getTag');
+            sinon.stub(tagsApi, 'destroyTag');
+            sinon.stub(tagsApi, 'createTag');
+            sinon.stub(tagsApi, 'regenerateTags');
+        });
+
+        beforeEach(function() {
+            tagsApi.findTags.reset().resolves([input]);
+            tagsApi.getTag.reset().resolves(input);
+            tagsApi.destroyTag.reset().resolves([]);
+            tagsApi.createTag.reset().resolves([]);
+            tagsApi.regenerateTags.reset().resolves();
+        });
+
+        after(function() {
+            tagsApi.findTags.restore();
+            tagsApi.getTag.restore();
+            tagsApi.destroyTag.restore();
+            tagsApi.createTag.restore();
+            tagsApi.regenerateTags.restore();
+        });
+
+        it('should create a tag', function() {
+            tagsApi.findTags.resolves([]);
+            return helper.request().post('/api/2.0/tags')
+                .send(input)
+                .expect('Content-Type', /^application\/json/)
+                .expect(201)
+                .then(function (req) {
+                    var tag = req.body;
+                    expect(tag).to.have.property('name').that.equals(input.name);
+                    expect(tag).to.have.property('rules').that.deep.equals(input.rules);
+                    expect(tagsApi.createTag).to.have.been.calledOnce;
+                    expect(tagsApi.regenerateTags).to.have.been.calledOnce;
+                });
+        });
+
+        it('should skip creating a tag that already exists', function() {
+            return helper.request().post('/api/2.0/tags')
+                .send(input)
+                .expect('Content-Type', /^application\/json/)
+                .expect(201)
+                .then(function (req) {
+                    var tag = req.body;
+                    expect(tag).to.have.property('name').that.equals(input.name);
+                    expect(tag).to.have.property('rules').that.deep.equals(input.rules);
+                    expect(tagsApi.createTag).to.have.not.been.called;
+                    expect(tagsApi.regenerateTags).to.have.not.been.called;
+                });
+        });
+
+        it('should get tags', function() {
+            return helper.request().get('/api/2.0/tags')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, [input]);
+        });
+
+        it('should return a tag from GET /tags/:id', function () {
+            return helper.request().get('/api/2.0/tags/tag-name')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, input);
+        });
+
+        it('should destroy a tag', function() {
+            return helper.request().delete('/api/2.0/tags/tag-name')
+                .expect(204);
+        });
+
+    });
+});

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -736,4 +736,88 @@ describe("Http.Services.Api.Nodes", function () {
 
     });
 
+    describe('Tagging', function() {
+        var node = {
+            id: '1234abcd1234abcd1234abce'
+        };
+
+        before(function() {
+            waterline.nodes.addTags = sinon.stub().resolves();
+            waterline.nodes.remTags = sinon.stub().resolves();
+            waterline.nodes.findByTag = sinon.stub().resolves();
+        });
+
+        beforeEach(function() {
+            waterline.nodes.addTags.reset();
+            waterline.nodes.remTags.reset();
+            waterline.nodes.findByTag.reset();
+        });
+
+        after(function() {
+            delete waterline.nodes.addTags;
+            delete waterline.nodes.remTags;
+            delete waterline.nodes.findByTag;
+        });
+
+        it('should call waterline to add a tag array', function() {
+            var tags = ['tag'];
+            needByIdentifier.withArgs(node.id).resolves(node);
+            return nodeApiService.addTagsById(node.id, tags)
+                .then(function() {
+                    expect(waterline.nodes.addTags).to.have.been.calledWith(node.id, tags);
+                    expect(needByIdentifier).to.have.been.calledWith(node.id);
+                });
+        });
+
+        it('should reject an invalid tag array', function() {
+            return nodeApiService.addTagsById(node.id, 'tag')
+                .catch(function(e) {
+                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(waterline.nodes.addTags).to.not.be.called;
+                    expect(needByIdentifier).to.not.be.called;
+                });
+        });
+
+        it('should call waterline to remove a tag', function() {
+            needByIdentifier.withArgs(node.id).resolves(node);
+            return nodeApiService.removeTagsById(node.id, 'tag')
+                .then(function() {
+                    expect(waterline.nodes.remTags).to.have.been.calledWith(node.id, 'tag');
+                    expect(needByIdentifier).to.have.been.calledWith(node.id);
+                });
+        });
+
+        it('should reject an invalid tag', function() {
+            return nodeApiService.removeTagsById(node.id, 1)
+                .catch(function(e) {
+                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(waterline.nodes.remTags).to.not.be.called;
+                    expect(needByIdentifier).to.not.be.called;
+                });
+        });
+
+        it('should call waterline to get tags on a node', function() {
+            needByIdentifier.withArgs(node.id).resolves(node);
+            return nodeApiService.getTagsById(node.id)
+                .then(function() {
+                    expect(needByIdentifier).to.have.been.calledWith(node.id);
+                });
+        });
+
+        it('should call waterline to get nodes with the tag', function() {
+            return nodeApiService.getNodesByTag('tag')
+                .then(function() {
+                    expect(waterline.nodes.findByTag).to.have.been.calledWith('tag');
+                });
+        });
+
+        it('should reject an invalid tag', function() {
+            return nodeApiService.getNodesByTag(1)
+                .catch(function(e) {
+                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(waterline.nodes.findByTag).to.not.be.called;
+                    expect(needByIdentifier).to.not.be.called;
+                });
+        });
+    });
 });

--- a/spec/lib/services/tags-api-service-spec.js
+++ b/spec/lib/services/tags-api-service-spec.js
@@ -1,0 +1,8 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+"use strict";
+
+describe("Http.Services.Api.Tags", function () {
+
+});

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -1,7 +1,7 @@
 swagger: "2.0"
 info:
   version: "0.0.1"
-  title: Hello World App
+  title: RackHD 2.0
 # during dev, should point to your local machine
 host: localhost:10010
 # basePath prefixes all resource paths
@@ -1402,6 +1402,109 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /nodes/{identifier}/tags:
+    x-swagger-router-controller: nodes
+    get:
+      operationId: nodesGetTagsById
+      summary: |
+        List of all tags on the node or an empty object if there are none
+      description: |
+        List of all tags on the node or an empty object if there are none
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Mac addresses or unique aliases to identify the node by
+          required: true
+          type: string
+      tags:
+        - nodes
+        - get
+      responses:
+        200:
+          description: array of all
+          schema:
+            type: array
+            items:
+              type: object
+        404:
+          description: The node with the identifier was not found.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    patch:
+      operationId: nodesPatchTagById
+      summary: |
+        Patch tags onto specified node
+      description: |
+        Patch tags onto specified node
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Mac addresses or unique aliases to identify the node by
+          required: true
+          type: string
+        - name: body
+          in: body
+          description: |
+            object patches to apply.
+          required: true
+          schema:
+            type: object
+      tags:
+        - nodes
+        - patch
+      responses:
+        200:
+          description: patch succeeded
+          schema:
+            type: object
+        404:
+          description: Not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /nodes/{identifier}/tags/{tagName}:
+    x-swagger-router-controller: nodes
+    delete:
+      operationId: nodesDelTagById
+      summary: |
+        Delete a tag from the specified node.
+      description: |
+        Delete a tag from the specified node.
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Mac addresses or unique aliases to identify the node by
+          required: true
+          type: string
+        - name: tagName
+          in: path
+          description: The name of the tag
+          required: true
+          type: string
+      tags:
+        - nodes
+        - delete
+      responses:
+        204:
+          description: Delete successful
+        404:
+          description: The node with the identifier was not found.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /nodes:
     x-swagger-router-controller: nodes
     get:
@@ -1458,6 +1561,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  
   /lookups:
     x-swagger-router-controller: unimplemented
     get:
@@ -1846,6 +1950,194 @@ paths:
               $ref: '#/definitions/lease'
         default:
           description: NotFound error
+  /tags:
+    x-swagger-router-controller: tags
+    get:
+      operationId: getAllTags
+      summary: Retrieve information about all tags
+      description: |
+        Retrieve information about all tags
+      tags: [ "/monorail/v2.0" ]
+      responses:
+        200:
+          description: |
+            An array of all tags
+          schema:
+            type: array
+            items: 
+              type: object
+        404:
+          description: |
+            The tag name identifier was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      operationId: createTag
+      summary: Create a new tag
+      description: |
+        Create a new tag
+      parameters:
+        - name: body
+          in: body
+          description: tag creation options
+          required: true
+          schema:
+            type: object
+      tags: [ "/monorail/v2.0" ]
+      responses:
+        200:
+          description: |
+            The created tag
+          schema:
+            type: object
+        500:
+          description: |
+            The tag could not be created
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /tags/{tagName}:
+    x-swagger-router-controller: tags
+    get:
+      operationId: getTag
+      summary: Retrieve information about the tag
+      description: |
+        Retrieve information about the tag
+      parameters:
+        - name: tagName
+          in: path
+          description: The tag identifier
+          required: true
+          type: string
+      tags: [ "/monorail/v2.0" ]
+      responses:
+        200:
+          description: |
+            The information about the specified tag
+          schema:
+            type: object
+        404:
+          description: |
+            The tag name identifier was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      operationId: deleteTag
+      summary: Delete the specified tag
+      description: |
+        Delete the specified tag
+      parameters:
+        - name: tagName
+          in: path
+          description: The tag identifier
+          required: true
+          type: string
+      tags: [ "/monorail/v2.0" ]
+      responses:
+        204:
+          description: |
+            No content
+          schema:
+            type: object
+        404:
+          description: |
+            The tag name identifier was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /tags/{tagName}/nodes:
+    x-swagger-router-controller: tags
+    get:
+      operationId: getNodesByTag
+      summary: Retrieve nodes with the specified tag
+      description: |
+        Retrieve nodes with the specified tag
+      parameters:
+        - name: tagName
+          in: path
+          description: The tag identifier
+          required: true
+          type: string
+      tags: [ "/monorail/v2.0" ]
+      responses:
+        200:
+          description: |
+            The list of nodes with the specified tag
+          schema:
+            type: array
+            items:
+              type: object
+        404:
+          description: |
+            The node with the identifier was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /tags/{tagName}/nodes/workflows:
+    x-swagger-router-controller: tags
+    post:
+      operationId: postWorkflowById
+      summary: |
+        create workflow for nodes with the specified tag
+      description: |
+        create workflow for nodes with the specified tag
+      parameters:
+        - name: tagName
+          in: path
+          description: The tag identifier
+          required: true
+          type: string
+        - name: body
+          in: body
+          description: Workflow options
+          required: false
+          schema:
+            type: object
+        - name: name
+          in: query
+          description: Workflow name
+          required: false
+          type: string
+# The OpenAPI Specification 2.0 does not allow type:object for a parameter in a query.  We will use the express req.query to decode
+#        - name: options
+#          in: query
+#          description: options
+#          required: false
+#          type: object
+      tags: [ "/monorail/v2.0" ]
+      responses:
+        202:
+          description: |
+            the workflow has been accepted
+          schema:
+            type: object
+        404:
+          description: |
+            The node with the identifier was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
 definitions:
   ErrorResponse:


### PR DESCRIPTION
Add 'tags' to nodes to identify groups of nodes by arbitrary tag names
Add 1.1 and 2.0 paths for new /nodes and /tags routes.

This is on @zyoung51's behalf,  resolves merge conflicts from https://github.com/RackHD/on-http/pull/135,  which can be closed.
@RackHD/corecommitters @uppalk1 @tannoa2 @keedya @zyoung51 