### PR TITLE
Work around npm 1.3.10 bug with prune.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,12 @@ static/tftp/
 static/web-ui/
 
 build/
+
+# HWIMO-BUILD artifacts
+on-http_*.dsc
+on-http_*.tar.gz
+on-http_*.build
+on-http_*.changes
+on-http_*.deb
+packagebuild
+

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -13,7 +13,14 @@ rsync -ar ../debianstatic/on-http/ debian
 rm -rf node_modules
 npm install
 npm run apidoc
-npm prune --production
+
+# The following is a workaround for a bug in npm 1.3.10 where
+# prune --production removes the redfish-node module which is needed.
+# We are replacing "npm prune --production with a fresh
+# "npm install --production"
+rm -rf node_modules
+npm install --production
+
 git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
 
 GITCOMMITDATE=$(git show -s --pretty="format:%ci")


### PR DESCRIPTION
npm prune --production doesn't work correctly in version 1.3.10.  It ends up removing the redfish-node module form on-tasks node_modules which is needed for on-http.

To work around this, we have to remove node_modules and run 'npm install --production' rather than do 'npm prune --production'.  We cannot just do 'npm install --production on line 14 because we need apidoc for line 15.