### PR TITLE
update travis to build node 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ sudo: true
 node_js:
   - "0.10"
   - "4"
+  - "5"
 
 matrix:
   allow_failures:
-   - node_js: "4"
+   - node_js: "5"
 
 addons:
   apt:


### PR DESCRIPTION
Travis will allow Node 5 to failures. Node .10 and 4 have to pass.