### PR TITLE
use 'repo' as base_url in profile for CoreOS

### DIFF
--- a/data/profiles/install-coreos.ipxe
+++ b/data/profiles/install-coreos.ipxe
@@ -5,6 +5,6 @@ set base-url <%=repo%>
 # JUST BOOT AND RUN COREOS
 # kernel ${base-url}/coreos_production_pxe.vmlinuz coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/pxe-cloud-config.yml
 #
-kernel ${base-url}/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/install-coreos.sh
-initrd ${base-url}/coreos_production_pxe_image.cpio.gz
+kernel ${base-url}/current/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/install-coreos.sh
+initrd ${base-url}/current/coreos_production_pxe_image.cpio.gz
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/profiles/install-coreos.ipxe
+++ b/data/profiles/install-coreos.ipxe
@@ -5,6 +5,6 @@ set base-url <%=repo%>
 # JUST BOOT AND RUN COREOS
 # kernel ${base-url}/coreos_production_pxe.vmlinuz coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/pxe-cloud-config.yml
 #
-kernel ${base-url}/current/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/install-coreos.sh
-initrd ${base-url}/current/coreos_production_pxe_image.cpio.gz
+kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/install-coreos.sh
+initrd ${base-url}/<%=version%>/coreos_production_pxe_image.cpio.gz
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/templates/install-coreos.sh
+++ b/data/templates/install-coreos.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 curl -O http://<%=server%>:<%=port%>/api/common/templates/pxe-cloud-config.yml
 sudo coreos-install -d <%=installDisk%> -c pxe-cloud-config.yml -b <%=repo%>
 sudo reboot


### PR DESCRIPTION
 - partial resolution to https://github.com/RackHD/RackHD/issues/146 and
   include 'current' in profile explicitly so we can use <%repo%> in the
   rendered install template correctly.
 - requires a change to the configuration in RackHD proxies to fully operate (https://github.com/RackHD/RackHD/pull/147)
 - additionally requires https://github.com/RackHD/on-tasks/pull/147 for a default 'version' for CoreOS install task