### PR TITLE
Fix post sku pack error, change the regenerateSku to use latest workflow API

### DIFF
--- a/lib/api/1.1/northbound/skus.js
+++ b/lib/api/1.1/northbound/skus.js
@@ -15,9 +15,9 @@ di.annotate(skusRouterFactory, new di.Provide('Http.Api.Skus'));
 di.annotate(skusRouterFactory, new di.Inject(
         'Services.Waterline',
         'Http.Services.RestApi',
+        'Http.Services.Api.Workflows',
         '_',
         'Promise',
-        'Protocol.TaskGraphRunner',
         'uuid',
         'Http.Services.SkuPack',
         'osTmpdir',
@@ -27,10 +27,10 @@ di.annotate(skusRouterFactory, new di.Inject(
 
 function skusRouterFactory (
     waterline, 
-    rest, 
+    rest,
+    workflowApiService,
     _, 
     Promise, 
-    taskGraphProtocol, 
     uuid, 
     skuPack, 
     tmp,
@@ -46,7 +46,7 @@ function skusRouterFactory (
         try {
             req.pipe(zlib.createGunzip())
                 .pipe(tar.Extract({path: tmpDir + '/' + name}))
-                .on('end', function() {                                   
+                .on('end', function() {
                     skuPack.installPack(tmpDir + '/' + name,skuid)
                         .spread(function(filename, contents) {
                             skuName = path.basename(filename, '.json');
@@ -62,7 +62,7 @@ function skusRouterFactory (
                         .catch(function(e) {
                             res.status(500).json({
                                 error: 'Failed to serve file request:' + e.message
-                            });                            
+                            });
                         })
                         .finally(function() {
                             return rimrafAsync(tmpDir + '/' + name);
@@ -262,12 +262,19 @@ function skusRouterFactory (
         });
     }, { renderOptions: { success: 204 }}));
 
+    /**
+     * Run the workflow for all nodes to regenerate SKU
+     * @private
+     * @return {Promise}
+     */
     function regenerateSkus() {
         return waterline.nodes.find({}).then(function (nodes) {
             return Promise.all(nodes.map(function (node) {
-                return taskGraphProtocol.runTaskGraph(
-                    'Graph.GenerateSku',
-                    { defaults: { nodeId: node.id }}
+                return workflowApiService.createAndRunGraph(
+                    {
+                        name: 'Graph.GenerateSku'
+                    },
+                    node.id
                 );
             }));
         });

--- a/spec/lib/api/1.1/skus-spec.js
+++ b/spec/lib/api/1.1/skus-spec.js
@@ -4,18 +4,18 @@
 'use strict';
 
 describe('Http.Api.Skus', function () {
-    var taskGraphProtocol;
+    var workflowApiService;
     before('start HTTP server', function () {
         this.timeout(5000);
-        taskGraphProtocol = {
-            runTaskGraph: sinon.stub()
+        workflowApiService = {
+            createAndRunGraph: sinon.stub()
         };
         helper.setupInjector([
             helper.require("/lib/services/sku-pack-service"),
             dihelper.simpleWrapper(function() { arguments[1](); }, 'rimraf')
         ]);
         return helper.startServer([
-            dihelper.simpleWrapper(taskGraphProtocol, 'Protocol.TaskGraphRunner')
+            dihelper.simpleWrapper(workflowApiService, 'Http.Services.Api.Workflows')
         ]);
     });
 
@@ -45,8 +45,8 @@ describe('Http.Api.Skus', function () {
             });
         });
 
-        beforeEach('reset runTaskGraph stub', function () {
-            taskGraphProtocol.runTaskGraph.reset();
+        beforeEach('reset workflowApiService stub', function () {
+            workflowApiService.createAndRunGraph.reset();
         });
 
         beforeEach('POST /sku', function () {
@@ -94,10 +94,13 @@ describe('Http.Api.Skus', function () {
         });
 
         it('should have regenerated SKUs', function () {
-            expect(taskGraphProtocol.runTaskGraph).to.have.been.calledOnce;
-            expect(taskGraphProtocol.runTaskGraph).to.have.been.calledWith('Graph.GenerateSku');
-            expect(taskGraphProtocol.runTaskGraph.firstCall.args[1])
-                .to.have.deep.property('defaults.nodeId', node.id);
+            expect(workflowApiService.createAndRunGraph).to.have.been.calledOnce;
+            expect(workflowApiService.createAndRunGraph).to.have.been.calledWith(
+                {
+                    name: 'Graph.GenerateSku'
+                },
+                node.id
+            );
         });
 
         it('should contain the new sku in GET /skus', function () {
@@ -115,8 +118,8 @@ describe('Http.Api.Skus', function () {
         describe('PATCH /skus/:id', function () {
             var updated;
 
-            beforeEach('reset runTaskGraph stub', function () {
-                taskGraphProtocol.runTaskGraph.reset();
+            beforeEach('reset workflowApiService stub', function () {
+                workflowApiService.createAndRunGraph.reset();
             });
 
             beforeEach('PATCH /skus/:id', function () {
@@ -139,10 +142,13 @@ describe('Http.Api.Skus', function () {
             });
 
             it('should have regenerated SKUs', function () {
-                expect(taskGraphProtocol.runTaskGraph).to.have.been.calledOnce;
-                expect(taskGraphProtocol.runTaskGraph).to.have.been.calledWith('Graph.GenerateSku');
-                expect(taskGraphProtocol.runTaskGraph.firstCall.args[1])
-                .to.have.deep.property('defaults.nodeId', node.id);
+                expect(workflowApiService.createAndRunGraph).to.have.been.calledOnce;
+                expect(workflowApiService.createAndRunGraph).to.have.been.calledWith(
+                    {
+                        name: 'Graph.GenerateSku'
+                    },
+                    node.id
+                );
             });
         });
 
@@ -165,8 +171,8 @@ describe('Http.Api.Skus', function () {
         });
 
         describe('DELETE /skus/:id', function () {
-            beforeEach('reset runTaskGraph stub', function () {
-                taskGraphProtocol.runTaskGraph.reset();
+            beforeEach('reset workflowApiService stub', function () {
+                workflowApiService.createAndRunGraph.reset();
             });
 
             beforeEach('DELETE /skus/:id', function () {
@@ -175,10 +181,13 @@ describe('Http.Api.Skus', function () {
             });
 
             it('should have regenerated SKUs', function () {
-                expect(taskGraphProtocol.runTaskGraph).to.have.been.calledOnce;
-                expect(taskGraphProtocol.runTaskGraph).to.have.been.calledWith('Graph.GenerateSku');
-                expect(taskGraphProtocol.runTaskGraph.firstCall.args[1])
-                .to.have.deep.property('defaults.nodeId', node.id);
+                expect(workflowApiService.createAndRunGraph).to.have.been.calledOnce;
+                expect(workflowApiService.createAndRunGraph).to.have.been.calledWith(
+                    {
+                        name: 'Graph.GenerateSku'
+                    },
+                    node.id
+                );
             });
 
             it('should 404 with GET /skus/:id ', function () {
@@ -217,7 +226,7 @@ describe('Http.Api.Skus', function () {
             });
 
             beforeEach('reset runTaskGraph stub', function () {
-                taskGraphProtocol.runTaskGraph.resolves();
+                workflowApiService.createAndRunGraph.resolves();
             });
 
             afterEach('teardown', function () {
@@ -292,8 +301,8 @@ describe('Http.Api.Skus', function () {
                 });
             });
 
-            beforeEach('reset runTaskGraph stub', function () {
-                taskGraphProtocol.runTaskGraph.reset();
+            beforeEach('reset workflowApiService stub', function () {
+                workflowApiService.createAndRunGraph.reset();
             });
 
             beforeEach('POST /sku', function () {


### PR DESCRIPTION
When I tried to POST a new SKU pack, it will always fail. I find it is due to the regenerateSku is not changed together with @benbp 's workflow enhancement design. Previously, we use taskGraphRunner to trigger a workflow, but now we use a helper workflowApiService to do the same work.

@RackHD/corecommitters @zyoung51 @pengz1 @WangWinson @iceiilin @cgx027 @sunnyqianzhang 