### PR TITLE
Add /tasks route to 2.0 API

### DIFF
--- a/lib/api/2.0/tasks.js
+++ b/lib/api/2.0/tasks.js
@@ -1,0 +1,54 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var tasksApiService = injector.get('Http.Services.Api.Tasks');
+var taskProtocol = injector.get('Protocol.Task');
+var Errors = injector.get('Errors');
+var presenter = injector.get('common-api-presenter');
+
+function getBootstrap (req, res) {
+    tasksApiService.getNode(req.swagger.params.macAddress.value)
+        .then(function (node) {
+             if (node) {
+                presenter(req, res)
+                    .renderTemplate(
+                        'bootstrap.js',
+                        {
+                            identifier: node.id
+                        }
+                    );
+            } else {
+                presenter(req, res).renderNotFound();
+            }
+        })
+        .catch(function (err) {
+            presenter(req, res).renderError(err);
+        });
+}
+
+var getTasksById = controller( {send204OnEmpty:true}, function (req){
+    return tasksApiService.getTasks(req.swagger.params.identifier.value)
+    .catch(function (err) {
+        if (err.name === 'NoActiveTaskError') {
+            //Return with no data, this will cause a 204 to be sent
+            return;
+        }
+        // throw a NotFoundError
+        throw new Errors.NotFoundError('Not Found');
+    });
+});
+
+var postTaskById = controller( {success: 201}, function (req){
+    return taskProtocol.respondCommands(
+        req.swagger.params.identifier.value,
+        req.swagger.params.body.raw);
+});
+
+module.exports = {
+    getBootstrap: getBootstrap,
+    getTasksById: getTasksById,
+    postTaskById: postTaskById
+};

--- a/lib/fittings/swagger_render.js
+++ b/lib/fittings/swagger_render.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var injector = require('../../index.js').injector;
+var _ = injector.get('_');
 
 module.exports = function create(fittingDef) {
     var swag = injector.get('Http.Services.Swagger');
@@ -13,11 +14,16 @@ module.exports = function create(fittingDef) {
             var operation = context.request.swagger.operation;
             var template = operation[templateNameKey];
             if (template === undefined) {
+                if (_.isEmpty(context.response.body) &&
+                    context.request.swagger.options.send204OnEmpty )
+                {
+                    status = 204;
+                }
                 context.response.status(status).json(context.response.body);
             } else {
-                swag.renderer(template, context.response.body, next)
+                swag.renderer(template, context.request.swagger.options.rendererOptions, next)
                 .then(function (renderedOutput) {
-                    context.response.status(status).json(renderedOutput);
+                    context.response.status(status).send(renderedOutput);
                 });
             }
         }

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -149,9 +149,20 @@ function httpServiceFactory(
             authEnabled: this.endpoint.authEnabled
         };
 
+        //todo: make this configurable vis endpoint
+        var sbSwaggerConfig = {
+            appRoot: path.resolve(__dirname, '../../'),
+            configDir: path.resolve(__dirname, '../../swagger_config'),
+            swagger: path.resolve(__dirname, '../../static/monorail-2.0-sb.yaml')
+        };
+
         var swaggerCreateAsync = Promise.promisify(swagger.create);
 
         var apiV2 = swaggerCreateAsync(swaggerConfig).then(function(swaggerExpress) {
+            return swaggerExpress.register(app);
+        });
+
+        var sbApiV2 = swaggerCreateAsync(sbSwaggerConfig).then(function(swaggerExpress) {
             return swaggerExpress.register(app);
         });
 
@@ -166,7 +177,7 @@ function httpServiceFactory(
             return swaggerExpress.register(app);
         });
 
-        return Promise.all([apiV2, redfish]);
+        return Promise.all([apiV2, sbApiV2, redfish]);
     };
 
     HttpService.prototype._setup =  function() {

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -4,6 +4,7 @@
 
 var di = require('di');
 var util = require('util');
+var ejs = require('ejs');
 
 module.exports = swaggerFactory;
 
@@ -13,8 +14,7 @@ di.annotate(swaggerFactory,
             'Promise',
             '_',
             di.Injector,
-            'Templates',
-            'ejs'
+            'Templates'
         )
     );
 
@@ -22,8 +22,7 @@ function swaggerFactory(
     Promise,
     _,
     injector,
-    templates,
-    ejs
+    templates
 ) {
     function _processError(err) {
         if (!util.isError(err) && err instanceof Object) {
@@ -133,10 +132,7 @@ function swaggerFactory(
                 return template.contents;
             })
             .then(function(contents) {
-                var output = Promise.map(data, function(item) {
-                    return JSON.parse(ejs.render(contents, item));
-                });
-                return output;
+                return ejs.render(contents, data);
             }).catch(function(err) {
                 next(_processError(err));
             });

--- a/spec/lib/api/2.0/tasks-spec.js
+++ b/spec/lib/api/2.0/tasks-spec.js
@@ -1,0 +1,127 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Tasks', function () {
+    var taskProtocol;
+    var tasksApiService;
+    var lookupService;
+    var templates;
+
+    before('start HTTP server', function () {
+        this.timeout(20000);
+        return helper.startServer();
+    });
+
+    beforeEach('set up mocks', function () {
+        taskProtocol = helper.injector.get('Protocol.Task');
+        // Defaults, you can tack on .resolves().rejects().resolves(), etc. like so
+        taskProtocol.activeTaskExists = sinon.stub().resolves();
+        taskProtocol.requestCommands = sinon.stub().resolves({ testcommands: 'cmd' });
+        taskProtocol.respondCommands = sinon.stub();
+
+        tasksApiService = helper.injector.get('Http.Services.Api.Tasks');
+        tasksApiService.getNode = sinon.stub();
+
+        lookupService = helper.injector.get('Services.Lookup');
+        lookupService.ipAddressToMacAddress = sinon.stub().resolves('00:11:22:33:44:55');
+
+        templates = helper.injector.get('Templates');
+
+        return helper.reset();
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    describe('GET /tasks/:id', function () {
+        it("should send down tasks", function() {
+            taskProtocol.activeTaskExists.resolves(null);
+            return helper.request().get('/api/2.0/tasks/testnodeid')
+            .expect(200)
+            .expect(function (res) {
+                expect(res.body).to.deep.equal({ testcommands: 'cmd' });
+            });
+        });
+
+        it("should return 204 if no active task exists", function() {
+            var tasksApiService = helper.injector.get('Http.Services.Api.Tasks');
+            taskProtocol.activeTaskExists.rejects(new tasksApiService.NoActiveTaskError());
+            return helper.request().get('/api/2.0/tasks/testnodeid')
+            .expect(204)
+            .expect(function (res) {
+                expect(res.body).to.be.empty;
+            });
+        });
+
+        it("should error if an active task exists but no commands are sent", function() {
+            taskProtocol.requestCommands.rejects(new Error(''));
+            return helper.request().get('/api/2.0/tasks/testnodeid')
+            .expect(404);
+        });
+
+
+    });
+
+    describe("GET /tasks/bootstrap.js", function() {
+        var stubTemplates;
+
+        before(function() {
+            stubTemplates = sinon.stub(templates, 'get');
+            stubTemplates.withArgs('bootstrap.js').resolves({
+                contents: 'test node id: <%= identifier %>'
+            });
+        });
+
+        after(function() {
+            stubTemplates.restore();
+        });
+
+       it("should render a bootstrap for the node", function() {
+            tasksApiService.getNode.resolves({ id: '123' });
+            return helper.request().get('/api/2.0/tasks/bootstrap.js?macAddress=00:11:22:33:44:55')
+                .expect(200)
+                .expect(function (res) {
+                    expect(tasksApiService.getNode).to.have.been.calledWith('00:11:22:33:44:55');
+                    expect(res.text).to.equal('test node id: 123');
+                });
+        });
+
+        it("should render a 404 if node not found", function() {
+            tasksApiService.getNode.resolves(null);
+            return helper.request()
+                .get('/api/2.0/tasks/bootstrap.js?macAddress=00:11:22:33:44:55')
+                .expect(404);
+        });
+
+        it("should render a 500 if tasksApiService.getNode errors", function() {
+            tasksApiService.getNode.rejects(new Error('asdf'));
+            return helper.request()
+                .get('/api/2.0/tasks/bootstrap.js?macAddress=00:11:22:33:44:55')
+                .expect(500);
+        });
+    });
+
+    describe("POST /tasks/:id", function () {
+        it("should accept a large entity response", function() {
+            function createBigString() {
+                var x = "";
+                for (var i = 0; i < 200000; i+=1) {
+                    x += "1";
+                }
+                return x;
+            }
+
+            var data = { foo: createBigString() };
+
+            return helper.request().post('/api/2.0/tasks/123')
+            .send(data)
+            .expect(function () {
+                expect(taskProtocol.respondCommands).to.have.been.calledWith('123', data);
+            })
+            .expect(201);
+        });
+    });
+});

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -1,0 +1,152 @@
+swagger: "2.0"
+info:
+  version: "0.0.1"
+  title: RackHD 2.0 Southbound
+# during dev, should point to your local machine
+#host: localhost:10010
+# basePath prefixes all resource paths
+basePath: /api/2.0
+#
+schemes:
+  # tip: remove http to make production-grade
+  - http
+  - https
+# format of bodies a client can send (Content-Type)
+consumes:
+  - application/json
+# format of the responses to the client (Accepts)
+produces:
+  - application/json
+tags:
+  - name: "/api/2.0"
+    description: RackHD 2.0 Southbound API
+paths:
+  /tasks/bootstrap.js:
+    x-swagger-router-controller: tasks
+    get:
+#      disable for now until we are using redfish renderer
+#      x-swagger-template: 'bootstrap.js'
+      operationId: getBootstrap
+      summary: |
+        get tasks bootstrap.js
+      description: |
+        used internally by the system - get tasks bootstrap.js
+      parameters:
+        - name: macAddress
+          in: query
+          description: query object to pass through to waterline.
+          required: false
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        "200":
+          description: Success
+          schema:
+            # a pointer to a definition
+            $ref: "#/definitions/VersionsResponse"
+        # responses may fall through to errors
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /tasks/{identifier}:
+    x-swagger-router-controller: tasks
+    get:
+    #do I need a serializer?
+      operationId: getTasksById
+      summary: |
+        get specific task
+      description: |
+        get specific task
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            task identifier
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            single task
+          schema:
+            type: object
+        404:
+          description: |
+            There is no task with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+#do I need a serializer      x-swagger-serializer: pollers
+      operationId: postTaskById
+      summary: |
+        post specific task
+      description: |
+        post specific task
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            poller identifier
+          required: true
+          type: string
+        - name: body
+          in: body
+          description: |
+            obm settings to apply.
+          required: true
+          schema:
+            $ref: '#/definitions/generic_obj'
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Specifics of the specified task
+          schema:
+            type: object
+        404:
+          description: |
+            There is no  task with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+
+  /swagger:
+    x-swagger-pipe: swagger_raw
+
+definitions:
+  ErrorResponse:
+    required:
+      - message
+    properties:
+      message:
+        type: string
+
+  VersionsResponse:
+    required:
+      - message
+    properties:
+      message:
+        type: string
+
+  Error:
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      fields:
+        type: string
+
+  generic_obj:
+   type: object


### PR DESCRIPTION
Added Southbound /tasks rout to the 2.0 API.

Right now all swagger routes, including the new tasks route, appear on both the southbound and northbound interfaces.  I am working on changes that make the routes available only on the correct interfaces.  This will be a different pull request.  