### PR TITLE
Don't return a 404 when there is no active workflow for a node

### DIFF
--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -391,8 +391,6 @@ function nodesRouterFactory (
      * @apiParam {String} identifier node identifier
      * @apiSuccess {json} workflow  the active workflow for that node.
      * @apiError NotFound1 The node with the <code>identifier</code> was not found.
-     * @apiError NotFound2 The node with the <code>identifier</code> does not have an
-     *                     active workflow.
      * @apiErrorExample Error-Response:
      *     HTTP/1.1 404 Not Found
      *     {

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -431,13 +431,6 @@ function nodeApiServiceFactory(
         return waterline.nodes.needByIdentifier(id)
         .then(function (node) {
             return workflowApiService.findActiveGraphForTarget(node.id);
-        })
-        .then(function(graph) {
-            if (_.isEmpty(graph)) {
-                throw new Errors.NotFoundError('Not Found');
-            } else {
-                return graph;
-            }
         });
     };
 

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -268,8 +268,7 @@ describe("Http.Services.Api.Nodes", function () {
         it('should throw a NotFoundError if the node has no active graph', function () {
             waterline.nodes.needByIdentifier.resolves({ id: 'testid' });
             findActiveGraphForTarget.resolves(null);
-            return expect(nodeApiService.getActiveNodeWorkflowById('test'))
-                    .to.be.rejectedWith(Errors.NotFoundError);
+            return expect(nodeApiService.getActiveNodeWorkflowById('test')).to.become(null);
         });
     });
 


### PR DESCRIPTION
At the request of @stuart-stanley. A 404 indicates an illegal request, most likely that the node ID doesn't exist at all, as compared to a legitimate request that just returns empty (e.g. are there active workflows? no).

@RackHD/corecommitters 