### PR TITLE
updated swagger spec for API 1.1.0

### DIFF
--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -677,6 +677,7 @@ paths:
         default:
           description: Unexpected error
           schema:
+            type: object
 
   /workflows/tasks/library:
     get:
@@ -727,7 +728,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - workflow
         - task
@@ -801,7 +803,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - workflow
         - put
@@ -940,7 +943,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - nodes
         - workflow
@@ -977,7 +981,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - nodes
         - dhcp
@@ -1432,7 +1437,7 @@ paths:
         - name: q
           in: query
           description: query object to pass through to waterline.
-          required: false
+          required: true
           type: string
       tags:
         - lookups
@@ -1539,7 +1544,8 @@ paths:
           description: |
             object patches to apply.
           required: true
-          type: object
+          schema:
+            type: object
       tags:
         - lookups
         - get
@@ -1714,7 +1720,8 @@ paths:
         - name: body
           in: body
           required: true
-          type: object
+          schema:
+            type: object
       tags:
         - config
         - patch


### PR DESCRIPTION
the previous swagger spec was broken because of a basic code generation. this needs to be maintained more carefully and not reliant upon generated outputs. @akutz fixed this part: You must have a  tag for a parameter of type . It was added wherever it was omitted, setting the schema to a variant type instead. It was omitted in a lot of requests as well as one response. Within the lookups, I (@kacole2) changed the lookup query reuirement from FALSE to TRUE. For some reason the code would fail to execute unless it was set to TRUE. There were some memory pointers happening and it will have to be looked at once again. To get a better idea of how this is all generated using go-swagger, checkout the gorackhd repo and follow the directions listed there. https://github.com/emccode/gorackhd

Signed-off-by: Kendrick Coleman <kendrickcoleman@gmail.com>