### PR TITLE
Add v2.0 workflows API

### DIFF
--- a/lib/api/2.0/workflowGraphs.js
+++ b/lib/api/2.0/workflowGraphs.js
@@ -5,7 +5,7 @@
 var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
-var _ = require('lodash');    // jshint ignore:line
+var _ = injector.get('_');    // jshint ignore:line
 
 /**
 * @api {get} /api/2.0/workflows/graphs GET /workflows/graphs

--- a/lib/api/2.0/workflowGraphs.js
+++ b/lib/api/2.0/workflowGraphs.js
@@ -1,0 +1,67 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var workflowApiService = injector.get('Http.Services.Api.Workflows');
+var _ = require('lodash');    // jshint ignore:line
+
+/**
+* @api {get} /api/2.0/workflows/graphs GET /workflows/graphs
+* @apiVersion 2.0.0
+* @apiName workflowsGetGraphs
+* @apiDescription Get list of all graphs
+* @apiSuccess {json} List of graphs
+* @apiGroup workflowGraphs
+*/
+var workflowsGetGraphs = controller(function() {
+    return workflowApiService.getGraphDefinitions();
+});
+
+/**
+* @api {get} /api/2.0/workflows/graphs/{injectableName} GET /workflows/graphs/{injectableName}
+* @apiVersion 2.0.0
+* @apiName workflowsGetGraphsByName
+* @apiDescription Get the graph with the specified injectable name
+* @apiParam {String} injectableName
+* @apiSuccess Graph with the specified injectable name
+* @apiGroup workflowGraphs
+*/
+var workflowsGetGraphsByName = controller(function(req) {
+    return workflowApiService.getGraphDefinitions(req.swagger.params.injectableName.value);
+});
+
+/**
+* @api {put} /api/2.0/workflows/graphs PUT /workflows/graphs
+* @apiVersion 2.0.0
+* @apiName workflowsPutGraphs
+* @apiDescription Add a graph to the graph library
+* @apiParam {Object} body
+* @apiSuccess Graph Created
+* @apiGroup workflowGraphs
+*/
+// Can include name in body to modify a specific graph
+var workflowsPutGraphs = controller({success: 201},function(req) {
+    return workflowApiService.defineTaskGraph(req.body);
+});
+
+/**
+* @api {delete} /api/2.0/workflows/graphs DELETE /workflows/graphs/{injectableName}
+* @apiVersion 2.0.0
+* @apiName workflowsDeleteGraphsByName
+* @apiDescription Delete the graph with the specified injectable name
+* @apiParam {String} injectableName
+* @apiSuccess Graph deleted
+* @apiGroup workflowGraphs
+*/
+var workflowsDeleteGraphsByName = controller(function(req) {
+    return workflowApiService.destroyGraphDefinition(req.swagger.params.injectableName.value); 
+});
+
+module.exports = {
+    workflowsGetGraphs: workflowsGetGraphs,
+    workflowsGetGraphsByName: workflowsGetGraphsByName,
+    workflowsPutGraphs: workflowsPutGraphs,
+    workflowsDeleteGraphsByName: workflowsDeleteGraphsByName
+};

--- a/lib/api/2.0/workflowTasks.js
+++ b/lib/api/2.0/workflowTasks.js
@@ -1,0 +1,72 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var workflowApiService = injector.get('Http.Services.Api.Workflows');
+var _ = require('lodash');    // jshint ignore:line
+
+
+/**
+* @api {put} /api/2.0/workflows/tasks PUT /workflows/tasks
+* @apiVersion 2.0.0
+* @apiDescription Add tasks to task library
+* @apiName workflowTasks-define
+* @apiGroup workflowTasks
+* @apiParam {json} task The task to be added to the library
+* @apiSuccess {string} Task createdN
+*/
+
+var workflowsPutTask = controller({success: 201}, function(req) {
+    return workflowApiService.defineTask(req.body);
+});
+
+/**
+* @api {get} /api/2.0/workflows/tasks GET /workflows/tasks
+* @apiVersion 2.0.0
+* @apiDescription Get list of tasks possible to run in workflows
+* @apiName workflowTasks-getAll
+* @apiSuccess {json} List of all tasks possible to run in workflows.
+* @apiGroup workflowTasks
+*/
+
+var workflowsGetAllTasks = controller(function() {
+    return workflowApiService.getTaskDefinitions();
+});
+
+/**
+* @api {get} /api/2.0/workflows/tasks/:injectableName GET /workflows/tasks/:injectableName
+* @apiVersion 2.0.0
+* @apiDescription Get the task with the specified injectable name
+* @apiName workflowTasks-getByName
+* @apiParam {String} Task injectable name
+* @apiSuccess {json} Task with the specified injectable name
+* @apiGroup workflowTasks
+*/
+
+var workflowsGetTasksByName = controller(function(req) {
+    return workflowApiService.getWorkflowsTasksByName(req.swagger.params.injectableName.value);
+});
+
+/**
+* @api {delete} /api/2.0/workflows/tasks/:injectableName DELETE /workflows/tasks/:injectableName
+* @apiVersion 2.0.0
+* @apiDescription Delete the task with the specified injectable name
+* @apiName workflowTasks-deleteByName
+* @apiGroup workflowTasks
+* @apiParam {string} injectableName
+* @apiSuccess {string} Task deleted
+*/
+
+var workflowsDeleteTasksByName = controller({success: 200}, function(req) {
+    return workflowApiService.deleteWorkflowsTasksByName(req.swagger.params.injectableName.value);
+});
+
+
+module.exports = {
+    workflowsPutTask: workflowsPutTask,
+    workflowsGetAllTasks: workflowsGetAllTasks,
+    workflowsGetTasksByName: workflowsGetTasksByName,
+    workflowsDeleteTasksByName: workflowsDeleteTasksByName
+};

--- a/lib/api/2.0/workflowTasks.js
+++ b/lib/api/2.0/workflowTasks.js
@@ -5,7 +5,7 @@
 var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
-var _ = require('lodash');    // jshint ignore:line
+var _ = injector.get('_');    // jshint ignore:line
 
 
 /**

--- a/lib/api/2.0/workflows.js
+++ b/lib/api/2.0/workflows.js
@@ -5,6 +5,7 @@
 var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
+var Errors = injector.get('Errors');
 var _ = require('lodash');    // jshint ignore:line
 
 /**
@@ -59,18 +60,32 @@ var workflowsGetById = controller(function(req) {
 });
 
 /**
-* @api {put} /api/2.0/workflows/:identifier PUT /workflows/:identifier/cancel
+* @api {put} /api/2.0/workflows/:identifier PUT /workflows/:identifier/action
 * @apiVersion 2.0.0
-* @apiDescription cancel the specified workflow
-* @apiName workflows-cancel
+* @apiDescription perform the specified action on the selected workflow
+* @apiName workflows-action
 * @apiGroup workflows
-* @apiParam {String} instanceId of workflow
+* @apiParam {String} identifier of workflow
 * @apiSuccess {json}  object.
 * @apiError NotFound There is no workflow with <code>instanceId</code>
 */
+var workflowsAction = controller(function(req) {
+    var command = req.body.command;
+    var options = req.body.options || {};
 
-var workflowsCancel = controller(function(req) {
-    return workflowApiService.cancelTaskGraph(req.swagger.params.identifier.value);
+    var actionFunctions = {
+        cancel: function() {
+            return workflowApiService.cancelTaskGraph(req.swagger.params.identifier.value);
+        }
+    };
+
+    if (_(actionFunctions).has(command)) {
+        return actionFunctions[command]();
+    }
+
+    throw new Errors.BadRequestError(
+        command + ' is not a valid workflow action'
+    );
 });
 
 /**
@@ -93,5 +108,5 @@ module.exports = {
     workflowsPost: workflowsPost,
     workflowsGetById: workflowsGetById,
     workflowsDeleteById: workflowsDeleteById,
-    workflowsCancel: workflowsCancel
+    workflowsAction: workflowsAction
 };

--- a/lib/api/2.0/workflows.js
+++ b/lib/api/2.0/workflows.js
@@ -1,0 +1,97 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var workflowApiService = injector.get('Http.Services.Api.Workflows');
+var _ = require('lodash');    // jshint ignore:line
+
+/**
+* @api {get} /api/2.0/workflows GET /workflows
+* @apiVersion 2.0.0
+* @apiDescription Get list of active and past run workflow instances
+* @apiName workflows-get
+* @apiGroup workflows
+* @apiSuccess {json} List of all workflows or if there are none an empty object.
+*/
+
+var workflowsGet = controller(function(req) {
+    return workflowApiService.getActiveWorkflows(req.query)
+    .then(function(workflows) {
+        if (req.swagger.query && _(req.swagger.query).has('active')) {
+            return _(workflows)
+            .filter(function(workflow) {
+                return workflow.active() === req.swagger.query.active;
+            });
+        }
+        return workflows;
+    });
+});
+
+/**
+* @api {post} /api/2.0/workflows POST /workflows
+* @apiVersion 2.0.0
+* @apiDescription Run a new workflow
+* @apiName workflows-run
+* @apiGroup workflows
+* @apiError Error problem was encountered, workflow was not run.
+*/
+
+var workflowsPost = controller({success: 201}, function(req) {
+    var configuration = _.defaults(req.query || {}, req.body || {});
+    return workflowApiService.createAndRunGraph(configuration);
+});
+
+/**
+* @api {get} /api/2.0/workflows/:identifier GET /workflows/:identifier
+* @apiVersion 2.0.0
+* @apiDescription get a specific workflow
+* @apiName workflows-getById
+* @apiGroup workflows
+* @apiParam {String} instanceId of workflow
+* @apiSuccess {json} workflows of the particular identifier or if there are none an empty object.
+* @apiError NotFound There is no workflow with <code>instanceId</code>
+*/
+
+var workflowsGetById = controller(function(req) {
+    return workflowApiService.getWorkflowById(req.swagger.params.identifier.value);
+});
+
+/**
+* @api {put} /api/2.0/workflows/:identifier PUT /workflows/:identifier/cancel
+* @apiVersion 2.0.0
+* @apiDescription cancel the specified workflow
+* @apiName workflows-cancel
+* @apiGroup workflows
+* @apiParam {String} instanceId of workflow
+* @apiSuccess {json}  object.
+* @apiError NotFound There is no workflow with <code>instanceId</code>
+*/
+
+var workflowsCancel = controller(function(req) {
+    return workflowApiService.cancelTaskGraph(req.swagger.params.identifier.value);
+});
+
+/**
+* @api {delete} /api/2.0/workflows/:identifier DELETE /workflows/:identifier
+* @apiVersion 2.0.0
+* @apiDescription Cancel currently running workflows for specified node
+* @apiName workflows-DeleteById
+* @apiGroup workflows
+* @apiParam {String} instanceId of workflow
+* @apiSuccess {json}  object.
+* @apiError NotFound The node with the identifier was not found <code>instanceId</code>
+*/
+
+var workflowsDeleteById = controller(function(req) {
+    return workflowApiService.deleteTaskGraph(req.swagger.params.identifier.value);
+});
+
+module.exports = {
+    workflowsGet: workflowsGet,
+    workflowsPost: workflowsPost,
+    workflowsGetById: workflowsGetById,
+    workflowsDeleteById: workflowsDeleteById,
+    workflowsCancel: workflowsCancel
+};

--- a/lib/api/2.0/workflows.js
+++ b/lib/api/2.0/workflows.js
@@ -6,7 +6,7 @@ var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var Errors = injector.get('Errors');
-var _ = require('lodash');    // jshint ignore:line
+var _ = injector.get('_');    // jshint ignore:line
 
 /**
 * @api {get} /api/2.0/workflows GET /workflows
@@ -79,13 +79,13 @@ var workflowsAction = controller(function(req) {
         }
     };
 
-    if (_(actionFunctions).has(command)) {
-        return actionFunctions[command]();
+    if (!_(actionFunctions).has(command)) {
+        throw new Errors.BadRequestError(
+            command + ' is not a valid workflow action'
+        );
     }
 
-    throw new Errors.BadRequestError(
-        command + ' is not a valid workflow action'
-    );
+    return actionFunctions[command]();
 });
 
 /**

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -450,7 +450,7 @@ function nodeApiServiceFactory(
                     'No active workflow graph found for node ' + id
                 );
             }
-            return [ graph, workflowApiService.cancelTaskGraph(graph.instanceId) ];
+            return [ graph, workflowApiService.cancelTaskGraph(graph.id) ];
         })
         .spread(function(graph, graphId) {
             if (!graphId) {

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -34,15 +34,17 @@ function swaggerFactory(
         return err;
     }
 
-    function _parseQuery(params) {
-        return _(params)
+    function _parseQuery(req) {
+        req.swagger.query = _(req.swagger.params)
         .pick(function(param) {
             if (param.parameterObject) {
-                return param.parameterObject.in === 'query';
+                return param.parameterObject.in === 'query' &&
+                       param.parameterObject.type === typeof(param.value);
             }
             return false;
         })
         .mapValues(function(param) {
+            req.query = _(req.query).omit(param.parameterObject.definition.name).value();
             if (typeof(param.value) === 'string' && param.value.match(/\+/)) {
                 return param.value.split(/\+/);
             }
@@ -58,7 +60,7 @@ function swaggerFactory(
         return function(req, res, next) {
             req.swagger.options = options;
             return Promise.resolve().then(function() {
-                req.swagger.query = _parseQuery(req.swagger.params);
+                _parseQuery(req);
                 return callback(req, res);
             }).then(function(result) {
                 if (!res.headersSent) {

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -134,12 +134,13 @@ function workflowApiServiceFactory(
         .then(function(workflow) {
             instanceId = workflow.instanceId;
 
-            if (workflow.active()) {
-                return taskGraphProtocol.cancelTaskGraph(instanceId);
+            if (!workflow.active()) {
+                throw new Errors.TaskCancellationError(
+                    graphId + ' is not an active workflow'
+                );
             }
-            throw new Errors.TaskCancellationError(
-                graphId + ' is not an active workflow'
-            );
+
+            return taskGraphProtocol.cancelTaskGraph(instanceId);
         })
         .then(function(cancelledGraphId) {
             if (cancelledGraphId !== instanceId) {

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -128,7 +128,56 @@ function workflowApiServiceFactory(
     };
 
     WorkflowApiService.prototype.cancelTaskGraph = function(graphId) {
-        return taskGraphProtocol.cancelTaskGraph(graphId);
+        var instanceId;
+
+        return waterline.graphobjects.needByIdentifier(graphId)
+        .then(function(workflow) {
+            instanceId = workflow.instanceId;
+
+            if (workflow.active()) {
+                return taskGraphProtocol.cancelTaskGraph(instanceId);
+            }
+            throw new Errors.TaskCancellationError(
+                graphId + ' is not an active workflow'
+            );
+        })
+        .then(function(cancelledGraphId) {
+            if (cancelledGraphId !== instanceId) {
+                // Cancelled graph ID doesn't match the requested ID.
+                throw new Errors.TaskCancellationError('Failed to cancel ' + graphId);
+            }
+            return waterline.graphobjects.needByIdentifier(graphId);
+        });
+    };
+
+    WorkflowApiService.prototype.deleteTaskGraph = function(graphId) {
+        var instanceId;
+
+        // Taskgraph deletion sequence:
+        // 1) Get the graph object by ID
+        // 2) Check if the returned workflow is running.
+        // 3) If it is running, cancel it otherwise go on to step 4.
+        // 4) Delete the graph object from the task graph store.
+        return waterline.graphobjects.needByIdentifier(graphId)
+        .then(function(workflow) {
+            // Since deleteGraph takes instanceId as an argument, save it
+            // here using a closure so we don't need to do another query later.
+            instanceId = workflow.instanceId;
+            if (workflow.active()) {
+                return taskGraphProtocol.cancelTaskGraph(instanceId);
+            }
+            return instanceId;
+        })
+        .then(function(cancelledGraphId) {
+            if (cancelledGraphId !== instanceId) {
+                // Cancelled graph ID doesn't match the requested ID.
+                throw new Errors.TaskCancellationError('Failed to cancel ' + graphId);
+            }
+            return taskGraphStore.deleteGraph(instanceId);
+        })
+        .then(function(deletedGraphs) {
+            return deletedGraphs[0];
+        });
     };
 
     WorkflowApiService.prototype.defineTaskGraph = function(definition) {
@@ -146,6 +195,39 @@ function workflowApiServiceFactory(
         return taskGraphStore.persistTaskDefinition(definition);
     };
 
+    WorkflowApiService.prototype.getWorkflowsTasksByName = function(injectableName) {
+        return taskGraphStore.getTaskDefinitions(injectableName);
+    };
+
+    WorkflowApiService.prototype.deleteWorkflowsTasksByName = function(injectableName) {
+        return taskGraphStore.getTaskDefinitions(injectableName)
+            .then(function (task){
+                if(_.isEmpty(task)){
+                    throw new Errors.NotFoundError(
+                        'Task definition not found for ' + injectableName
+                    );
+                }else{
+                    return taskGraphStore.deleteTaskByName(injectableName);
+
+                }
+            });
+    };
+
+    WorkflowApiService.prototype.putWorkflowsTasksByName = function(definition, injectableName) {
+        return taskGraphStore.getTaskDefinitions(injectableName)
+            .then(function (task){
+                if(_.isEmpty(task)){
+                    throw new Errors.NotFoundError(
+                        'Task definition not found for ' + injectableName
+                    );
+                }else{
+                    return taskGraphStore.persistTaskDefinition(definition);
+
+                }
+            });
+    };
+
+
     WorkflowApiService.prototype.getGraphDefinitions = function(injectableName) {
         return taskGraphStore.getGraphDefinitions(injectableName);
     };
@@ -155,7 +237,32 @@ function workflowApiServiceFactory(
     };
 
     WorkflowApiService.prototype.findActiveGraphForTarget = function(target) {
-        return taskGraphStore.findActiveGraphForTarget(target);
+        return waterline.graphobjects.find({ node: target })
+            .then(function(workflows){
+                return _.filter(workflows, function(wf) {
+                    return wf.active();
+                })[0];
+            })
+            .then(function (workflow){
+                if(_.isEmpty(workflow)){
+                    throw new Errors.NotFoundError('Active workflow not found for node');
+                }else{
+                    return workflow;
+
+                }
+            });
+    };
+
+    WorkflowApiService.prototype.getActiveWorkflows = function(query) {
+        return waterline.graphobjects.find(query);
+    };
+
+    WorkflowApiService.prototype.getWorkflowById = function(id) {
+        return waterline.graphobjects.needByIdentifier(id);
+    };
+
+    WorkflowApiService.prototype.destroyGraphDefinition = function(injectableName) {
+        return taskGraphStore.destroyGraphDefinition(injectableName);
     };
 
     return new WorkflowApiService();

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -222,7 +222,6 @@ function workflowApiServiceFactory(
                     );
                 }else{
                     return taskGraphStore.persistTaskDefinition(definition);
-
                 }
             });
     };
@@ -237,20 +236,10 @@ function workflowApiServiceFactory(
     };
 
     WorkflowApiService.prototype.findActiveGraphForTarget = function(target) {
-        return waterline.graphobjects.find({ node: target })
-            .then(function(workflows){
-                return _.filter(workflows, function(wf) {
-                    return wf.active();
-                })[0];
-            })
-            .then(function (workflow){
-                if(_.isEmpty(workflow)){
-                    throw new Errors.NotFoundError('Active workflow not found for node');
-                }else{
-                    return workflow;
-
-                }
-            });
+        return waterline.graphobjects.findOne({
+            node: target,
+            _status: Constants.Task.ActiveStates
+        });
     };
 
     WorkflowApiService.prototype.getActiveWorkflows = function(query) {

--- a/spec/lib/api/2.0/workflowGraphs-spec.js
+++ b/spec/lib/api/2.0/workflowGraphs-spec.js
@@ -1,0 +1,89 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Workflows.2.0', function () {
+    var workflowApiService;
+
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        workflowApiService = {
+            getGraphDefinitions: sinon.stub(),
+            workflowsGetGraphsByName: sinon.stub(),
+            defineTaskGraph: sinon.stub(),
+            destroyGraphDefinition: sinon.stub()
+        };
+
+        return helper.startServer([
+            dihelper.simpleWrapper(workflowApiService, 'Http.Services.Api.Workflows'),
+        ]);
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    afterEach('set up mocks', function () {
+        workflowApiService.getGraphDefinitions.reset();
+        workflowApiService.workflowsGetGraphsByName.reset();
+        workflowApiService.defineTaskGraph.reset();
+        workflowApiService.destroyGraphDefinition.reset();
+    });
+
+    describe('workflowsGetGraphs', function () {
+        it('should retrieve the workflow Graphs', function () {
+            var task = { name: 'foobar' };
+            workflowApiService.getGraphDefinitions.resolves([task]);
+
+            return helper.request().get('/api/2.0/workflows/graphs')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, [task]);
+        });
+    });
+
+    describe('workflowsGetGraphsByName', function () {
+        it('should retrieve the graph by Name', function () {
+            var graph = { name: 'foobar' };
+            workflowApiService.getGraphDefinitions.resolves(graph);
+
+            return helper.request().get('/api/2.0/workflows/graphs/' + graph.name)
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, graph)
+                .expect(function() {
+                    expect(workflowApiService.getGraphDefinitions).to.have.been.calledOnce;
+                    expect(workflowApiService.getGraphDefinitions)
+                        .to.have.been.calledWith('foobar');
+                });
+        });
+    });
+
+   describe('workflowsPutGraphs', function () {
+        it('should persist a graph', function () {
+            var graph = { name: 'foobar' };
+            workflowApiService.defineTaskGraph.resolves(graph);
+
+            return helper.request().put('/api/2.0/workflows/graphs')
+            .send(graph)
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, graph);
+        });
+    });
+
+   describe('workflowsDeleteGraphsByName', function () {
+        it('should delete Graph by name', function () {
+            var graph = { name: 'Destroy.Me' };
+            workflowApiService.destroyGraphDefinition.resolves(graph);
+
+            return helper.request().delete('/api/2.0/workflows/graphs/' + graph.name)
+            .expect('Content-Type', /^application\/json/)
+            .expect(200, graph)
+            .expect(function() {
+                expect(workflowApiService.destroyGraphDefinition).to.have.been.calledOnce;
+                expect(workflowApiService.destroyGraphDefinition)
+                    .to.have.been.calledWith('Destroy.Me');
+            });
+        });
+    });
+});
+

--- a/spec/lib/api/2.0/workflowTasks-spec.js
+++ b/spec/lib/api/2.0/workflowTasks-spec.js
@@ -1,0 +1,173 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.workflowTasks.2.0', function () {
+    var waterline;
+    var workflowApiService;
+
+    before('start HTTP server', function () {
+        var self = this;
+        this.timeout(5000);
+
+        waterline = {
+            start: sinon.stub(),
+            stop: sinon.stub(),
+            lookups: {
+                setIndexes: sinon.stub()
+            }
+        };
+        this.sandbox = sinon.sandbox.create();
+
+        return helper.startServer([
+            dihelper.simpleWrapper(waterline, 'Services.Waterline'),
+        ])
+        .then(function() {
+            workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
+            self.sandbox.stub(workflowApiService, 'defineTask').resolves();
+            self.sandbox.stub(workflowApiService, 'getTaskDefinitions').resolves();
+            self.sandbox.stub(workflowApiService, 'getWorkflowsTasksByName').resolves();
+            self.sandbox.stub(workflowApiService, 'deleteWorkflowsTasksByName').resolves();
+        });
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    beforeEach('set up mocks', function () {
+        waterline.nodes = {
+            findByIdentifier: sinon.stub().resolves()
+        };
+        waterline.graphobjects = {
+            find: sinon.stub().resolves([]),
+            findByIdentifier: sinon.stub().resolves(),
+            needByIdentifier: sinon.stub().resolves()
+        };
+        waterline.lookups = {
+            // This method is for lookups only and it
+            // doesn't impact behavior whether it is a
+            // resolve or a reject since it's related
+            // to logging.
+            findOneByTerm: sinon.stub().rejects()
+        };
+    });
+
+    afterEach('clean up mocks', function () {
+        this.sandbox.reset();
+    });
+
+
+    describe('workflowsPutTask ', function () {
+        it('should persist a task', function () {
+            var task = {
+                friendlyName: 'dummy',
+                injectableName: 'dummyName',
+                options: {
+                    oids: 'SNMPv2-MIB::sysDescr'
+                }
+            };
+            workflowApiService.defineTask.resolves(task);
+
+            return helper.request().put('/api/2.0/workflows/tasks')
+                .send(task)
+                .expect('Content-Type', /^application\/json/)
+                .expect(201, task);
+        });
+
+    });
+
+    describe('workflowsGetAllTasks', function () {
+        it('should return a list of persisted graph objects', function () {
+            var graph = { name: 'foobar' };
+            workflowApiService.getTaskDefinitions.resolves([graph]);
+
+            return helper.request().get('/api/2.0/workflows/tasks')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, [graph])
+                .expect(function () {
+                    expect(workflowApiService.getTaskDefinitions).to.have.been.calledOnce;
+                });
+        });
+
+        it('should return an empty list of persisted graph objects', function () {
+            var graph = [];
+            workflowApiService.getTaskDefinitions.resolves(graph);
+
+            return helper.request().get('/api/2.0/workflows/tasks')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, graph)
+                .expect(function () {
+                    expect(workflowApiService.getTaskDefinitions).to.have.been.calledOnce;
+                });
+        });
+
+    });
+
+    describe('workflowsGetTasksByName', function () {
+        var workflowTask = {
+                friendlyName: 'dummy',
+                injectableName: 'dummyName',
+                options: {
+                    oids: 'SNMPv2-MIB::sysDescr'
+                }
+            };
+
+        it('should return a particular task persisted graph objects', function () {
+            workflowApiService.getWorkflowsTasksByName.resolves(workflowTask);
+            return helper.request().get('/api/2.0/workflows/tasks/'+workflowTask.injectableName)
+            .send( {
+                friendlyName: 'dummy',
+                injectableName: 'dummyName',
+                options: {
+                    oids: 'SNMPv2-MIB::sysDescr'
+                }
+            })
+            .expect('Content-Type', /^application\/json/)
+            .expect(200)
+            .expect(function ( res ) {
+                expect(workflowApiService.getWorkflowsTasksByName).to.have.been.calledOnce;
+                expect(workflowApiService.getWorkflowsTasksByName)
+                    .to.have.been.calledWith(workflowTask.injectableName);
+                expect(res.body).to.have.property('friendlyName', 'dummy');
+                expect(res.body).to.have.property('injectableName', 'dummyName');
+                expect(res.body).to.have.property('options').to.be.an('object');
+                expect(res.body).to.have.deep.property('options.oids', 'SNMPv2-MIB::sysDescr');
+                });
+        });
+
+        it('should return 404 when getWorkflowsTasksByName is not found', function () {
+            var badGraphName = 'invalidName';
+            var Errors = helper.injector.get('Errors');
+            workflowApiService.getWorkflowsTasksByName.rejects(new Errors.NotFoundError('test'));
+            return helper.request().get('/api/2.0/workflows/tasks/'+badGraphName)
+            .expect('Content-Type', /^application\/json/)
+            .expect(404);
+        });
+    });
+
+    describe('workflowsDeleteTasksByName', function () {
+        var workflowTask;
+        beforeEach(function () {
+           return helper.request().put('/api/2.0/workflows/tasks')
+            .send({
+                friendlyName: 'dummy',
+                injectableName: 'dummyName',
+                options: {
+                    oids: 'SNMPv2-MIB::sysDescr'
+                }
+            })
+            .expect('Content-Type', /^application\/json/)
+            .expect(201)
+            .then(function (req) {
+                workflowTask = req.body;
+            });
+        });
+
+        it('should delete the Task with DELETE /workflows/tasks/injectableName', function () {
+            return helper.request().delete('/api/2.0/workflows/tasks/'+ workflowTask.injectableName)
+                .expect(200);
+        });
+    });
+});

--- a/spec/lib/api/2.0/workflowTasks-spec.js
+++ b/spec/lib/api/2.0/workflowTasks-spec.js
@@ -134,7 +134,7 @@ describe('Http.Api.workflowTasks.2.0', function () {
                 expect(res.body).to.have.property('injectableName', 'dummyName');
                 expect(res.body).to.have.property('options').to.be.an('object');
                 expect(res.body).to.have.deep.property('options.oids', 'SNMPv2-MIB::sysDescr');
-                });
+            });
         });
 
         it('should return 404 when getWorkflowsTasksByName is not found', function () {

--- a/spec/lib/api/2.0/workflows-spec.js
+++ b/spec/lib/api/2.0/workflows-spec.js
@@ -1,0 +1,177 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Workflows.2.0', function () {
+    var waterline;
+    var workflowApiService;
+
+    before('start HTTP server', function () {
+        var self = this;
+        this.timeout(5000);
+
+        waterline = {
+            start: sinon.stub(),
+            stop: sinon.stub(),
+            lookups: {
+                setIndexes: sinon.stub()
+            }
+        };
+        this.sandbox = sinon.sandbox.create();
+
+        return helper.startServer([
+            dihelper.simpleWrapper(waterline, 'Services.Waterline')
+        ])
+        .then(function() {
+            workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
+            self.sandbox.stub(workflowApiService, 'defineTask').resolves();
+            self.sandbox.stub(workflowApiService, 'getActiveWorkflows').resolves();
+            self.sandbox.stub(workflowApiService, 'createAndRunGraph').resolves();
+            self.sandbox.stub(workflowApiService, 'getWorkflowById').resolves();
+            self.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves();
+            self.sandbox.stub(workflowApiService, 'deleteTaskGraph').resolves();
+        });
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    beforeEach('set up mocks', function () {
+        waterline.nodes = {
+            findByIdentifier: sinon.stub().resolves()
+        };
+        waterline.graphobjects = {
+            find: sinon.stub().resolves([]),
+            findByIdentifier: sinon.stub().resolves(),
+            needByIdentifier: sinon.stub().resolves()
+        };
+        waterline.lookups = {
+            // This method is for lookups only and it
+            // doesn't impact behavior whether it is a
+            // resolve or a reject since it's related
+            // to logging.
+            findOneByTerm: sinon.stub().rejects()
+        };
+    });
+
+    afterEach('clean up mocks', function () {
+        this.sandbox.reset();
+    });
+
+    describe('workflowsGet', function () {
+        it('should return a list of persisted graph objects', function () {
+            var graph = { name: 'foobar' };
+            workflowApiService.getActiveWorkflows.resolves([graph]);
+
+            return helper.request().get('/api/2.0/workflows')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, [graph])
+                .expect(function () {
+                    expect(workflowApiService.getActiveWorkflows).to.have.been.calledOnce;
+                });
+        });
+
+        it('should return 404 if not found ', function () {
+            var Errors = helper.injector.get('Errors');
+            workflowApiService.getActiveWorkflows.rejects(new Errors.NotFoundError('test'));
+
+            return helper.request().get('/api/2.0/workflows')
+                .expect('Content-Type', /^application\/json/)
+                .expect(404);
+        });
+
+    });
+
+    describe('workflowsPost', function () {
+        it('should persist a task graph', function () {
+            var graph = {
+                             "friendlyName": "Catalog dmi",
+                             "implementsTask": "Task.Base.Linux.Catalog",
+                             "injectableName": "Task.Catalog.dmi",
+                        };
+            workflowApiService.createAndRunGraph.resolves(graph);
+
+            return helper.request().post('/api/2.0/workflows')
+                .send(graph)
+                .expect('Content-Type', /^application\/json/)
+                .expect(201)
+                .expect(function (res ){
+                    expect(res.body).to.have.property("friendlyName", "Catalog dmi");
+                    expect(res.body).to.have.property("implementsTask", "Task.Base.Linux.Catalog");
+                    expect(res.body).to.have.property("injectableName", "Task.Catalog.dmi");
+
+                });
+        });
+    });
+
+
+    describe('workflowsGetById', function () {
+        it('should return a single persisted graph', function () {
+            var graph = { id: 'foobar' };
+            workflowApiService.getWorkflowById.resolves(graph);
+
+            return helper.request().get('/api/2.0/workflows/foobar')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, graph)
+                .expect(function () {
+                    expect(workflowApiService.getWorkflowById).to.have.been.calledOnce;
+                    expect(workflowApiService.getWorkflowById).to.have.been.calledWith('foobar');
+                });
+        });
+
+        it('should return a 404 if not found', function () {
+            var Errors = helper.injector.get('Errors');
+            workflowApiService.getWorkflowById.rejects(new Errors.NotFoundError('test'));
+
+            return helper.request().get('/api/2.0/workflows/12345')
+                .expect('Content-Type', /^application\/json/)
+                .expect(404);
+        });
+    });
+
+    describe('workflowsCancel', function () {
+        it('should cancel a task', function () {
+            var graph = { instancId: 'foobar',
+                          _status: 'cancelled'
+                        };
+
+            workflowApiService.cancelTaskGraph.resolves(graph);
+            return helper.request().put('/api/2.0/workflows/56e6ef601c3a31638be765fc/cancel')
+                .set('Content-Type', 'application/json')
+                .expect(200)
+                .expect(function() {
+                    expect(workflowApiService.cancelTaskGraph).to.have.been.calledOnce;
+                    expect(workflowApiService.cancelTaskGraph)
+                         .to.have.been.calledWith('56e6ef601c3a31638be765fc');
+                })
+                .expect(function(res) {
+                    expect(res.body).to.deep.equal(graph);
+                });
+        });
+    });
+
+
+   describe('workflowsDeleteById', function () {
+
+        var workflow = {
+                friendlyName: 'dummy',
+                id: 'dummyId',
+                state: 'running',
+                instanceId: 'foo'
+            };
+
+        it('should delete the Task with DELETE /workflows/id', function () {
+            return helper.request().delete('/api/2.0/workflows/'+ workflow.id)
+                .expect(200)
+                .expect(function() {
+                    expect(workflowApiService.deleteTaskGraph).to.have.been.calledOnce;
+                    expect(workflowApiService.deleteTaskGraph)
+                         .to.have.been.calledWith(workflow.id);
+                });
+        });
+
+    });
+
+});

--- a/spec/lib/api/2.0/workflows-spec.js
+++ b/spec/lib/api/2.0/workflows-spec.js
@@ -44,6 +44,7 @@ describe('Http.Api.Workflows.2.0', function () {
         };
         waterline.graphobjects = {
             find: sinon.stub().resolves([]),
+            findOne: sinon.stub().resolves(),
             findByIdentifier: sinon.stub().resolves(),
             needByIdentifier: sinon.stub().resolves()
         };
@@ -131,15 +132,17 @@ describe('Http.Api.Workflows.2.0', function () {
         });
     });
 
-    describe('workflowsCancel', function () {
+    describe('workflowsAction', function () {
         it('should cancel a task', function () {
-            var graph = { instancId: 'foobar',
+            var action = { command: 'cancel' };
+            var graph = { instanceId: 'foobar',
                           _status: 'cancelled'
                         };
 
             workflowApiService.cancelTaskGraph.resolves(graph);
-            return helper.request().put('/api/2.0/workflows/56e6ef601c3a31638be765fc/cancel')
+            return helper.request().put('/api/2.0/workflows/56e6ef601c3a31638be765fc/action')
                 .set('Content-Type', 'application/json')
+                .send(action)
                 .expect(200)
                 .expect(function() {
                     expect(workflowApiService.cancelTaskGraph).to.have.been.calledOnce;
@@ -173,5 +176,4 @@ describe('Http.Api.Workflows.2.0', function () {
         });
 
     });
-
 });

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -278,11 +278,11 @@ describe("Http.Services.Api.Nodes", function () {
                 id: '123'
             };
             var graph = {
-                instanceId: 'testgraphid'
+                id: 'testgraphid'
             };
             waterline.nodes.needByIdentifier.resolves(node);
             findActiveGraphForTarget.resolves(graph);
-            this.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves(graph.instanceId);
+            this.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves(graph.id);
 
             return nodeApiService.delActiveWorkflowById('testnodeid')
             .then(function() {
@@ -291,7 +291,7 @@ describe("Http.Services.Api.Nodes", function () {
                     .to.have.been.calledWith(node.id);
                 expect(workflowApiService.cancelTaskGraph).to.have.been.calledOnce;
                 expect(workflowApiService.cancelTaskGraph)
-                    .to.have.been.calledWith(graph.instanceId);
+                    .to.have.been.calledWith(graph.id);
             });
         });
 

--- a/spec/lib/services/swagger-api-service-spec.js
+++ b/spec/lib/services/swagger-api-service-spec.js
@@ -66,23 +66,47 @@ describe('Services.Http.Swagger', function() {
 
         it('should process query', function() {
             var req = {
+                query: {},
                 swagger: {
                     params: {
                         firstName: {
-                            parameterObject: { in: 'query'  },
+                            parameterObject: {
+                                in: 'query',
+                                type: 'string',
+                                definition: { name: 'firstName' }
+                            },
                             value: 'Rack'
                         },
                         lastName: {
-                            parameterObject: { in: 'query' },
+                            parameterObject: {
+                                in: 'query',
+                                type: 'string',
+                                definition: { name: 'lastName' }
+                            },
                             value: 'HD'
                         },
                         middleName: {
-                            parameterObject: { in: 'query' },
+                            parameterObject: {
+                                in: 'query',
+                                type: 'string',
+                                definition: { name: 'middleName' }
+                            },
                             value:'John+Paul+George'
                         },
+                        undefinedName: {
+                            parameterObject: {
+                                in: 'query',
+                                type: 'string',
+                                definition: { name: 'undefinedName' }
+                            },
+                            value: undefined
+                        },
                         inBody: {
-                            parameterObject: { in: 'body' },
-                            value: 'no a query'
+                            parameterObject: {
+                                in: 'body',
+                                type: 'string',
+                            },
+                            value: 'not a query'
                         }
                     }
                 }
@@ -91,7 +115,7 @@ describe('Services.Http.Swagger', function() {
                 headersSent: false
             };
             var mockData = {data: 'mock data'};
-            var optController = swaggerService.controller({success: 201}, mockController);
+            var optController = swaggerService.controller(mockController);
 
             expect(optController).to.be.a('function');
             mockController.resolves(mockData);
@@ -105,8 +129,7 @@ describe('Services.Http.Swagger', function() {
                 expect(req.swagger.query).to.have.property('middleName')
                     .and.to.deep.equal(['John', 'Paul', 'George']);
                 expect(req.swagger.query).not.to.have.property('inBody');
-                expect(req.swagger.options).to.have.property('success')
-                    .and.to.equal(201);
+                expect(req.swagger.query).not.to.have.property('undefinedName');
             });
         });
 

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -33,7 +33,8 @@ describe('Http.Services.Api.Workflows', function () {
         };
         waterline.graphobjects = {
             needByIdentifier: sinon.stub().resolves({ id: 'testgraphid', _status: 'pending' }),
-            find: sinon.stub().resolves()
+            find: sinon.stub().resolves(),
+            findOne: sinon.stub().resolves()
         };
         waterline.graphdefinitions = {
             destroy: sinon.stub().resolves({ injectableName: 'test' })
@@ -227,7 +228,7 @@ describe('Http.Services.Api.Workflows', function () {
     });
 
     it('should return a NotFoundError if the node was not found', function () {
-        store.findActiveGraphForTarget.rejects(new Errors.NotFoundError('Not Found'));
+        waterline.graphobjects.findOne.rejects(new Errors.NotFoundError('Not Found'));
         return expect(workflowApiService.findActiveGraphForTarget('testnodeid'))
             .to.be.rejectedWith(Errors.NotFoundError);
     });

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -318,7 +318,7 @@ describe('Http.Services.Api.Workflows', function () {
         );
         waterline.graphobjects.needByIdentifier.rejects(mockWorkflowError);
         return workflowApiService.cancelTaskGraph()
-            .should.eventually.be.rejectedWith(mockWorkflowError);
+            .should.be.rejectedWith(mockWorkflowError);
     });
 
 
@@ -349,15 +349,9 @@ describe('Http.Services.Api.Workflows', function () {
     it('should return active workflows ', function() {
         var activeWorkflow = {
                                id      : 'testgraphid',
-                               _status :"pending"
-
-                           };
+                               _status : 'pending'
+                             };
         waterline.graphobjects.find.resolves(activeWorkflow);
-        return workflowApiService.getWorkflowById().then(function (workflows) {
-            expect(workflows).to.deep.equal(activeWorkflow);
-        });
+        return expect(workflowApiService.getWorkflowById()).to.become(activeWorkflow);
     });
-
-
-
 });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -719,43 +719,21 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /workflows/library:
-    x-swagger-router-controller: unimplemented
-    get:
-      operationId: unimplemented
-      x-privileges: [ 'Read' ]
-      x-authentication-type: [ 'jwt' ]
-      summary: |
-        List all workflows available to run
-      description: |
-        List all workflows available to run
-      tags: [ "/api/2.0" ]
-      responses:
-        200:
-          description: |
-            List all workflows available to run
-          schema:
-            type: object
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
   /workflows/tasks:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: workflowTasks
     get:
-      operationId: unimplemented
+      operationId: workflowsGetAllTasks
       x-privileges: [ 'Read' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
-        Fetch tasks from task library
+        Get list of tasks possible to run in workflows
       description: |
-        Fetch tasks from task library
+        Get list of tasks possible to run in workflows
       tags: [ "/api/2.0" ]
       responses:
         200:
           description: |
-            Fetch tasks from task library
+            List of tasks possible to run in workflows
           schema:
             type: object
         default:
@@ -763,18 +741,25 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      operationId: unimplemented
+      operationId: workflowsPutTask
       x-privileges: [ 'Write' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
         Add tasks to task library
       description: |
         Add tasks to task library
+      parameters:
+        - name: body
+          in: body
+          description: Workflow name
+          required: false
+          schema:
+            $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
         200:
           description: |
-            Add tasks to task library
+            Task created
           schema:
             type: object
         500:
@@ -786,17 +771,197 @@ paths:
           description: Upload failed
           schema:
             $ref: '#/definitions/Error'
-  /workflows:
-    x-swagger-router-controller: unimplemented
+
+  /workflows/tasks/{injectableName}:
+    x-swagger-router-controller: workflowTasks
     get:
-      operationId: unimplemented
+      operationId: workflowsGetTasksByName
       x-privileges: [ 'Read' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
-        Fetch workflows
+        Get the task with the specified injectable name
       description: |
-        Fetch workflows
+        Get the task with the specified injectable name
+      parameters:
+        - name: injectableName
+          in: path
+          description: |
+            Task injectable name
+          required: true
+          type: string
       tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Task with the specified injectable name
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      operationId: workflowsDeleteTasksByName
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Delete the task with the specified injectable name
+      description: |
+        Delete the task with the specified injectable name
+      parameters:
+        - name: injectableName
+          in: path
+          description: |
+            Task injectable name
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Task deleted
+          schema:
+            type: object
+        404:
+          description: |
+            The task with the specified injectable name was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /workflows/graphs:
+    x-swagger-router-controller: workflowGraphs
+    get:
+      operationId: workflowsGetGraphs
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Get list of all graphs
+      description: |
+        Get list of all graphs
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            List of graphs
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      operationId: workflowsPutGraphs
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Add a graph to the graph library
+      description: |
+        Add a graph to the graph library
+      parameters:
+        - name: body
+          in: body
+          description: Workflow name
+          required: false
+          schema:
+            $ref: '#/definitions/generic_obj'
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Graph created
+          schema:
+            type: object
+        500:
+          description: |
+            Error problem was encountered, graph was not written.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Upload failed
+          schema:
+            $ref: '#/definitions/Error'
+
+  /workflows/graphs/{injectableName}:
+    x-swagger-router-controller: workflowGraphs
+    get:
+      operationId: workflowsGetGraphsByName
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Get the graph with the specified injectable name
+      description: |
+        Get the graph with the specified injectable name
+      parameters:
+        - name: injectableName
+          in: path
+          description: |
+            Graph injectable name
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Graph with the specified injectable name
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      operationId: workflowsDeleteGraphsByName
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Delete the graph with the specified injectable name
+      description: |
+        Delete the graph with the specified injectable name
+      parameters:
+        - name: injectableName
+          in: path
+          description: |
+            Graph injectable name
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Graph deleted
+          schema:
+            type: object
+        404:
+          description: |
+            The graph with the specified injectable name was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /workflows:
+    x-swagger-router-controller: workflows
+    get:
+      operationId: workflowsGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Get list of active and past run workflow instances
+      description: |
+        Get list of active and past run workflow instances
+      tags: [ "/api/2.0" ]
+      parameters:
+        - name: active
+          in: query
+          description: |
+            Filter active workflows
+          required: false
+          type: boolean
       responses:
         200:
           description: |
@@ -807,30 +972,132 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-    put:
-      operationId: unimplemented
+    post:
+      operationId: workflowsPost
       x-privileges: [ 'Write' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
-        define new workflow
+        Run a new workflow
       description: |
-        define new workflow
+        Run a new workflow
+      parameters:
+        - name: body
+          in: body
+          description: Workflow name
+          required: false
+          schema:
+            $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
-            Fetch workflows
+            Success
           schema:
             type: object
         500:
           description: |
-            Error problem was encountered, workflow was not written.
+            Error problem was encountered, workflow was not run.
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Upload failed
           schema:
             $ref: '#/definitions/Error'
+
+  /workflows/{identifier}:
+    x-swagger-router-controller: workflows
+    get:
+      operationId: workflowsGetById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        get a specific workflow
+      description: |
+        get a specific workflow
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Workflow identifier
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Specified workflow
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      operationId: workflowsDeleteById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Delete the workflow with the specified ID
+      description: |
+        Delete the workflow with the specified ID
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Workflow ID
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Canceled workflows for specified node
+          schema:
+            type: object
+        404:
+          description: |
+            The workflow with the identifier was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /workflows/{identifier}/cancel:
+    x-swagger-router-controller: workflows
+    put:
+      operationId: workflowsCancel
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        cancel the specified workflow
+      description: |
+        cancel the specified workflow
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Workflow identifier
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            Specified workflow
+          schema:
+            type: object
+        404:
+          description: |
+            The workflow with the identifier was not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
 
   /nodes/{identifier}/workflows/active:
     x-swagger-router-controller: nodes

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -1064,16 +1064,16 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /workflows/{identifier}/cancel:
+  /workflows/{identifier}/action:
     x-swagger-router-controller: workflows
     put:
-      operationId: workflowsCancel
+      operationId: workflowsAction
       x-privileges: [ 'Write' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
-        cancel the specified workflow
+        Perform the specified action on the selected workflow
       description: |
-        cancel the specified workflow
+        Perform the specified action on the selected workflow
       parameters:
         - name: identifier
           in: path
@@ -1081,6 +1081,13 @@ paths:
             Workflow identifier
           required: true
           type: string
+        - name: action
+          in: body
+          description:
+            Command to execute on selected workflow
+          required: true
+          schema:
+            $ref: '#/definitions/action'
       tags: [ "/api/2.0" ]
       responses:
         200:
@@ -2601,3 +2608,15 @@ definitions:
     required:
       - username
       - password
+  action:
+    description: Action object
+    properties:
+      command:
+        type: string
+        description: 'Command to execute'
+        enum: [ "cancel" ]
+      options:
+        type: object
+        description: 'Command options object'
+    required:
+      - command


### PR DESCRIPTION
* GET, POST, DELETE, cancel a workflow.
* GET, PUT, DELETE a graph definition.
* GET, PUT, DELETE a task definition.
* active query param to workflows route

Separate the workflows routes into workflows /workflows/graphs and /workflows/tasks.  The graphs route is used for graph definitions. ant the tasks route is used for task definitions  Some semantics are now inconsistent with /nodes/:identifier/workflows.  This will be cleaned up in another PR.

See https://groups.google.com/forum/#!topic/rackhd/SvggYYKeeaQ for more detailed discussion.

This change has contributions from @dalebremner @abildw and @srinia6 

Depends on https://github.com/RackHD/on-core/pull/107