### PR TITLE
fix SKU Pack defineTask/defineTaskGraph error

### DIFF
--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -10,7 +10,6 @@ module.exports = nodesRouterFactory;
 di.annotate(nodesRouterFactory, new di.Provide('Http.Api.Nodes'));
 di.annotate(nodesRouterFactory, new di.Inject(
         'Services.Waterline',
-        'Protocol.TaskGraphRunner',
         'TaskGraph.TaskGraph',
         'Http.Services.RestApi',
         'Http.Services.Api.Nodes',
@@ -24,7 +23,6 @@ di.annotate(nodesRouterFactory, new di.Inject(
 
 function nodesRouterFactory (
     waterline,
-    taskGraphProtocol,
     TaskGraph,
     rest,
     nodeApiService,

--- a/lib/api/1.1/northbound/skus.js
+++ b/lib/api/1.1/northbound/skus.js
@@ -56,8 +56,9 @@ function skusRouterFactory (
                             return regenerateSkus();
                         })
                         .then(function() {
-                            res.status(201);
-                            res.send(skuName);
+                            res.status(201).json({
+                                id: skuName
+                            });
                         })
                         .catch(function(e) {
                             res.status(500).json({

--- a/lib/api/1.1/northbound/workflows.js
+++ b/lib/api/1.1/northbound/workflows.js
@@ -10,7 +10,6 @@ module.exports = workflowsRouterFactory;
 di.annotate(workflowsRouterFactory, new di.Provide('Http.Api.Workflows'));
 di.annotate(workflowsRouterFactory,
     new di.Inject(
-        'Protocol.TaskGraphRunner',
         'Http.Services.RestApi',
         'Http.Services.Api.Workflows',
         'Services.Waterline',
@@ -20,7 +19,6 @@ di.annotate(workflowsRouterFactory,
 );
 
 function workflowsRouterFactory (
-    taskgraphRunner,
     rest,
     workflowApiService,
     waterline,

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -300,7 +300,7 @@ function CommonApiPresenterFactory(
                             // If we failed to render the error then we've got larger problems.
 
                             logger.error('Unable to render error template.', {
-                                macaddress: macaddress,
+                                macaddress: options.macaddress,
                                 error: terrible
                             });
 

--- a/lib/services/sku-pack-service.js
+++ b/lib/services/sku-pack-service.js
@@ -20,7 +20,7 @@ di.annotate(skuPackServiceFactory,
         'fs',
         'rimraf',
         'Assert',
-        'Protocol.TaskGraphRunner',
+        'Http.Services.Api.Workflows',
         'Constants',
         'Services.Environment'
     )
@@ -36,7 +36,7 @@ function skuPackServiceFactory(
     nodeFs,
     rimraf,
     assert,
-    taskgraphRunner,
+    workflowApiService,
     Constants,
     Env
 ) {
@@ -53,7 +53,7 @@ function skuPackServiceFactory(
     /**
      * Given a nodeId, return the prioritized scope order
      * @param  {string}     nodeId
-     */    
+     */
      SkuPackService.prototype.setupScope = function(nodeId) {
         var defaultScope = [ Constants.Scope.Global ];
         if(!nodeId)  {
@@ -95,7 +95,7 @@ function skuPackServiceFactory(
      * Register a SKU package into the service
      * @param  {String}     name the filename
      * @param  {String}     contents the file contents
-     * @return {Promise[]}    
+     * @return {Promise[]}
      */
     SkuPackService.prototype.registerPack = function(name, contents) {
         var promises = [];
@@ -119,7 +119,7 @@ function skuPackServiceFactory(
                             return _.map(templates,function(contents,name) {
                                 return Templates.put(name, contents, skuName);
                             });
-                        }) 
+                        })
                     );
                 }
 
@@ -130,7 +130,7 @@ function skuPackServiceFactory(
                             return _.map(profiles,function(contents,name) {
                                 return Profiles.put(name, contents, skuName);
                             });
-                        }) 
+                        })
                     );
                 }
 
@@ -143,7 +143,7 @@ function skuPackServiceFactory(
                         var data = JSON.parse(contents);
                         tasks.push(data.injectableName);
                         data.injectableName = data.injectableName + '::' + skuName;
-                        return taskgraphRunner.defineTask(data);
+                        return workflowApiService.defineTask(data);
                     });
                 }
                 promises.push(taskPromises);
@@ -162,7 +162,7 @@ function skuPackServiceFactory(
                                 item.taskName = item.taskName + '::' + skuName;
                             }
                         });
-                        return taskgraphRunner.defineTaskGraph(data);
+                        return workflowApiService.defineTaskGraph(data);
                     });
                     promises.push(workflowPromises);
                 }
@@ -183,7 +183,7 @@ function skuPackServiceFactory(
      * Unregister a SKU package into the service
      * @param  {String}     skuid the skuid being unregistered
      * @param  {String}     contents the file contents
-     * @return {Promise}    
+     * @return {Promise}
      */
     SkuPackService.prototype.unregisterPack = function(skuid, contents) {
         var promises = [];
@@ -193,11 +193,11 @@ function skuPackServiceFactory(
 
         try {
             var conf = JSON.parse(contents);
-            
+
             if(conf.hasOwnProperty('httpStaticRoot')) {
                 if( skuid in self.skuHandlers ) {
                     delete self.skuHandlers[skuid];
-                }                    
+                }
             }
 
             if(conf.hasOwnProperty('httpTemplateRoot')) {
@@ -237,7 +237,7 @@ function skuPackServiceFactory(
     /**
      * Start the SKU pack service
      * @param  {String}     confRoot The root path of the sku pack configuration files
-     * @return {Promise}    
+     * @return {Promise}
      */
     SkuPackService.prototype.start = function(confRoot) {
         var self = this;
@@ -257,7 +257,7 @@ function skuPackServiceFactory(
      * Validate a SKU pack
      * @param  {String}     contents The configuration file contents
      * @param  {String}     fromRoot The path to the configuration file
-     * @return {Promise}    
+     * @return {Promise}
      */
     SkuPackService.prototype.validatePack = function(contents, fromRoot) {
         try {
@@ -287,7 +287,7 @@ function skuPackServiceFactory(
      * Install a SKU pack
      * @param  {String}     fromRoot The path to the configuration file
      * @param  {String}     skuid Specify the skuid or undefined to create a new SKU id
-     * @return {Promise}    
+     * @return {Promise}
      */
     SkuPackService.prototype.installPack = function(fromRoot, skuid) {
         var self = this;
@@ -346,7 +346,7 @@ function skuPackServiceFactory(
     /**
      * Delete a SKU pack
      * @param  {String}     skuid The skuid of the sku's package that shall be removed
-     * @return {Promise}    
+     * @return {Promise}
      */
     SkuPackService.prototype.deletePack = function(skuid) {
         var self = this;

--- a/lib/services/tags-api-service.js
+++ b/lib/services/tags-api-service.js
@@ -10,7 +10,6 @@ di.annotate(tagApiServiceFactory, new di.Provide('Http.Services.Api.Tags'));
 di.annotate(tagApiServiceFactory,
     new di.Inject(
         'Services.Waterline',
-        'Protocol.TaskGraphRunner',
         'Promise',
         'Http.Services.Api.Workflows'
     )
@@ -18,7 +17,6 @@ di.annotate(tagApiServiceFactory,
 
 function tagApiServiceFactory(
     waterline,
-    taskGraphProtocol,
     Promise,
     workflowApiService
 ) {

--- a/spec/lib/api/1.1/skus-spec.js
+++ b/spec/lib/api/1.1/skus-spec.js
@@ -258,8 +258,12 @@ describe('Http.Api.Skus', function () {
                             _resolve(201);
                         }
                         _reject(code);
+                        return res;
                     },
-                    send: sinon.stub()
+                    send: sinon.stub(),
+                    json: function(obj) {
+                        return JSON.stringify(obj);
+                    }
                 };
 
                 req.on('open', function() {
@@ -288,8 +292,12 @@ describe('Http.Api.Skus', function () {
                             _resolve(201);
                         }
                         _reject(code);
+                        return res;
                     },
-                    send: sinon.stub()
+                    send: sinon.stub(),
+                    json: function(obj) {
+                        return JSON.stringify(obj);
+                    }
                 };
 
                 skus.skuPackHandler(req, res, 'skuid');


### PR DESCRIPTION
When inject the tasks/workflows of SKU pack, it will fail due to defineTask and defineWorkflow error. The root cause is that after @benbp 's workflow change, the previous TaskGraphRunner should be replaced with WorkflowApiService. This PR is to fix this problem together some other minor enhancement:

Changes include:
1. Fix SKU pack defineTask/defineTaskGraph error
2. remove unused taskGraphRunner inject (because it has been replaced with workflowApiService)
3. change POST the SKU pack returns a JSON object, this is the standard response format for all other APIs

@RackHD/corecommitters @zyoung51 @pengz1 @sunnyqianzhang 