### PR TITLE
Add dynamic and static IP/MAC lookups

### DIFF
--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -27,6 +27,11 @@ function profilesRouterFactory (
     /**
      * @api {get} /api/1.1/profiles GET /
      * @apiVersion 1.1.0
+     * @apiParam {query} macs List of valid MAC addresses to lookup
+     * @apiParam {query} mac When macs parameter is not passed, 
+     *                       passed with IP adds MAC address to lookup
+     * @apiParam {query} ip When macs parameters is not passed, 
+     *                      passed with MAC adds IP address to lookup
      * @apiDescription used internally by the system -- will NOT get a list of all profiles,
      *                 look at api/current/profiles/library
      * @apiName profiles-get

--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -31,9 +31,13 @@ function profilesRouterFactory (
      */
 
     router.get('/profiles', function (req, res) {
+        if (req.query.mac && req.query.ip) {
+            profileApiService.setNode(req.query);
+            req.query.macs = req.query.mac
+        }
+        
         if (req.query.macs) {
             var macAddresses = profileApiService.getMacs(req.query.macs);
-
             return profileApiService.getNode(macAddresses)
             .then(function (node) {
                 if (node.newRecord) {

--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -11,15 +11,18 @@ di.annotate(profilesRouterFactory, new di.Provide('Http.Api.Internal.Profiles'))
 di.annotate(profilesRouterFactory,
     new di.Inject(
         'Http.Services.Api.Profiles',
-        'common-api-presenter'
+        'common-api-presenter',
+        'Logger'
     )
 );
 
 function profilesRouterFactory (
     profileApiService,
-    presenter
+    presenter,
+    Logger
 ) {
     var router = express.Router();
+    var logger = Logger.initialize(profilesRouterFactory);
 
     /**
      * @api {get} /api/1.1/profiles GET /
@@ -32,10 +35,18 @@ function profilesRouterFactory (
 
     router.get('/profiles', function (req, res) {
         if (req.query.mac && req.query.ip) {
-            profileApiService.setNode(req.query);
-            req.query.macs = req.query.mac
+            profileApiService.setLookup(req.query)
+            .catch(function(err) {
+                logger.error('Error Setting Lookup', {
+                    mac: req.params.mac,
+                    ip: req.params.ip,
+                    error: err
+                });
+                res.status(500).json(err);
+            });
+            req.query.macs = req.query.mac;
         }
-        
+
         if (req.query.macs) {
             var macAddresses = profileApiService.getMacs(req.query.macs);
             return profileApiService.getNode(macAddresses)

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -63,7 +63,7 @@ function profileApiServiceFactory(
         return _.flattenDeep([macs]);
     };
 
-    ProfileApiService.prototype.setNode = function(query) {
+    ProfileApiService.prototype.setLookup = function(query) {
         return waterline.nodes.findByIdentifier(this.getMacs(query.mac))
         .then(function (node) {
             if (_.isUndefined(node)) {

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -14,6 +14,7 @@ di.annotate(profileApiServiceFactory,
         'Protocol.Events',
         'Services.Waterline',
         'Services.Configuration',
+        'Services.Lookup',
         'Logger',
         'Errors',
         '_'
@@ -26,6 +27,7 @@ function profileApiServiceFactory(
     eventsProtocol,
     waterline,
     configuration,
+    lookupService,
     Logger,
     Errors,
     _
@@ -59,6 +61,18 @@ function profileApiServiceFactory(
 
     ProfileApiService.prototype.getMacs = function(macs) {
         return _.flattenDeep([macs]);
+    };
+
+    ProfileApiService.prototype.setNode = function(query) {
+        return waterline.nodes.findByIdentifier(this.getMacs(query.mac))
+        .then(function (node) {
+            if (_.isUndefined(node)) {
+                return lookupService.setIpAddress(
+                    query.ip,
+                    query.mac
+                );
+            }
+        });
     };
 
     ProfileApiService.prototype.getNode = function(macAddresses) {

--- a/spec/lib/api/1.1/profiles-spec.js
+++ b/spec/lib/api/1.1/profiles-spec.js
@@ -40,7 +40,7 @@ describe('Http.Api.Profiles', function () {
         sinon.stub(profileApiService, 'getNode').resolves({});
         sinon.stub(profileApiService, 'createNodeAndRunDiscovery').resolves({});
         sinon.stub(profileApiService, 'runDiscovery').resolves({});
-        sinon.stub(profileApiService, 'setNode').resolves();
+        sinon.stub(profileApiService, 'setLookup').resolves();
     });
 
     afterEach('teardown mocks', function () {
@@ -122,7 +122,7 @@ describe('Http.Api.Profiles', function () {
             return helper.request().get('/api/1.1/profiles?mac=00:01:02:03:04:05&&ip=1.1.1.1')
                 .expect(200)
                 .expect(function() {
-                    expect(profileApiService.setNode).to.have.been.called;
+                    expect(profileApiService.setLookup).to.have.been.calledOnce;
                 });
         });
         

--- a/spec/lib/api/1.1/profiles-spec.js
+++ b/spec/lib/api/1.1/profiles-spec.js
@@ -126,6 +126,11 @@ describe('Http.Api.Profiles', function () {
                 });
         });
         
+        it("should send 500 set mac and ip fails", function() {
+            profileApiService.setLookup.rejects();
+            return helper.request().get('/api/1.1/profiles?mac=00:01:02:03:04:05&&ip=1.1.1.1')
+                .expect(500);
+        });
         
         it("should send down redirect.ipxe if 'macs' are not in req.query", function() {
             profileApiService.getNode.restore();

--- a/spec/lib/api/1.1/profiles-spec.js
+++ b/spec/lib/api/1.1/profiles-spec.js
@@ -40,6 +40,7 @@ describe('Http.Api.Profiles', function () {
         sinon.stub(profileApiService, 'getNode').resolves({});
         sinon.stub(profileApiService, 'createNodeAndRunDiscovery').resolves({});
         sinon.stub(profileApiService, 'runDiscovery').resolves({});
+        sinon.stub(profileApiService, 'setNode').resolves();
     });
 
     afterEach('teardown mocks', function () {
@@ -117,6 +118,15 @@ describe('Http.Api.Profiles', function () {
     });
 
     describe("GET /profiles", function() {
+        it("should receive both mac and ip query", function() {
+            return helper.request().get('/api/1.1/profiles?mac=00:01:02:03:04:05&&ip=1.1.1.1')
+                .expect(200)
+                .expect(function() {
+                    expect(profileApiService.setNode).to.have.been.called;
+                });
+        });
+        
+        
         it("should send down redirect.ipxe if 'macs' are not in req.query", function() {
             profileApiService.getNode.restore();
             return helper.request().get('/api/1.1/profiles')

--- a/spec/lib/api/login/login-spec.js
+++ b/spec/lib/api/login/login-spec.js
@@ -18,7 +18,7 @@ describe('Http.Api.Login', function () {
 
     var endpoint = {
         "address": "0.0.0.0",
-        "port": 8443,
+        "port": 9443,
         "httpsEnabled": true,
         "httpsCert": "data/dev-cert.pem",
         "httpsKey": "data/dev-key.pem",
@@ -85,7 +85,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should return a token with correct credential in request body', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(SUCCESS_STATUS)
@@ -95,7 +95,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with wrong username in request body', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "balabalabala", password: "admin123"})
                 .expect(UNAUTHORIZED_STATUS)
@@ -106,7 +106,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with wrong password in request body', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "balabalabala"})
                 .expect(UNAUTHORIZED_STATUS)
@@ -117,7 +117,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with empty username in request body', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "", password: "admin123"})
                 .expect(BAD_REQUEST_STATUS)
@@ -128,7 +128,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with empty password in request body', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: ""})
                 .expect(BAD_REQUEST_STATUS)
@@ -139,7 +139,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with no username key in request body', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({password: "admin123"})
                 .expect(BAD_REQUEST_STATUS)
@@ -150,7 +150,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with no password key in request body', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin"})
                 .expect(BAD_REQUEST_STATUS)
@@ -164,7 +164,7 @@ describe('Http.Api.Login', function () {
         // with credential in the header. Following test will fail if auth header
         // is supported in the future, thus people will get alerted.
         it('should fail with credential in request header', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .set('username', 'admin')
                 .set('password', 'admin123')
@@ -176,7 +176,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail no credential at all - https', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .expect(BAD_REQUEST_STATUS)
                 .expect(function(res) {
@@ -237,7 +237,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with auth disabled', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(NOT_FOUND_STATUS);
@@ -260,7 +260,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with auth', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(ERROR_STATUS)
@@ -285,7 +285,7 @@ describe('Http.Api.Login', function () {
         });
 
         it('should fail with auth', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(UNAUTHORIZED_STATUS)

--- a/spec/lib/services/auth-service-spec.js
+++ b/spec/lib/services/auth-service-spec.js
@@ -17,7 +17,7 @@ describe('Auth.Service', function () {
     var token = '';
     var endpoint = {
         "address": "0.0.0.0",
-        "port": 8443,
+        "port": 9443,
         "httpsEnabled": true,
         "httpsCert": "data/dev-cert.pem",
         "httpsKey": "data/dev-key.pem",
@@ -92,7 +92,7 @@ describe('Auth.Service', function () {
         });
 
         it('should return a token from /login', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(SUCCESS_STATUS)
@@ -103,13 +103,13 @@ describe('Auth.Service', function () {
         });
 
         it('should able to access with correct token in query string', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config?auth_token=' + token)
                 .expect(SUCCESS_STATUS);
         });
 
         it('should fail with wrong token in query string', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config?auth_token=' + token + 'balabalabala')
                 .expect(UNAUTHORIZED_STATUS)
                 .expect(function (res) {
@@ -119,7 +119,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with empty token in query string', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config?auth_token=')
                 .expect(UNAUTHORIZED_STATUS)
                 .expect(function (res) {
@@ -129,7 +129,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with wrong token key in query string', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config?auth_tokennnnnnnn=')
                 .expect(UNAUTHORIZED_STATUS)
                 .expect(function (res) {
@@ -139,7 +139,7 @@ describe('Auth.Service', function () {
         });
 
         it('should able to access with correct token in query header', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .set("authorization", 'JWT ' + token)
                 .send()
@@ -147,7 +147,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with wrong token in query header', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .set("authorization", 'JWT ' + token + 'balabalabala')
                 .send()
@@ -159,7 +159,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with empty token in query header', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .set("authorization", '')
                 .send()
@@ -171,7 +171,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with wrong token key in query header', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .set("authorization_balabalabala", '')
                 .send()
@@ -183,14 +183,14 @@ describe('Auth.Service', function () {
         });
 
         it('should able to access with correct token in query body', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .send({auth_token: token}) /* jshint ignore: line */
                 .expect(SUCCESS_STATUS);
         });
 
         it('should fail with wrong token in query body', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .send({auth_token: token + 'balabalabala'}) /* jshint ignore: line */
                 .expect(UNAUTHORIZED_STATUS)
@@ -201,7 +201,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with empty token in query body', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .send({auth_token: ''}) /* jshint ignore: line */
                 .expect(UNAUTHORIZED_STATUS)
@@ -212,7 +212,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with wrong token key in query body', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .send({auth_tokennnnnnnnn: token}) /* jshint ignore: line */
                 .expect(UNAUTHORIZED_STATUS)
@@ -223,7 +223,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with no token at all', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config')
                 .expect(UNAUTHORIZED_STATUS)
                 .expect(function (res) {
@@ -247,7 +247,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail with auth', function() {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config?auth_token=' + token)
                 .expect(ERROR_STATUS)
                 .expect(function(res) {
@@ -332,7 +332,7 @@ describe('Auth.Service', function () {
         });
 
         it('should return a token from /login', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(SUCCESS_STATUS)
@@ -348,7 +348,7 @@ describe('Auth.Service', function () {
             var Promise = helper.injector.get('Promise');
             return Promise.delay(1000)
                 .then(function(){
-                    return helper.request('https://localhost:8443')
+                    return helper.request('https://localhost:9443')
                         .get('/api/1.1/config?auth_token=' + token)
                         .expect(UNAUTHORIZED_STATUS)
                         .expect(function (res) {
@@ -380,7 +380,7 @@ describe('Auth.Service', function () {
         });
 
         it('should return a token from /login', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(SUCCESS_STATUS)
@@ -391,7 +391,7 @@ describe('Auth.Service', function () {
         });
 
         it('should able to access with correct token in query string', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config?auth_token=' + token)
                 .expect(SUCCESS_STATUS);
         });
@@ -401,7 +401,7 @@ describe('Auth.Service', function () {
             var Promise = helper.injector.get('Promise');
             return Promise.delay(1000)
                 .then(function(){
-                    return helper.request('https://localhost:8443')
+                    return helper.request('https://localhost:9443')
                         .get('/api/1.1/config?auth_token=' + token)
                         .expect(SUCCESS_STATUS);
                 });
@@ -425,7 +425,7 @@ describe('Auth.Service', function () {
         });
 
         it('should fail accessing /login with internal error', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(ERROR_STATUS)
@@ -459,7 +459,7 @@ describe('Auth.Service', function () {
         });
 
         it('should return a token from /login', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .post('/login')
                 .send({username: "admin", password: "admin123"})
                 .expect(SUCCESS_STATUS)
@@ -472,7 +472,7 @@ describe('Auth.Service', function () {
         it('Should get token expire error', function() {
             this.timeout(5000);
 
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
                 .get('/api/1.1/config?auth_token=' + token)
                 .expect(ERROR_STATUS)
                 .expect(function (res) {

--- a/spec/lib/services/http-service-spec.js
+++ b/spec/lib/services/http-service-spec.js
@@ -75,7 +75,7 @@ describe('Http.Server', function () {
             // can't use port 443 because it requires setuid root
             singleService = new HttpService(
                 {
-                    'port': 8443,
+                    'port': 9443,
                     'httpsEnabled': true,
                     'httpsCert': 'data/dev-cert.pem',
                     'httpsKey': 'data/dev-key.pem'
@@ -86,7 +86,7 @@ describe('Http.Server', function () {
         });
 
         it('should respond to requests', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
             .get('/test')
             .expect(200)
             .expect('Hello World!');
@@ -128,7 +128,7 @@ describe('Http.Server', function () {
             var endpoints = [
                 {
                     'address': '0.0.0.0',
-                    'port': 8443,
+                    'port': 9443,
                     'httpsEnabled': true,
                     'httpsCert': 'data/dev-cert.pem',
                     'httpsKey': 'data/dev-key.pem',
@@ -136,7 +136,7 @@ describe('Http.Server', function () {
                 },
                 {
                     'address': '0.0.0.0',
-                    'port': 9080,
+                    'port': 9880,
                     'httpsEnabled': false,
                 },
                 {
@@ -158,14 +158,14 @@ describe('Http.Server', function () {
         });
 
         it('should respond to request to endpoint 1', function () {
-            return helper.request('https://localhost:8443')
+            return helper.request('https://localhost:9443')
             .get('/test/0')
             .expect(200)
             .expect('This is from endpoint path /test/0');
         });
 
         it('should respond to request to endpoint 2', function () {
-            return helper.request('http://localhost:9080')
+            return helper.request('http://localhost:9880')
             .get('/test/1')
             .expect(200)
             .expect('This is from endpoint path /test/1');

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -9,6 +9,7 @@ describe("Http.Services.Api.Profiles", function () {
     var workflowApiService;
     var eventsProtocol;
     var waterline;
+    var lookupService;
 
     before("Http.Services.Api.Profiles before", function() {
         helper.setupInjector([
@@ -26,6 +27,7 @@ describe("Http.Services.Api.Profiles", function () {
         taskProtocol = helper.injector.get("Protocol.Task");
         workflowApiService = helper.injector.get("Http.Services.Api.Workflows");
         eventsProtocol = helper.injector.get("Protocol.Events");
+        lookupService = helper.injector.get("Services.Lookup");
     });
 
     beforeEach("Http.Services.Api.Profiles beforeEach", function() {
@@ -45,6 +47,35 @@ describe("Http.Services.Api.Profiles", function () {
         return profileApiService.waitForDiscoveryStart("testnodeid")
         .then(function() {
             expect(taskProtocol.requestProperties).to.have.been.calledThrice;
+        });
+    });
+    
+    describe("setNode", function() {
+        var node;
+        var query = {
+            'ip':'ip',
+            'mac':'mac'
+        };
+        
+        it("setNode should add IP lookup entry for new node", function() {
+            this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
+            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
+            return profileApiService.setNode(query)
+            .then(function() {
+                expect(lookupService.setIpAddress).to.be.called;
+            });
+        });
+        
+        it("setNode not add IP lookup entry for existing node", function() {
+            node = {
+                discovered: true
+            };
+            this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
+            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
+            return profileApiService.setNode(query)
+            .then(function() {
+                expect(lookupService.setIpAddress).to.not.be.called;
+            });
         });
     });
 

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -50,29 +50,29 @@ describe("Http.Services.Api.Profiles", function () {
         });
     });
     
-    describe("setNode", function() {
+    describe("setLookup", function() {
         var node;
         var query = {
             'ip':'ip',
             'mac':'mac'
         };
         
-        it("setNode should add IP lookup entry for new node", function() {
+        it("setLookup should add IP lookup entry for new node", function() {
             this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
             this.sandbox.stub(lookupService, 'setIpAddress').resolves();
-            return profileApiService.setNode(query)
+            return profileApiService.setLookup(query)
             .then(function() {
-                expect(lookupService.setIpAddress).to.be.called;
+                expect(lookupService.setIpAddress).to.be.calledOnce;
             });
         });
         
-        it("setNode not add IP lookup entry for existing node", function() {
+        it("setLookup not add IP lookup entry for existing node", function() {
             node = {
                 discovered: true
             };
             this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
             this.sandbox.stub(lookupService, 'setIpAddress').resolves();
-            return profileApiService.setNode(query)
+            return profileApiService.setLookup(query)
             .then(function() {
                 expect(lookupService.setIpAddress).to.not.be.called;
             });


### PR DESCRIPTION
- Option to remove DHCP-Proxy dependency (example dhcpd.conf PR https://github.com/RackHD/RackHD/pull/114) and decouple DHCP service/least file tailing.
- Creates lookup entry based on DHCP bootfile option request query parameters
- Fixed unit-tests to use unique http/https ports that are causing random ADDRINUSE errors

@RackHD/corecommitters @geoff-reid @zyoung51 @uppalk1 @tannoa2 @anhou 