### PR TITLE
Improve the http proxy performance for big file transimission

### DIFF
--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -342,19 +342,19 @@ function httpServiceFactory(
                 serverAddr = httpProxy.server;
 
             //localPath & remotePath should always starts with /
-            if (!_.startsWith(localPath, sep)) {
+            if (!localPath.startsWith(sep)) {
                 localPath = sep + localPath;
             }
-            if (!_.startsWith(remotePath, sep)) {
+            if (!remotePath.startsWith(sep)) {
                 remotePath = sep + remotePath;
             }
 
-            //localPath & remotePath should both ends with / or not, otherwise the pathRewite will
+            //localPath & remotePath should both ends with / or not, otherwise the pathRewrite will
             //not work well
-            if (_.endsWith(remotePath, sep) && !_.endsWith(localPath, sep)) {
+            if (remotePath.endsWith(sep) && !localPath.endsWith(sep)) {
                 localPath = localPath + sep;
             }
-            else if (!_.endsWith(remotePath, sep) && _.endsWith(localPath, sep)) {
+            else if (!remotePath.endsWith(sep) && localPath.endsWith(sep)) {
                 remotePath = remotePath + sep;
             }
 

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -9,7 +9,7 @@ var onFinished = require('on-finished');
 var http = require('http');
 var https = require('https');
 var fs = require('fs');
-var proxy = require('express-http-proxy');
+var proxyMiddleware = require('http-proxy-middleware');
 var path = require('path');
 var bodyParser = require('body-parser');
 
@@ -139,23 +139,23 @@ function httpServiceFactory(
             configDir: path.resolve(__dirname, '../../swagger_config'),
             swagger: path.resolve(__dirname, '../../static/' + endpoint.yamlName),
         };
-        
+
         var redfishConfig = {
             appRoot: path.resolve(__dirname, '../../'),
             configDir: path.resolve(__dirname, '../../swagger_config'),
             swagger: path.resolve(__dirname, '../../static/redfish.yaml'),
         };
-        
+
         var swaggerCreateAsync = Promise.promisify(swagger.create);
-        
+
         var apiV2 = swaggerCreateAsync(swaggerConfig).then(function(swaggerExpress) {
             return swaggerExpress.register(app);
         });
-        
+
         var redfish = swaggerCreateAsync(redfishConfig).then(function(swaggerExpress) {
             var swaggerUi = require('swagger-tools/middleware/swagger-ui');
             app.use(
-                swaggerUi(swaggerExpress.runner.swagger, { 
+                swaggerUi(swaggerExpress.runner.swagger, {
                     swaggerUi: '/swagger-ui',
                     swaggerUiDir: path.resolve(__dirname, '../../static/swagger-ui')
                 })
@@ -335,19 +335,41 @@ function httpServiceFactory(
      * @returns
      */
     function createHttpProxy(app, httpProxy){
+        var sep = path.sep; //The platform-specific file separator. '\\' or '/'
         try {
-            var localPath = httpProxy.localPath || '/',
-                remotePath = httpProxy.remotePath || '/',
+            var localPath = httpProxy.localPath || sep,
+                remotePath = httpProxy.remotePath || sep,
                 serverAddr = httpProxy.server;
-            app.use(localPath, proxy(serverAddr, {
-                forwardPath: function (req) {
-                    return path.join(remotePath, require('url').parse(req.url).path);
-                },
-                decorateRequest: function (req) {
-                    //For HTTPS access
-                    req.rejectUnauthorized = false;
-                }
-            }));
+
+            //localPath & remotePath should always starts with /
+            if (!_.startsWith(localPath, sep)) {
+                localPath = sep + localPath;
+            }
+            if (!_.startsWith(remotePath, sep)) {
+                remotePath = sep + remotePath;
+            }
+
+            //localPath & remotePath should both ends with / or not, otherwise the pathRewite will
+            //not work well
+            if (_.endsWith(remotePath, sep) && !_.endsWith(localPath, sep)) {
+                localPath = localPath + sep;
+            }
+            else if (!_.endsWith(remotePath, sep) && _.endsWith(localPath, sep)) {
+                remotePath = remotePath + sep;
+            }
+
+            var pathRewrite = {};
+            pathRewrite['^' + localPath] = remotePath; //^ is a symbol in regex, means beginning
+
+            var proxy = proxyMiddleware(localPath, {
+                target: serverAddr,
+                changeOrigin: true, //needed for virtual hosted sites. Without this, proxy to
+                                    //external sites will fail and are blocked by corp's internal
+                                    //firewall
+                pathRewrite: pathRewrite,
+                secure: false //ignore verify SSL Certs, so proxy works for https
+            });
+            app.use(proxy);
             logger.info('Create proxy succeeded',
                 {
                     localPath: localPath,

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
   "dependencies": {
     "body-parser": "^1.10.1",
     "cors": "^2.5.2",
+    "debug": "^2.2.0",
     "di": "git+https://github.com/RackHD/di.js.git",
     "ejs": "^2.0.8",
     "es6-shim": "^0.22.2",
     "express": "^4.10.7",
-    "express-http-proxy": "^0.6.0",
     "glob": "^4.3.2",
+    "http-proxy-middleware": "~0.11.0",
     "jsonwebtoken": "^5.4.4",
     "lodash": "^3.10.1",
     "moment": "~2.11.1",
@@ -41,8 +42,7 @@
     "swagger-tools": "~0.9.11",
     "tar": "~2.2.1",
     "tv4": "~1.2.7",
-    "ws": "^0.8.0",
-    "debug": "^2.2.0"
+    "ws": "^0.8.0"
   },
   "devDependencies": {
     "apidoc": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "body-parser": "^1.10.1",
     "cors": "^2.5.2",
-    "debug": "^2.2.0",
     "di": "git+https://github.com/RackHD/di.js.git",
     "ejs": "^2.0.8",
     "es6-shim": "^0.22.2",

--- a/spec/lib/services/http-service-spec.js
+++ b/spec/lib/services/http-service-spec.js
@@ -195,17 +195,17 @@ describe('Http.Server', function () {
         before('start', function () {
             var proxyConfig = [
                 {
-                    "localPath": "/local/proxy1",
-                    "server": "http://test.com",
-                    "remotePath": '/remote1/'
+                    'localPath': '/local/proxy1',
+                    'server': 'http://test.com',
+                    'remotePath': '/remote1/'
                 },
                 {
-                    "localPath": "local/proxy2",
-                    "server": "http://test.com"
+                    'localPath': 'local/proxy2',
+                    'server': 'http://test.com'
                 },
                 {
-                    "server": "http://test.com",
-                    "remotePath": "/remote3"
+                    'server': 'http://test.com',
+                    'remotePath': '/remote3'
                 },
                 {
                     //this is to test whether server.listen can still run without speicfy server

--- a/spec/lib/services/http-service-spec.js
+++ b/spec/lib/services/http-service-spec.js
@@ -197,10 +197,10 @@ describe('Http.Server', function () {
                 {
                     "localPath": "/local/proxy1",
                     "server": "http://test.com",
-                    "remotePath": '/remote1'
+                    "remotePath": '/remote1/'
                 },
                 {
-                    "localPath": "/local/proxy2",
+                    "localPath": "local/proxy2",
                     "server": "http://test.com"
                 },
                 {
@@ -214,8 +214,8 @@ describe('Http.Server', function () {
                 },
                 {
                     'server': 'http://test.com',
-                    'remotePath': '/remote5',
-                    'localPath': '/local/proxy5'
+                    'remotePath': 'remote5',
+                    'localPath': '/local/proxy5/'
                 }
             ];
 

--- a/spec/lib/services/obm-api-service-spec.js
+++ b/spec/lib/services/obm-api-service-spec.js
@@ -6,7 +6,6 @@
 describe("Http.Services.Api.Obms", function () {
     var obmService;
     var Promise;
-    var chai = require('chai');
     chai.use(require('chai-string'));
     before("Http.Services.Api.Obms before", function() {
         helper.setupInjector([


### PR DESCRIPTION
The issue link is: https://github.com/RackHD/RackHD/issues/90, and some discussion is in the google group: https://groups.google.com/forum/#!topic/rackhd/NAKw1ZXixlQ

This fix is to replace the old proxy library `express-http-proxy` with `http-proxy-middleware`, because `express-http-proxy` has bad performance for big file transmission, because it will first cache all content into memory and then passed to requester. But `http-proxy-middleware` works in a stream way,  the content is gradually passed to the requester, this will dramatically require less memory usage.

I have tested in vagrant environment (with 512M memory), use the `http-proxy-middleware` succeed to download a 3GB file via proxy. But the `express-http-proxy` will make the ORA hangs even I tried to increase the memory to 2GB.

@RackHD/corecommitters @pengz1 @iceiilin @WangWinson @tedstockwell @sunnyqianzhang 