### PR TITLE
Add swagger query parser

### DIFF
--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -35,6 +35,22 @@ function swaggerFactory(
         return err;
     }
 
+    function _parseQuery(params) {
+        return _(params)
+        .pick(function(param) {
+            if (param.parameterObject) {
+                return param.parameterObject.in === 'query';
+            }
+            return false;
+        })
+        .mapValues(function(param) {
+            if (typeof(param.value) === 'string' && param.value.match(/\+/)) {
+                return param.value.split(/\+/);
+            }
+            return param.value;
+        }).value();
+    }
+
     function swaggerController(options, callback) {
         if (typeof options === 'function') {
             callback = options;
@@ -43,6 +59,7 @@ function swaggerFactory(
         return function(req, res, next) {
             req.swagger.options = options;
             return Promise.resolve().then(function() {
+                req.swagger.query = _parseQuery(req.swagger.params);
                 return callback(req, res);
             }).then(function(result) {
                 if (!res.headersSent) {

--- a/spec/lib/services/swagger-api-service-spec.js
+++ b/spec/lib/services/swagger-api-service-spec.js
@@ -64,6 +64,52 @@ describe('Services.Http.Swagger', function() {
             });
         });
 
+        it('should process query', function() {
+            var req = {
+                swagger: {
+                    params: {
+                        firstName: {
+                            parameterObject: { in: 'query'  },
+                            value: 'Rack'
+                        },
+                        lastName: {
+                            parameterObject: { in: 'query' },
+                            value: 'HD'
+                        },
+                        middleName: {
+                            parameterObject: { in: 'query' },
+                            value:'John+Paul+George'
+                        },
+                        inBody: {
+                            parameterObject: { in: 'body' },
+                            value: 'no a query'
+                        }
+                    }
+                }
+            };
+            var res = {
+                headersSent: false
+            };
+            var mockData = {data: 'mock data'};
+            var optController = swaggerService.controller({success: 201}, mockController);
+
+            expect(optController).to.be.a('function');
+            mockController.resolves(mockData);
+            return optController(req, res, mockNext).then(function() {
+                expect(res.body).to.equal(mockData);
+                expect(mockNext).to.be.called.once;
+                expect(req.swagger.query).to.have.property('firstName')
+                    .and.to.equal('Rack');
+                expect(req.swagger.query).to.have.property('lastName')
+                    .and.to.equal('HD');
+                expect(req.swagger.query).to.have.property('middleName')
+                    .and.to.deep.equal(['John', 'Paul', 'George']);
+                expect(req.swagger.query).not.to.have.property('inBody');
+                expect(req.swagger.options).to.have.property('success')
+                    .and.to.equal(201);
+            });
+        });
+
         it('should not call next after sending headers', function() {
             var req = { swagger: {} };
             var res = {


### PR DESCRIPTION
Add parser for swagger query parameter objects.  Only queries explicitly added as parameters in swagger.yaml will be parsed.  No routes support queries yet; this work will be submitted in another PR.

String type queries can be logically ORed by seperating them with a '+'.  For example, ?name='John+George' matches resources with name=John or name=George.