### PR TITLE
Support default ipxe bootSettings

### DIFF
--- a/data/profiles/defaultboot.ipxe
+++ b/data/profiles/defaultboot.ipxe
@@ -1,0 +1,4 @@
+kernel <%=url%>/<%=kernel%>
+initrd <%=url%>/<%=initrd%>
+imgargs <%=kernel%> <%=bootargs%>
+boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -49,7 +49,7 @@ function profilesRouterFactory (
                     if (node.newRecord) {
                         presenter(req, res).renderProfile('redirect.ipxe');
                     } else {
-                        return profileApiService.renderProfileFromTask(node)
+                        return profileApiService.renderProfileFromTaskOrNode(node)
                         .then(function (render) {
                             presenter(req, res).renderProfile(render.profile, render.options);
                         });

--- a/lib/serializables/v1/boot.js
+++ b/lib/serializables/v1/boot.js
@@ -1,0 +1,46 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = BootFactory;
+
+di.annotate(BootFactory, new di.Provide('Serializables.V1.Boot'));
+di.annotate(BootFactory,
+    new di.Inject(
+        'Promise',
+        'Serializable'
+    )
+);
+
+function BootFactory (
+    Promise,
+    Serializable
+) {
+    function Boot (defaults) {
+        Serializable.call(
+            this,
+            Boot.schema,
+            defaults
+        );
+    }
+
+    Boot.schema = {
+        id: 'Serializables.V1.Boot',
+        type: 'object',
+        properties: {
+            profile: {
+                type: 'string'
+            },
+            options: {
+                type: 'object'
+            }
+        },
+        required: [ 'profile', 'options' ]
+    };
+
+    Serializable.register(BootFactory, Boot);
+
+    return Boot;
+}

--- a/lib/serializables/v1/node.js
+++ b/lib/serializables/v1/node.js
@@ -55,6 +55,12 @@ function NodeFactory (
                 items: {
                     $ref: 'Serializables.V1.Snmp'
                 }
+            },
+            bootSettings: {
+                type: 'object',
+                items: {
+                    $ref: 'Serializables.V1.Boot'
+                }
             }
         },
         required: [ 'name' ]

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -173,7 +173,7 @@ function profileApiServiceFactory(
         .catch(retryRequestProperties);
     };
 
-    ProfileApiService.prototype.renderProfileFromTask = function(node) {
+    ProfileApiService.prototype.renderProfileFromTaskOrNode = function(node) {
         var self = this;
         return workflowApiService.findActiveGraphForTarget(node.id)
         .then(function (taskgraphInstance) {
@@ -202,12 +202,30 @@ function profileApiServiceFactory(
                     };
                 });
             } else {
-                return {
-                    profile: 'error.ipxe',
-                    options: {
-                        error: 'Unable to locate active workflow.'
+                if (_.has(node, 'bootSettings')) {
+                    if (_.has(node.bootSettings, 'options') &&
+                            _.has(node.bootSettings, 'profile')) {
+                        return {
+                            profile: node.bootSettings.profile,
+                            options: node.bootSettings.options
+                        };
+                    } else {
+                        return {
+                            profile: 'error.ipxe',
+                            options: {
+                                error: 'Unable to retrieve node bootSettings.'
+                            }
+                        };
                     }
-                };
+                }
+                else {
+                    return {
+                        profile: 'error.ipxe',
+                        options: {
+                            error: 'Unable to locate active workflow or there is no bootSettings.'
+                        }
+                    };
+                }
             }
         });
     };

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -175,4 +175,99 @@ describe("Http.Services.Api.Profiles", function () {
             expect(profileApiService.waitForDiscoveryStart).to.have.been.calledWith(node.id);
         });
     });
+
+    describe("renderProfile", function() {
+
+        it("render profile fail when no active graph and cannot get node bootSettings", function() {
+            var node = { id: 'test' , bootSettings: {} };
+
+            var bootSettingsFailure = {
+                profile: 'error.ipxe',
+                options: {
+                    error: 'Unable to retrieve node bootSettings.'
+                }
+            };
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
+
+            return profileApiService.renderProfileFromTaskOrNode(node)
+            .then(function(result) {
+                expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
+                expect(taskProtocol.requestProperties).to.not.be.called;
+                expect(result).to.deep.equal(bootSettingsFailure);
+            });
+        });
+
+        it("render profile pass when no active graphs and node has bootSettings", function() {
+            var node = { id: 'test' , bootSettings: { profile: 'profile', options: "options" } };
+
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
+
+            return profileApiService.renderProfileFromTaskOrNode(node)
+            .then(function(result) {
+                expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
+                expect(taskProtocol.requestProperties).to.not.be.called;
+                expect(result).to.deep.equal(node.bootSettings);
+            });
+        });
+
+        it("render profile fail due to no active graph or there is not bootSettings", function() {
+            var node = { id: 'test' };
+            var activeGraphFailure = {
+                profile: 'error.ipxe',
+                options: {
+                    error: 'Unable to locate active workflow or there is no bootSettings.'
+                }
+            };
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
+
+            return profileApiService.renderProfileFromTaskOrNode(node)
+            .then(function(result) {
+                expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
+                expect(taskProtocol.requestProperties).to.not.be.called;
+                expect(result).to.deep.equal(activeGraphFailure);
+            });
+        });
+
+        it("render profile pass when having active graph and render succeed", function() {
+            var node = { id: 'test' };
+
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(true);
+            this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves('properties');
+
+            return profileApiService.renderProfileFromTaskOrNode(node)
+            .then(function(result) {
+                expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
+                expect(taskProtocol.requestProfile).to.have.been.calledOnce;
+                expect(taskProtocol.requestProperties).to.have.been.calledOnce;
+                expect(result).to.deep.equal({ profile: 'profile', options: 'properties'});
+            });
+        });
+
+        it("render profile fail when retrieve workflow properties fail", function() {
+            var node = { id: 'test' };
+            var retrieveProperitesFailure = {
+                profile: 'error.ipxe',
+                options: {
+                    error: 'Unable to retrieve workflow properties.'
+                }
+            };
+
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(true);
+            this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
+            this.sandbox.stub(taskProtocol, 'requestProperties').rejects(new Error(''));
+
+            return profileApiService.renderProfileFromTaskOrNode(node)
+            .then(function(result) {
+                expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
+                expect(taskProtocol.requestProfile).to.have.been.calledOnce;
+                expect(taskProtocol.requestProperties).to.have.been.calledOnce;
+                expect(result).to.deep.equal(retrieveProperitesFailure);
+            });
+        });
+
+    });
 });

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -199,7 +199,7 @@ describe("Http.Services.Api.Profiles", function () {
         });
 
         it("render profile pass when no active graphs and node has bootSettings", function() {
-            var node = { id: 'test' , bootSettings: { profile: 'profile', options: "options" } };
+            var node = { id: 'test' , bootSettings: { profile: 'profile', options: {} } };
 
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
             this.sandbox.stub(taskProtocol, 'requestProperties').resolves();

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -236,14 +236,14 @@ describe("Http.Services.Api.Profiles", function () {
 
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(true);
             this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
-            this.sandbox.stub(taskProtocol, 'requestProperties').resolves('properties');
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
 
             return profileApiService.renderProfileFromTaskOrNode(node)
             .then(function(result) {
                 expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
                 expect(taskProtocol.requestProfile).to.have.been.calledOnce;
                 expect(taskProtocol.requestProperties).to.have.been.calledOnce;
-                expect(result).to.deep.equal({ profile: 'profile', options: 'properties'});
+                expect(result).to.deep.equal({ profile: 'profile', options: { kargs: null }});
             });
         });
 


### PR DESCRIPTION
resolve https://github.com/RackHD/RackHD/issues/104

related PR　https://github.com/RackHD/on-dhcp-proxy/pull/29

@RackHD/rackhd_dev @RackHD/corecommitters @ytjohn 

a brief usage is below, details will be in another PR for RackHD/docs
run PATCH method to node to apply default ipxe boot setting, the fileds 'profile','option' is must required, 'profile'  could be customized, the fields in 'options' should be the same with the parameters in customized profile.  a default profile 'defaultboot.ipxe' is provided for convenience.
```
$ curl -X PATCH -H "Content-Type: application/json" --data @boot.json http://localhost:8080/api/common/nodes/{identifer}
```
a example of boot.json  is below:
```
{
    "bootSettings":{
        "profile":"defaultboot.ipxe",
        "options":{
            "url":"http://172.31.128.1:9080/common",
            "kernel":"vmlinuz-3.13.0-32-generic",
            "initrd":"initrd.img-3.13.0-32-generic",
            "bootargs":"console=tty0 console=ttyS0,115200n8"
        }
    }
}
```