### PR TITLE
[swagger] Add AuthN/AuthZ processing to routes

### DIFF
--- a/lib/api/2.0/users.js
+++ b/lib/api/2.0/users.js
@@ -1,0 +1,93 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var _ = injector.get('_'); // jshint ignore:line
+var configuration = injector.get('Services.Configuration');
+var waterline = injector.get('Services.Waterline');
+var Errors = injector.get('Errors');
+var aclService = injector.get('Acl.Services');
+var localUserException = configuration.get('enableLocalHostException', true);
+
+var addUser = controller({success: 201}, function(req, res) {
+    var userObj = _.pick(req.swagger.params.body.value, ['username', 'password', 'role']);
+    userObj.role = userObj.role || 'ReadOnly';  //TODO: move to Constants when Role code is added
+
+    return waterline.localusers.find({}).then(function(users) {
+        if(!users.length && localUserException && res.locals.ipAddress === '127.0.0.1') {
+            // Only when there are no users, and the remote is a local connection, and we 
+            // permit it, then let them add the first user.
+            return waterline.localusers.create(userObj)
+            .then(function(user) {
+                return [user, aclService.aclMethod('addUserRoles',
+                    userObj.username,
+                    userObj.role )];
+            }).spread(function(user) {
+                return _.pick(user, ['username', 'role']);
+            });
+        }
+
+        if( !_.find(users, function(user) {
+            return user.username === userObj.username;
+        })) {
+            if( req.isAuthenticated && req.isAuthenticated() ) {
+                return waterline.localusers.create(userObj)
+                .then(function(user) {
+                    return [user, aclService.aclMethod('addUserRoles',
+                        userObj.username,
+                        userObj.role )];
+                }).spread(function(user) {
+                    return _.pick(user, ['username', 'role']);
+                });
+            }
+        }
+
+        throw new Errors.UnauthorizedError('Unauthorized');
+    });
+});
+
+var modifyUser = controller(function(req) {
+    var userObj = _.pick(req.swagger.params.body.value, ['username', 'password', 'role']);
+    if(!req.isAuthenticated) {
+        throw new Errors.UnauthorizedError('Unauthorized');
+    }
+
+    if(!req.isAuthenticated()) {
+        throw new Errors.UnauthorizedError('Unauthorized');
+    }
+
+    if( (req.user === userObj.username && req.hasRole('ConfigureSelf')) ||
+        req.hasRole('Administrator') || 
+        req.hasRole('ConfigureUsers') )
+    {
+        return waterline.localusers.findOne({username: userObj.username})
+        .then(function(user) {
+            if(user.role !== userObj.role) {
+                return aclService.aclMethod('removeUserRoles',
+                    user.username,
+                    user.role)
+                .then(function() {
+                    return user;
+                });
+            }
+            return user;
+        }).then(function() {
+            return waterline.localusers.update({username: userObj.username}, userObj);
+        }).then(function(user) {
+            return [user, aclService.aclMethod('addUserRoles',
+                user.username,
+                user.role )];
+        }).spread(function(user) {
+            return _.pick(user, ['username', 'role']);
+        });
+    }
+
+    throw new Errors.ForbiddenError('Forbidden');
+});
+
+module.exports = {
+    addUser: addUser,
+    modifyUser: modifyUser
+};

--- a/lib/fittings/swagger_authn.js
+++ b/lib/fittings/swagger_authn.js
@@ -1,0 +1,21 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var injector = require('../../index.js').injector;
+var debug = require('debug')('swagger:authn');
+
+module.exports = function create(fittingDef, bagpipes) {
+    var authn = injector.get('Auth.Services');
+    var runner = bagpipes.config.swaggerNodeRunner;
+    var authEnabled = runner.config.swagger.authEnabled;
+    return function swagger_authn(context, next) {    // jshint ignore:line
+        var operation = context.request.swagger.operation;
+        var authType = operation['x-authentication-type'];
+        if(!authEnabled || !authType) {
+            debug('skipping authn');
+            return next();
+        }
+        return authn.authenticateWithMethod(context.request, context.response, next, authType);
+    };
+};

--- a/lib/fittings/swagger_authz.js
+++ b/lib/fittings/swagger_authz.js
@@ -1,0 +1,67 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var injector = require('../../index.js').injector;
+var _ = injector.get('_');    // jshint ignore:line
+var Promise = injector.get('Promise');    // jshint ignore:line
+var debug = require('debug')('swagger:authz');
+var Error = injector.get('Errors'); // jshint ignore:line
+
+function loadSwagger(authz, swaggerDef) {
+    var promises = [];
+    var methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];
+    _.forOwn(swaggerDef.paths, function(value, resourceName) {
+        _.forEach(methods, function(method) {
+            if(_.has(value, method) && _.has(value[method], 'x-privileges')) {
+                _.forEach(value[method]['x-privileges'], function(role) {
+                    var resource = swaggerDef.basePath + resourceName;
+                    debug('adding ACL: %s:%s:%s', role, resource, method);
+                    promises.push( authz.aclMethod('allow', role, resource, method) );
+                });
+            }
+        });
+    });
+    return Promise.all(promises);
+}
+
+var hasRole = function(role) {
+    return _.includes(this.roles, role );
+};
+
+module.exports = function create(fittingDef, bagpipes) {
+    injector = require('../../index.js').injector;
+    var authz = injector.get('Acl.Services');
+    var swaggerNodeRunner = bagpipes.config.swaggerNodeRunner;
+    var ready = loadSwagger(authz, swaggerNodeRunner.swagger);
+    var basePath = swaggerNodeRunner.swagger.basePath;
+    return function swagger_authn_authz(context, next) {    // jshint ignore:line
+        if(context.request.user) {
+            ready.then(function() {
+                return authz.aclMethod('isAllowed',
+                    context.request.user,
+                    basePath + context.request.swagger.operation.pathObject.path,
+                    context.request.method.toLowerCase());
+            }).then(function(allowed) {
+                if(!allowed) {
+                    return context.response.status(403).json({message: "Forbidden"});
+                } else {
+                    authz.aclMethod('userRoles', context.request.user)
+                    .then(function(roles) {
+                        return authz.aclMethod('_allRoles', roles);
+                    }).then(function(allRoles) {
+                        context.request.roles = allRoles;
+                        context.request.hasRole = hasRole;
+                        next();
+                    });
+                }
+            })
+            .catch(function(err) {
+                next(err);
+            });
+        } else {
+            debug('skipping authz, unknown authn');
+            next();
+        }
+    };
+};

--- a/lib/services/acl-service.js
+++ b/lib/services/acl-service.js
@@ -1,0 +1,75 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di'),
+    nodeAcl = require( 'acl' );
+
+module.exports = aclServiceFactory;
+di.annotate(aclServiceFactory, new di.Provide('Acl.Services'));
+di.annotate(aclServiceFactory,
+    new di.Inject(
+        'Services.Configuration',
+        'Promise',
+        'Services.Waterline',
+        '_'
+    )
+);
+
+function aclServiceFactory(
+    configuration,
+    Promise,
+    waterline,
+    _
+) {
+    function AclService() {
+        this.acl = new nodeAcl(new nodeAcl.memoryBackend());  // jshint ignore:line
+    }
+
+    AclService.prototype.start = function() {
+        var acl = this.acl;
+        var endpoints = configuration.get('httpEndpoints', []);
+        var authEnabled = _(endpoints).filter(function(endpoint) {
+            return endpoint.authEnabled === true;
+        }).compact().value();
+
+        // Only initialize the service if an endpoint has enabled authn
+        if(_.isEmpty(authEnabled)) {
+            return;
+        }
+
+        return Promise.all([
+            waterline.localusers.find({}),
+            waterline.roles.find({})
+        ]).spread(function(users, roles) {
+            var promises = _.map(users, function(user) {
+                    return acl.addUserRoles(user.username, user.role);
+                });
+            var rolePromises = _.map(roles, function(roles) {
+                    return acl.addRoleParents(roles.role, roles.privileges);
+                });
+            Array.prototype.push.apply(promises, rolePromises);
+            return Promise.all(promises);
+        }).then(function() {
+            // Enforce a subset of hardcoded privileges:
+            return Promise.all([
+                // 2.0 API's fixed privileges
+                acl.addRoleParents('Administrator', ['Read', 'Write']),
+                acl.addRoleParents('ReadOnly', ['Read']),
+
+                // Redfish 1.0 fixed privileges
+                acl.addRoleParents('Administrator', ['Login','ConfigureManager','ConfigureUsers']),
+                acl.addRoleParents('Administrator', ['ConfigureComponents','ConfigureSelf']),
+                acl.addRoleParents('Operator', ['Login','ConfigureComponents','ConfigureSelf']),
+                acl.addRoleParents('ReadOnly', ['Login', 'ConfigureSelf'])
+            ]);
+        });
+    };
+
+    AclService.prototype.aclMethod = function(name) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        return this.acl[name].apply(this.acl, args);
+    };
+
+    return new AclService();
+}

--- a/lib/services/auth-service.js
+++ b/lib/services/auth-service.js
@@ -4,12 +4,12 @@
 
 var di = require('di'),
     jwt = require('jsonwebtoken'),
-    crypto = require('crypto'),
     passport = require('passport'),
     JwtStrategy = require('passport-jwt').Strategy,
     LocalStrategy = require('passport-local').Strategy,
     BasicStrategy = require('passport-http').BasicStrategy,
-    ExtractJwt = require('passport-jwt').ExtractJwt;
+    ExtractJwt = require('passport-jwt').ExtractJwt,
+    AnonStrategy = require('passport-anonymous').Strategy;
 
 var BAD_REQUEST_STATUS = 400;
 var UNAUTHORIZED_STATUS = 401;
@@ -21,14 +21,16 @@ di.annotate(authServiceFactory,
     new di.Inject(
         'Assert',
         'Services.Configuration',
-        '_'
+        '_',
+        'Services.Waterline'
     )
 );
 
 function authServiceFactory(
     assert,
     configuration,
-    _
+    _,
+    waterline
 ) {
     var redfishSessions = [];
 
@@ -37,22 +39,11 @@ function authServiceFactory(
 
     AuthService.prototype.init = function(){
         var self = this;
-        this.strategies = [];
 
         self.algorithm = 'HS256';
         self.secretOrKey = '';
         self.ignoreTokenExpiration = false;
         self.encoder = 'base64';
-
-        self.hashConfig = {
-            // number of bytes in the Hash
-            hashBytes: 64,
-            // number of bytes in the slat
-            saltBytes: 64,
-            // number of iterations to get the final hash, longer means more secure,
-            // but also slower
-            iterations: 10000
-        };
 
         self.loadFromConf();
 
@@ -67,6 +58,24 @@ function authServiceFactory(
             secretOrKey : self.secretOrKey,
             ignoreExpiration : self.ignoreTokenExpiration
         };
+
+        // used to serialize the user for the session
+        passport.serializeUser(function(user, done) {
+            done(null, user); 
+        });
+
+        // used to deserialize the user
+        passport.deserializeUser(function(id, done) {
+            waterline.localusers.findOne({id: id})
+            .then(function(user) {
+                if(user) {
+                    done(null, user.username);
+                }
+                done(null, false);
+            }).catch(function(err) {
+                done(err);
+            });
+        });
     };
 
     AuthService.prototype.getPassportMidware = function () {
@@ -86,38 +95,17 @@ function authServiceFactory(
                     { jwtFromRequest: ExtractJwt.fromHeader('x-auth-token') }),
             self.jwtStrategyRedfish.bind(self)));
         passport.use(new BasicStrategy(self.localStrategyAuth.bind(self)));
+        passport.use(new AnonStrategy());
 
         return passportMidware;
     };
 
-    AuthService.prototype.loadFromConf = function (){
-        var username = configuration.get('authUsername', 'admin');
-        var passwordHash = configuration.get('authPasswordHash',
-            'KcBN9YobNV0wdux8h0fKNqi4uoKCgGl/j8c6YGlG7iA0PB3P9ojbmANGhD' +
-            'lcSBE0iOTIsYsGbtSsbqP4wvsVcw==');
-        var salt = configuration.get('authPasswordSalt',
-            'zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItL' +
-            'A3p7BSCWIzkw4GwWuezoMvKf3UXg==');
-        var secret = configuration.get('authTokenSecret',
-            'RackHDRocks!');
-
-        assert.string(username, 'Invalid username in configure file');
-        assert.string(passwordHash, 'Invalid password hash in configure file');
-        assert.string(salt, 'Invalid crypto salt in configure file');
+    AuthService.prototype.loadFromConf = function () {
+        var secret = configuration.get('authTokenSecret', 'RackHDRocks!');
         assert.string(secret, 'Invalid token secret in configure file');
-
-        this.userFromConf = username;
-        this.hashFromConf = new Buffer(passwordHash, this.encoder);
-        this.saltFromConf = new Buffer(salt, this.encoder);
         this.secretOrKey = new Buffer(secret, this.encoder);
 
-        if (this.hashFromConf.length !== this.hashConfig.hashBytes ||
-            this.saltFromConf.length !== this.hashConfig.saltBytes){
-            throw new Error('Invalid password hash or salt length in configure file');
-        }
-
-        this.expiresIn = configuration.get('authTokenExpireIn',
-                                            86400); //86400 = 24 * 60 * 60, 24hours
+        this.expiresIn = configuration.get('authTokenExpireIn', 24 * 60 * 60 /* 24 hours */);
         assert.number(this.expiresIn, 'Invalid token expire value in configure file');
 
         if (this.expiresIn === 0){
@@ -126,39 +114,14 @@ function authServiceFactory(
     };
 
     AuthService.prototype.localStrategyAuth = function (username, password, done) {
-        var self =  this;
-        self.calcPasswordHash(
-            password,
-            self.saltFromConf,
-            self.hashConfig.iterations,
-            self.hashConfig.hashBytes,
-            function(err, hashCalculated){
-                if(err){
-                    return done(err);
-                }
-                if (!hashCalculated ||
-                    username !== self.userFromConf ||
-                    hashCalculated.toString(self.encoder) !==
-                    self.hashFromConf.toString(self.encoder)) {
-
-                    return done(null, false, {
-                        message: 'Invalid username or password'
-                    });
-                }
+        waterline.localusers.findOne({username: username}).then(function(user) {
+            if(user && user.comparePassword(password)) {
                 return done(null, username);
-            });
-    };
-
-    AuthService.prototype.calcPasswordHash = function (password, salt, iteration, bytes, callback) {
-        var self = this;
-
-        crypto.pbkdf2(password, salt, self.hashConfig.iterations, self.hashConfig.hashBytes,
-            function(err, hash){
-                if(err){
-                    callback(err);
-                }
-                callback(null, hash);
-            });
+            }
+            return done(null, false, {message: 'Unauthorized'});
+        }).catch(function(err) {
+            return done(err);
+        });
     };
 
     AuthService.prototype.createJwtToken = function (user) {
@@ -172,13 +135,14 @@ function authServiceFactory(
     };
 
     AuthService.prototype.jwtStrategyAuth = function(jwtPayload, done) {
-        var user = jwtPayload.user;
-        if (user === this.userFromConf){
-            return done(null, user);
-        }
-        else{
-            return done(null, false);
-        }
+        waterline.localusers.findOne({username: jwtPayload.user}).then(function(user) {
+            if(user) {
+                return done(null, user.username);
+            }
+            return done(null, false, {message: 'Unauthorized'});
+        }).catch(function(err) {
+            return done(err);
+        });
     };
 
     AuthService.prototype.jwtStrategyRedfish = function(jwtPayload, done) {
@@ -235,9 +199,8 @@ function authServiceFactory(
                     }
                 }
                 else {
-                    var username = self.userFromConf;
                     var token = {
-                        'token': self.createJwtToken(username)
+                        'token': self.createJwtToken(user)
                     };
 
                     res.send(token);
@@ -259,6 +222,26 @@ function authServiceFactory(
                 }
                 else {
                     next();
+                }
+            }
+        )(req, res, next);
+    };
+
+    AuthService.prototype.authenticateWithMethod = function(req, res, next, method) {
+        passport.authenticate(method, {session: false}, function(err, user, challenges) {
+                if(err){
+                    res.status(ERROR_STATUS).send({message: 'Internal server error'});
+                }
+                else if (!user){
+                    res.status(UNAUTHORIZED_STATUS).send({message: challenges.message});
+                }
+                else {
+                    req.login(user, function(err) {
+                        if(err) {
+                            return next(err);
+                        }
+                        next();
+                    });
                 }
             }
         )(req, res, next);

--- a/lib/services/auth-service.js
+++ b/lib/services/auth-service.js
@@ -59,22 +59,12 @@ function authServiceFactory(
             ignoreExpiration : self.ignoreTokenExpiration
         };
 
-        // used to serialize the user for the session
+        // We do not use passport.session middleware and run our strategies
+        // with session: false, but this is a required function for req.logIn 
+        // to succeed.  The 'user' value below is the value passed to req.logIn
+        // and it is returned to indicate success.
         passport.serializeUser(function(user, done) {
             done(null, user); 
-        });
-
-        // used to deserialize the user
-        passport.deserializeUser(function(id, done) {
-            waterline.localusers.findOne({id: id})
-            .then(function(user) {
-                if(user) {
-                    done(null, user.username);
-                }
-                done(null, false);
-            }).catch(function(err) {
-                done(err);
-            });
         });
     };
 

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -152,7 +152,7 @@ function httpServiceFactory(
         var swaggerCreateAsync = Promise.promisify(swagger.create);
 
         var apiV2 = swaggerCreateAsync(swaggerConfig).then(function(swaggerExpress) {
-            swaggerExpress.register(app);
+            return swaggerExpress.register(app);
         });
 
         var redfish = swaggerCreateAsync(redfishConfig).then(function(swaggerExpress) {
@@ -163,7 +163,7 @@ function httpServiceFactory(
                     swaggerUiDir: path.resolve(__dirname, '../../static/swagger-ui')
                 })
             );
-            swaggerExpress.register(app);
+            return swaggerExpress.register(app);
         });
 
         return Promise.all([apiV2, redfish]);

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -93,6 +93,7 @@ function httpServiceFactory(
         this.app = express();
         this.endpoint = this._parseEndpoint(endpoint);
         this.server = null;
+        authService.init();
         this._setup();
     }
 
@@ -138,18 +139,20 @@ function httpServiceFactory(
             appRoot: path.resolve(__dirname, '../../'),
             configDir: path.resolve(__dirname, '../../swagger_config'),
             swagger: path.resolve(__dirname, '../../static/' + endpoint.yamlName),
+            authEnabled: this.endpoint.authEnabled
         };
 
         var redfishConfig = {
             appRoot: path.resolve(__dirname, '../../'),
             configDir: path.resolve(__dirname, '../../swagger_config'),
             swagger: path.resolve(__dirname, '../../static/redfish.yaml'),
+            authEnabled: this.endpoint.authEnabled
         };
 
         var swaggerCreateAsync = Promise.promisify(swagger.create);
 
         var apiV2 = swaggerCreateAsync(swaggerConfig).then(function(swaggerExpress) {
-            return swaggerExpress.register(app);
+            swaggerExpress.register(app);
         });
 
         var redfish = swaggerCreateAsync(redfishConfig).then(function(swaggerExpress) {
@@ -205,16 +208,16 @@ function httpServiceFactory(
         // UI Directory
         app.use('/ui', express.static('./static/web-ui'));
 
-        // Setup authentication
+        // Initialize authentication always
+        app.use(authService.getPassportMidware());
+
+        // Only apply authentication routes if auth is enabled
         if (endpoint.authEnabled) {
             // mount ./login only when authentication is enabled
             app.use(injector.get('Http.Api.Login'));
-
-            var authService = injector.get('Auth.Services');
-            authService.init();
-            app.use(authService.getPassportMidware());
-            app.all('/api/*', authService.authMiddlewareJwt.bind(authService));
-            app.all('/redfish/v1/*', authService.authMiddlewareRedfish.bind(authService));
+            app.all('/api/1.1/*', authService.authMiddlewareJwt.bind(authService));
+            app.all('/api/common/*', authService.authMiddlewareJwt.bind(authService));
+            app.all('/api/current/*', authService.authMiddlewareJwt.bind(authService));
         }
 
         // Mount API Routers

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "acl": "~0.4.9",
     "body-parser": "^1.10.1",
     "cors": "^2.5.2",
+    "debug": "~2.2.0",
     "di": "git+https://github.com/RackHD/di.js.git",
     "ejs": "^2.0.8",
     "es6-shim": "^0.22.2",
@@ -33,6 +35,7 @@
     "on-tasks": "git+https://github.com/RackHD/on-tasks.git",
     "os-tmpdir": "~1.0.1",
     "passport": "^0.3.2",
+    "passport-anonymous": "~1.0.1",
     "passport-http": "~0.3.0",
     "passport-local": "^1.0.0",
     "passport-jwt": "~2.0.0",

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -13,7 +13,7 @@ global.onHttpContext = index.onHttpContextFactory();
 // Legacy
 global.dihelper = onHttpContext.helper;
 
-helper.startServer = function (overrides) {
+helper.startServer = function (overrides, endpointOpt) {
     overrides = (overrides || []).concat([
         onHttpContext.helper.simpleWrapper({
             publishLog: sinon.stub().resolves()
@@ -33,11 +33,12 @@ helper.startServer = function (overrides) {
 
     helper.injector.get('Services.Configuration')
         .set('skuPackRoot', 'spec/lib/services/sku-static')
-        .set('httpEndpoints', [
+        .set('httpEndpoints', [ _.merge( {}, 
             {
                 'port': 8089,
                 'httpsEnabled': false
-            }
+            },
+            endpointOpt )
         ]);
 
     index.injector = helper.injector;

--- a/spec/lib/api/2.0/users-spec.js
+++ b/spec/lib/api/2.0/users-spec.js
@@ -29,12 +29,12 @@ describe('Http.Api.Users', function () {
             sinon.stub(waterline.localusers, 'update');
             waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
                 username: userObj.username,
-                comparePassword: function(password) { return password === 'admin123' },
+                comparePassword: function(password) { return password === 'admin123'; },
                 role: userObj.role
             });
             waterline.localusers.findOne.withArgs({username: 'readonly'}).resolves({
                 username: readOnlyObj.username,
-                comparePassword: function(password) { return password === 'read123' },
+                comparePassword: function(password) { return password === 'read123'; },
                 role: readOnlyObj.role
             });
             waterline.localusers.findOne.resolves();
@@ -75,7 +75,7 @@ describe('Http.Api.Users', function () {
             });
     });
 
-    it('should 200 a user post attempt with auth tokens', function() {
+    it('should 201 a user post attempt with auth tokens', function() {
         waterline.localusers.create.resolves(readOnlyObj);
         waterline.localusers.find.resolves([ userObj ]);
         return helper.request().post('/login')

--- a/spec/lib/api/2.0/users-spec.js
+++ b/spec/lib/api/2.0/users-spec.js
@@ -1,0 +1,150 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Users', function () {
+    var userObj = {
+        username: 'admin',
+        password: 'admin123',
+        role: 'Administrator'
+    };
+
+    var readOnlyObj = {
+        username: 'readonly',
+        password: 'read123',
+        role: 'ReadOnly'
+    };
+
+    var waterline;
+    
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        return helper.startServer([], { authEnabled: true })
+        .then(function() {
+            waterline = helper.injector.get('Services.Waterline');
+            sinon.stub(waterline.localusers, 'create');
+            sinon.stub(waterline.localusers, 'find');
+            sinon.stub(waterline.localusers, 'findOne');
+            sinon.stub(waterline.localusers, 'update');
+            waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
+                username: userObj.username,
+                comparePassword: function(password) { return password === 'admin123' },
+                role: userObj.role
+            });
+            waterline.localusers.findOne.withArgs({username: 'readonly'}).resolves({
+                username: readOnlyObj.username,
+                comparePassword: function(password) { return password === 'read123' },
+                role: readOnlyObj.role
+            });
+            waterline.localusers.findOne.resolves();
+        });
+    });
+
+    beforeEach(function() {
+        waterline.localusers.create.reset();
+        waterline.localusers.find.reset();
+        waterline.localusers.update.reset();
+        waterline.localusers.findOne.reset();
+    });
+
+    it('should 201 a user post attempt with localexception', function() {
+        waterline.localusers.find.resolves([]);
+        waterline.localusers.create.resolves(userObj);
+        return helper.request().post('/api/2.0/users')
+            .send(userObj)
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, {
+                username: userObj.username,
+                role: userObj.role
+            })
+            .expect(function() {
+                expect(waterline.localusers.find).to.have.been.calledOnce;
+                expect(waterline.localusers.create).to.have.been.calledWith(userObj);
+            });
+    });
+
+    it('should 401 a user post attempt without auth tokens', function() {
+        waterline.localusers.find.resolves([ userObj ]);
+        return helper.request().post('/api/2.0/users')
+            .send(userObj)
+            .expect('Content-Type', /^application\/json/)
+            .expect(401)
+            .expect(function() {
+                expect(waterline.localusers.find).to.have.been.calledOnce;
+            });
+    });
+
+    it('should 200 a user post attempt with auth tokens', function() {
+        waterline.localusers.create.resolves(readOnlyObj);
+        waterline.localusers.find.resolves([ userObj ]);
+        return helper.request().post('/login')
+            .send({username: "admin", password: "admin123"})
+            .expect(200)
+            .then(function(res) {
+                return res.body.token;
+            }).then(function(token) {
+                return helper.request().post('/api/2.0/users')
+                    .set("authorization", 'JWT ' + token)
+                    .send(readOnlyObj)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(201);
+            });
+    });
+
+    it('should 403 a user post without access', function() {
+        return helper.request().post('/login')
+            .send({username: "readonly", password: "read123"})
+            .expect(200)
+            .then(function(res) {
+                return res.body.token;
+            }).then(function(token) {
+                return helper.request().post('/api/2.0/users')
+                    .set("authorization", 'JWT ' + token)
+                    .send(readOnlyObj)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(403);
+            });
+    });
+
+    it('should 401 a user post attempt with invalid auth tokens', function() {
+        return helper.request().post('/login')
+            .send({username: "admin", password: "admin123"})
+            .expect(200)
+            .then(function(res) {
+                return res.body.token;
+            }).then(function(token) {
+                return helper.request().post('/api/2.0/users')
+                    .set("authorization", 'JWT ' + token + 'blab')
+                    .send(readOnlyObj)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(401);
+            });
+    });
+
+    it('should 200 a user modification attempt with auth tokens', function() {
+        waterline.localusers.update.resolves(readOnlyObj);
+        waterline.localusers.find.resolves([ userObj ]);
+        return helper.request().post('/login')
+            .send({username: "admin", password: "admin123"})
+            .expect(200)
+            .then(function(res) {
+                return res.body.token;
+            }).then(function(token) {
+                return helper.request().put('/api/2.0/users')
+                    .set("authorization", 'JWT ' + token)
+                    .send(readOnlyObj)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(200);
+            });
+    });
+
+    after('stop HTTP server', function () {
+        waterline.localusers.create.restore();
+        waterline.localusers.find.restore();
+        waterline.localusers.findOne.restore();
+        waterline.localusers.update.restore();
+        return helper.stopServer();
+    });
+
+});

--- a/spec/lib/api/login/login-spec.js
+++ b/spec/lib/api/login/login-spec.js
@@ -83,11 +83,11 @@ describe('Http.Api.Login', function () {
         waterline = helper.injector.get('Services.Waterline');
         waterline.localusers = {
             findOne: sinon.stub()
-        }
+        };
         waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
-                username: 'admin',
-                comparePassword: function(password) { return password === 'admin123' }
-            });
+            username: 'admin',
+            comparePassword: function(password) { return password === 'admin123'; }
+        });
         waterline.localusers.findOne.resolves();
     });
 

--- a/spec/lib/api/login/login-spec.js
+++ b/spec/lib/api/login/login-spec.js
@@ -77,7 +77,23 @@ describe('Http.Api.Login', function () {
     after('disallow self signed certs', function () {
         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
     });
+    
+    var waterline;
+    before('setup default admin user', function() {
+        waterline = helper.injector.get('Services.Waterline');
+        waterline.localusers = {
+            findOne: sinon.stub()
+        }
+        waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
+                username: 'admin',
+                comparePassword: function(password) { return password === 'admin123' }
+            });
+        waterline.localusers.findOne.resolves();
+    });
 
+    after('remove waterline definition', function() {
+        delete waterline.localusers;
+    });
     describe('test with authentication enabled', function () {
         before('start HTTPs server', function () {
             this.timeout(5000);
@@ -101,7 +117,7 @@ describe('Http.Api.Login', function () {
                 .expect(UNAUTHORIZED_STATUS)
                 .expect(function(res) {
                     expect(res.body.message).to.be.a('string');
-                    expect(res.body.message).to.equal('Invalid username or password');
+                    expect(res.body.message).to.equal('Unauthorized');
                 });
         });
 
@@ -112,7 +128,7 @@ describe('Http.Api.Login', function () {
                 .expect(UNAUTHORIZED_STATUS)
                 .expect(function(res) {
                     expect(res.body.message).to.be.a('string');
-                    expect(res.body.message).to.equal('Invalid username or password');
+                    expect(res.body.message).to.equal('Unauthorized');
                 });
         });
 

--- a/spec/lib/api/redfish-1.0/session-service-spec.js
+++ b/spec/lib/api/redfish-1.0/session-service-spec.js
@@ -42,7 +42,7 @@ describe('Redfish Session Service', function () {
             sinon.stub(waterline.localusers, 'findOne');
             waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
                 username: 'admin',
-                comparePassword: function(password) { return password === 'admin123' }
+                comparePassword: function(password) { return password === 'admin123'; }
             });
             waterline.localusers.findOne.resolves();
 

--- a/spec/lib/api/redfish-1.0/session-service-spec.js
+++ b/spec/lib/api/redfish-1.0/session-service-spec.js
@@ -39,6 +39,12 @@ describe('Redfish Session Service', function () {
             waterline = helper.injector.get('Services.Waterline');
             sinon.stub(waterline.graphobjects);
             sinon.stub(waterline.nodes);
+            sinon.stub(waterline.localusers, 'findOne');
+            waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
+                username: 'admin',
+                comparePassword: function(password) { return password === 'admin123' }
+            });
+            waterline.localusers.findOne.resolves();
 
             Promise = helper.injector.get('Promise');
 
@@ -87,6 +93,7 @@ describe('Redfish Session Service', function () {
 
         restoreStubs(waterline.graphobjects);
         restoreStubs(waterline.nodes);
+        waterline.localusers.findOne.restore();
         return helper.stopServer();
     });
 

--- a/spec/lib/services/auth-service-spec.js
+++ b/spec/lib/services/auth-service-spec.js
@@ -90,11 +90,11 @@ describe('Auth.Service', function () {
         waterline = helper.injector.get('Services.Waterline');
         waterline.localusers = {
             findOne: sinon.stub()
-        }
+        };
         waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
-                username: 'admin',
-                comparePassword: function(password) { return password === 'admin123' }
-            });
+            username: 'admin',
+            comparePassword: function(password) { return password === 'admin123'; }
+        });
         waterline.localusers.findOne.resolves();
     });
 

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -2115,6 +2115,14 @@ paths:
             the user has been created
           schema:
             type: object
+        401:
+          description: Unauthorized
+          schema:
+            type: object
+        403:
+          description: Forbidden
+          schema:
+            type: object
         default:
           description: Unexpected error
           schema:
@@ -2136,9 +2144,17 @@ paths:
             $ref: '#/definitions/user_obj'
       tags: [ "/api/2.0" ]
       responses:
-        201:
+        200:
           description: |
-            the user has been created
+            the user has been updated
+          schema:
+            type: object
+        401:
+          description: Unauthorized
+          schema:
+            type: object
+        403:
+          description: Forbidden
           schema:
             type: object
         default:

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -44,6 +44,8 @@ paths:
     x-swagger-router-controller: pollers
     get:
       operationId: pollersLibGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of possible library pollers
       description: |
@@ -63,6 +65,8 @@ paths:
     x-swagger-router-controller: pollers
     get:
       operationId: pollersLibByIdGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get a single library poller
       description: |
@@ -95,6 +99,8 @@ paths:
     get:
       x-swagger-serializer: pollers
       operationId: pollersGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of all pollers
       description: |
@@ -113,6 +119,8 @@ paths:
     post:
       x-swagger-deserializer: pollers
       operationId: pollersPost
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         create a poller
       description: |
@@ -140,6 +148,8 @@ paths:
     get:
       x-swagger-serializer: pollers
       operationId: pollersIdGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Get specifics of the specified poller
       description: |
@@ -170,6 +180,8 @@ paths:
     patch:
       x-swagger-deserializer: pollers
       operationId: pollersPatch
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         patch specifics of the specified poller
       description: |
@@ -205,6 +217,8 @@ paths:
             $ref: '#/definitions/Error'
     delete:
       operationId: pollersDelete
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         delete the specified poller
       description: |
@@ -234,6 +248,8 @@ paths:
     x-swagger-router-controller: pollers
     get:
       operationId: pollersDataGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Get data for the specific poller
       description: |
@@ -265,6 +281,8 @@ paths:
     x-swagger-router-controller: pollers
     get:
       operationId: pollersCurrentDataGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Get latest data for the specific poller
       description: |
@@ -297,6 +315,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of possible templates
       description: |
@@ -316,6 +336,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get a single template
       description: |
@@ -345,6 +367,8 @@ paths:
             $ref: '#/definitions/Error'
     put:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         put a single template
       description: |
@@ -377,6 +401,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of skus
       description: |
@@ -394,6 +420,8 @@ paths:
             $ref: '#/definitions/Error'
     post:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         create a sku
       description: |
@@ -418,6 +446,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get a single sku
       description: |
@@ -447,6 +477,8 @@ paths:
             $ref: '#/definitions/Error'
     patch:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         patch a single sku
       description: |
@@ -481,6 +513,8 @@ paths:
             $ref: '#/definitions/Error'
     delete:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Delete specific sku.
       description: |
@@ -512,6 +546,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get nodes for specific sku
       description: |
@@ -544,6 +580,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of possible profiles
       description: |
@@ -563,6 +601,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get a single profile
       description: |
@@ -592,6 +632,8 @@ paths:
             $ref: '#/definitions/Error'
     put:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         put a single profile
       description: |
@@ -625,6 +667,8 @@ paths:
     get:
       x-swagger-serializer: obms
       operationId: getObmLib
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of possible OBM services
       description: |
@@ -645,6 +689,8 @@ paths:
     get:
       x-swagger-serializer: obms
       operationId: getObmLibById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get a single OBM service
       description: |
@@ -677,6 +723,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         List all workflows available to run
       description: |
@@ -697,6 +745,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch tasks from task library
       description: |
@@ -714,6 +764,8 @@ paths:
             $ref: '#/definitions/Error'
     put:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Add tasks to task library
       description: |
@@ -738,6 +790,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch workflows
       description: |
@@ -755,6 +809,8 @@ paths:
             $ref: '#/definitions/Error'
     put:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         define new workflow
       description: |
@@ -780,6 +836,8 @@ paths:
     x-swagger-router-controller: nodes
     get:
       operationId: nodesGetActiveWorkflowById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch currently running workflows for specified node
       description: |
@@ -810,6 +868,8 @@ paths:
             $ref: '#/definitions/Error'
     delete:
       operationId: nodesDelActiveWorkflowById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Cancel currently running workflows for specified node
       description: |
@@ -843,6 +903,8 @@ paths:
     x-swagger-router-controller: nodes
     get:
       operationId: nodesGetWorkflowById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch all workflows for specified node
       description: |
@@ -873,6 +935,8 @@ paths:
             $ref: '#/definitions/Error'
     post:
       operationId: nodesPostWorkflowById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         create workflow for specified node
       description: |
@@ -925,6 +989,8 @@ paths:
     x-swagger-router-controller: nodes
     get:
       operationId: nodesGetPollersById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch all pollers for specified node
       description: |
@@ -958,6 +1024,8 @@ paths:
     x-swagger-router-controller: nodes
     get:
       operationId: nodesGetCatalogSourceById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch catalog of specified node for given source
       description: |
@@ -998,6 +1066,8 @@ paths:
     x-swagger-router-controller: nodes
     get:
       operationId: nodesGetCatalogById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch catalog of specified node
       description: |
@@ -1031,6 +1101,8 @@ paths:
     x-swagger-router-controller: nodes
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Fetch status of identify light on node through OBM (if supported)
       description: |
@@ -1060,6 +1132,8 @@ paths:
             $ref: '#/definitions/Error'
     post:
       operationId: nodesPostObmIdById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Enable or disable identify light on node through OBM (if supported)
       description: |
@@ -1098,6 +1172,8 @@ paths:
       x-swagger-serializer: nodes
       # swagger template and schema names (not sure how to get schema in fitting)...
       operationId: nodesGetObmById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get the obm settings associated with a node.
       description: |
@@ -1129,6 +1205,8 @@ paths:
       x-swagger-deserializer: nodes
       # swagger template and schema names (not sure how to get schema in fitting)...
       operationId: nodesPostObmById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         set the obm settings associated with a node.
       description: |
@@ -1167,6 +1245,8 @@ paths:
       x-swagger-serializer: nodes
       # swagger template and schema names (not sure how to get schema in fitting)...
       operationId: nodesGetById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         List of all nodes or if there are none an empty object
       description: |
@@ -1197,6 +1277,8 @@ paths:
             $ref: '#/definitions/Error'
     delete:
       operationId: nodesDelById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Delete specified node.
       description: |
@@ -1225,6 +1307,8 @@ paths:
       x-swagger-deserializer: nodes
       # swagger template and schema names (not sure how to get schema in fitting)...
       operationId: nodesPatchById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Patch specified node
       description: |
@@ -1262,6 +1346,8 @@ paths:
     x-swagger-router-controller: nodes
     get:
       operationId: nodesGetTagsById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         List of all tags on the node or an empty object if there are none
       description: |
@@ -1291,6 +1377,8 @@ paths:
             $ref: '#/definitions/Error'
     patch:
       operationId: nodesPatchTagById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Patch tags onto specified node
       description: |
@@ -1327,6 +1415,8 @@ paths:
     x-swagger-router-controller: nodes
     delete:
       operationId: nodesDelTagById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         Delete a tag from the specified node.
       description: |
@@ -1360,6 +1450,8 @@ paths:
     get:
       x-swagger-serializer: nodes
       operationId: nodesGetAll
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         List of all nodes or if there are none an empty object
       description: |
@@ -1384,6 +1476,8 @@ paths:
       x-swagger-deserializer: nodes
       # swagger template and schema names (not sure how to get schema in fitting)...
       operationId: nodesPost
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         post
       description: |
@@ -1412,6 +1506,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         find all
       description: |
@@ -1430,6 +1526,8 @@ paths:
             $ref: '#/definitions/Error'
     post:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         find all
       description: |
@@ -1455,6 +1553,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         lookup id
       description: |
@@ -1479,6 +1579,8 @@ paths:
             $ref: '#/definitions/Error'
     post:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         post id
       description: |
@@ -1509,6 +1611,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get file based on uuid
       description: |
@@ -1542,6 +1646,8 @@ paths:
             $ref: '#/definitions/Error'
     put:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         put file based on filename
       description: |
@@ -1581,6 +1687,8 @@ paths:
             $ref: '#/definitions/Error'
     delete:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         delete file based on uuid
       description: |
@@ -1612,6 +1720,8 @@ paths:
     x-swagger-router-controller: config
     get:
       operationId: getConfig
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get server configuration
       description: |
@@ -1628,6 +1738,8 @@ paths:
             $ref: '#/definitions/Error'
     patch:
       operationId: patchConfig
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         patch/update server configuration
       description: |
@@ -1655,6 +1767,8 @@ paths:
     x-swagger-router-controller: catalogs
     get:
       operationId: getCatalog
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of all catalogs
       description: |
@@ -1682,6 +1796,8 @@ paths:
     x-swagger-router-controller: catalogs
     get:
       operationId: getCatalogById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get list of all catalogs
       description: |
@@ -1709,6 +1825,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         get DHCP lease table
       description: |
@@ -1728,6 +1846,8 @@ paths:
     x-swagger-router-controller: unimplemented
     get:
       operationId: unimplemented
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         fetch lease information for the mac specified
       description: |
@@ -1750,6 +1870,8 @@ paths:
           description: NotFound error
     delete:
       operationId: unimplemented
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: get list of all catalogs
       description: |
         Delete the lease for the mac specified and return information about deleted lease.
@@ -1773,6 +1895,8 @@ paths:
     x-swagger-router-controller: tags
     get:
       operationId: getAllTags
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: Retrieve information about all tags
       description: |
         Retrieve information about all tags
@@ -1796,6 +1920,8 @@ paths:
             $ref: '#/definitions/Error'
     post:
       operationId: createTag
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: Create a new tag
       description: |
         Create a new tag
@@ -1826,6 +1952,8 @@ paths:
     x-swagger-router-controller: tags
     get:
       operationId: getTag
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: Retrieve information about the tag
       description: |
         Retrieve information about the tag
@@ -1853,6 +1981,8 @@ paths:
             $ref: '#/definitions/Error'
     delete:
       operationId: deleteTag
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: Delete the specified tag
       description: |
         Delete the specified tag
@@ -1882,6 +2012,8 @@ paths:
     x-swagger-router-controller: tags
     get:
       operationId: getNodesByTag
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
       summary: Retrieve nodes with the specified tag
       description: |
         Retrieve nodes with the specified tag
@@ -1914,6 +2046,8 @@ paths:
     x-swagger-router-controller: tags
     post:
       operationId: postWorkflowById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
       summary: |
         create workflow for nodes with the specified tag
       description: |
@@ -1957,7 +2091,60 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-
+  /users:
+    x-swagger-router-controller: users
+    post:
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt', 'anonymous' ]
+      operationId: addUser
+      summary: |
+        Add a new user
+      description: |
+        Add a new user
+      parameters:
+        - name: body
+          in: body
+          description: User information
+          required: true
+          schema:
+            $ref: '#/definitions/user_obj'
+      tags: [ "/api/2.0" ]
+      responses:
+        201:
+          description: |
+            the user has been created
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      x-privileges: [ 'ConfigureUsers', 'ConfigureSelf' ]
+      x-authentication-type: [ 'jwt' ]
+      operationId: modifyUser
+      summary: |
+        Update properties on a user
+      description: |
+        Update properties on a user
+      parameters:
+        - name: body
+          in: body
+          description: User information
+          required: true
+          schema:
+            $ref: '#/definitions/user_obj'
+      tags: [ "/api/2.0" ]
+      responses:
+        201:
+          description: |
+            the user has been created
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /swagger:
     x-swagger-pipe: swagger_raw
 
@@ -2119,3 +2306,15 @@ definitions:
 
   generic_obj:
    type: object
+
+  user_obj:
+    properties:
+      username:
+        type: string
+      password:
+        type: string
+      role:
+        type: string
+    required:
+      - username
+      - password

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -24,6 +24,8 @@ paths:
   /:
     x-swagger-router-controller: service-root
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic', 'anonymous' ]
       summary: retrieve list of root-level resources 
       description: >
         This object represents the root Redfish service.  All values for resources described 
@@ -49,6 +51,8 @@ paths:
   /Chassis:
     x-swagger-router-controller: chassis
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of physical components
       description: >
         Defines a collection of physical components managed by the service
@@ -72,6 +76,8 @@ paths:
   /Chassis/{identifier}:
     x-swagger-router-controller: chassis
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve specific information for a physical component
       description: >
         Retrieves a detailed information catalog for the physical component 
@@ -101,6 +107,8 @@ paths:
   /Chassis/{identifier}/Thermal:
     x-swagger-router-controller: chassis
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: Retrieve thermal characteristics of a chassis
       description: >
         defines a collection of thermal elements contained within a resource.
@@ -129,6 +137,8 @@ paths:
   /Chassis/{identifier}/Power:
     x-swagger-router-controller: chassis
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: Retrieve power characteristics of a chassis
       description: >
         defines a collection of power elements contained within a resource.
@@ -157,6 +167,8 @@ paths:
   /Systems:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of computer systems
       description: retrieve list of computer systems
       operationId: listSystems
@@ -179,6 +191,8 @@ paths:
   /Systems/{identifier}:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve information for a specific computer systems (physical and/or virtual)
       description: >
         defines a computer system and its respective properties.  A computer system represents a 
@@ -212,6 +226,8 @@ paths:
   /Systems/{identifier}/Processors:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve the processor collection for the specified system identifier
       description: >
         defines a collection of processors contained within a resource.
@@ -242,6 +258,8 @@ paths:
   /Systems/{identifier}/Processors/{socket}:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve a specified processor for the specified system identifier
       description: >
         This represents the properties of a processor attached to a System.
@@ -276,6 +294,8 @@ paths:
   /Systems/{identifier}/SimpleStorage:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve the simple storage collection
       description: >
         Defines a collection of simple storage collections that are
@@ -307,6 +327,8 @@ paths:
   /Systems/{identifier}/SimpleStorage/{index}:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: Retrieve the simple storage collection by device identifier
       description: >
         Defines a collection of storage devices on the device specified by
@@ -342,6 +364,8 @@ paths:
   /Systems/{identifier}/LogServices:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of the logs for a computer system
       description: >
         Defines a collection of log services that are available for the system
@@ -373,6 +397,8 @@ paths:
   /Systems/{identifier}/LogServices/sel:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of the logs for a computer system
       description: >
         Defines a collection of SEL entries for the system described by
@@ -404,6 +430,8 @@ paths:
   /Systems/{identifier}/LogServices/sel/Entries:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of the logs entries for associated for log service
       description: >
         Defines a collection of entries for the system described by identifier
@@ -434,6 +462,8 @@ paths:
   /Systems/{identifier}/LogServices/sel/Entries/{entryId}:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve log entry by logId associated for log service
       description: >
         Defines a log entry specified by entryId within the LogService of the
@@ -469,6 +499,8 @@ paths:
   /Systems/{identifier}/Actions/ComputerSystem.Reset:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve the list of reset types for the specified compute node
       description: >
         Retrieve  a list of valid reset types for the system described by identifier
@@ -497,6 +529,8 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
     post:
+      x-privileges: [ 'ConfigureComponents' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: reset a node
       description: >
         Perform the reset specified in the post data arguments on the system
@@ -532,6 +566,8 @@ paths:
   /Systems/{identifier}/Actions/RackHD.BootImage:
     x-swagger-router-controller: systems
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve the list of boot image types for the specified compute node
       description: >
         Retrieve  a list of valid boot image types for the system described by identifier
@@ -560,6 +596,8 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
     post:
+      x-privileges: [ 'ConfigureComponents' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: install a boot image on a node
       description: >
         Perform the boot image installation specified in the post data arguments on 
@@ -596,6 +634,8 @@ paths:
   /AccountService:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'ConfigureUsers' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve account service information
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -613,6 +653,8 @@ paths:
   /EventService:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of policies used by event service listeners
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -630,6 +672,8 @@ paths:
   /ManagerAccounts:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'ConfigureManager' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of manager accounts
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -653,6 +697,8 @@ paths:
   /ManagerAccounts/{identifier}:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'ConfigureManager' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve a manager account by name
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -681,6 +727,8 @@ paths:
   /Managers:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'ConfigureManager' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of management servers
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -704,6 +752,8 @@ paths:
   /Managers/{identifier}:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'ConfigureManager' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of management servers
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -732,6 +782,8 @@ paths:
   /Registries:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: Unspecified
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -749,6 +801,8 @@ paths:
   /Roles:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'ConfigureUsers' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of roles for use in ManagerAccounts
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -772,6 +826,8 @@ paths:
   /Roles/{identifier}:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'ConfigureUsers' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve a manager account role by name
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -800,6 +856,7 @@ paths:
   /Schemas:
     x-swagger-router-controller: unimplemented
     get:
+      x-privileges: [ 'Login' ]
       summary: Unspecified
       operationId: unimplemented
       tags: [ "/redfish/v1" ]
@@ -817,6 +874,8 @@ paths:
   /SessionService:
     x-swagger-router-controller: session-service
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve a list of sessions
       operationId: getSessionService
       tags: [ "/redfish/v1" ]
@@ -840,6 +899,8 @@ paths:
   /SessionService/Sessions:
     x-swagger-router-controller: session-service
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve a sessions description
       operationId: getSessions
       tags: [ "/redfish/v1" ]
@@ -861,6 +922,7 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
     post:
+      x-privileges: [ 'Login' ]
       summary: create a new session
       operationId: postSession
       tags: [ "/redfish/v1" ]
@@ -890,6 +952,8 @@ paths:
   /SessionService/Sessions/{identifier}:
     x-swagger-router-controller: session-service
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve session information
       operationId: getSessionInfo
       tags: [ "/redfish/v1" ]
@@ -916,6 +980,8 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
     delete:
+      x-privileges: [ 'ConfigureSelf' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: logout of the session
       operationId: doLogoutSession
       tags: [ "/redfish/v1" ]
@@ -945,6 +1011,8 @@ paths:
   /TaskService:
     x-swagger-router-controller: task-service
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of all tasks
       description: This object represents the root Redfish service.
       operationId: taskServiceRoot
@@ -969,6 +1037,8 @@ paths:
   /TaskService/Tasks:
     x-swagger-router-controller: task-service
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of all tasks
       description: This object represents the root Redfish service.
       operationId: listTasks
@@ -993,6 +1063,8 @@ paths:
   /TaskService/Tasks/{identifier}:
     x-swagger-router-controller: task-service
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve a task entry by task Id
       description: This object represents the root Redfish service.
       operationId: getTask
@@ -1022,6 +1094,8 @@ paths:
   /TaskService/Oem/Tasks/{identifier}:
     x-swagger-router-controller: task-service
     get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve list of tasks per system Id
       description: This object represents the root Redfish service.
       operationId: getSystemTasks

--- a/swagger_config/default.yaml
+++ b/swagger_config/default.yaml
@@ -40,6 +40,8 @@ swagger:
       - onError: json_error_handler
       - cors
       - swagger_params_parser
+      - swagger_authn
+      - swagger_authz
       - swagger_security
       - _swagger_validate
       - express_compatibility


### PR DESCRIPTION
- Fittings are created to enable authn (using x-authentication-type) and
  authz (using x-privileges) on a per-method basis defined within the
  swagger file
- ACL service is created as an interface to node_acl.  The ACL service
  contains the mappings of users to roles, and roles to privileges.
- A /users route is added to 2.0 to enable a starting point for a user
  management API.  Initially POST and PUT are supported to create and update
  users.  A local user exception is added to permit a localhost connection to
  add the first user into the database when authentication is enabled and no
  users exist yet.
- The authentication service is refactored to remove the hardcoded default
  username/password and to remove decryptable passwords.  Bcrypt is used
  instead for 1-way password hashing.