### PR TITLE
Add northbound sku support

### DIFF
--- a/lib/fittings/swagger_locals.js
+++ b/lib/fittings/swagger_locals.js
@@ -1,0 +1,45 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var injector = require('../../index.js').injector;
+var _ = injector.get('_');    // jshint ignore:line
+var Promise = injector.get('Promise');    // jshint ignore:line
+var debug = require('debug')('swagger:locals'); // jshint ignore:line
+var Error = injector.get('Errors'); // jshint ignore:line
+
+var skuParamHandler = function(context, value) {
+    var injector = require('../../index.js').injector;
+    var nodeServiceApi = injector.get('Http.Services.Api.Nodes');
+    return nodeServiceApi.getNodeById(value)
+    .then(function(node) {
+        if(node.sku) {
+            context.response.locals.scope.unshift(node.sku);
+        }
+    })
+    .catch(function() {
+        debug('Skipping processing in skuParamHandler for %s', value);
+    });
+};
+
+module.exports = function create() {
+    var anchorFuncs = {
+        sku: skuParamHandler
+    };
+    var anchors = _.keys(anchorFuncs);
+
+    return function swagger_locals(context, next) {    // jshint ignore:line
+        var promises = [];
+        var operation = context.request.swagger.operation;
+        _.forEach(operation.parameterObjects, function(param) {
+            if(-1 !== _.indexOf(anchors, param['x-param-handler'])) {
+                var value = _.get(context.request.swagger.params, [param.name, 'raw'].join('.') );
+                promises.push( anchorFuncs[param['x-param-handler']].apply(null, [context, value]) );
+            }
+        });
+
+        return Promise.all(promises).then(function() {
+            next();
+        });
+    };
+};

--- a/lib/services/redfish-validator-service.js
+++ b/lib/services/redfish-validator-service.js
@@ -18,7 +18,9 @@ di.annotate(redfishValidatorFactory,
         'Templates',
         'ejs',
         'Http.Api.Services.Schema',
-        'Errors'
+        'Errors',
+        'Services.Environment',
+        'Constants'
     )
 );
 
@@ -31,7 +33,9 @@ function redfishValidatorFactory(
     templates,
     ejs,
     schemaApiService,
-    Errors
+    Errors,
+    env,
+    Constants
 ) {
     var logger = Logger.initialize(redfishValidatorFactory);
     var fs = Promise.promisifyAll(nodeFs);
@@ -81,7 +85,14 @@ function redfishValidatorFactory(
 
     RedfishValidator.prototype.render = function(templateName, schemaName, options) {
         var self = this;
-        return Promise.all([self.get(templateName, options), ready])
+        return Promise.props({
+            sku: options.templateScope ? env.get('config', {}, [ options.templateScope[0] ]) : null,
+            env: options.templateScope ? env.get('config', {}, options.templateScope ) : null
+        }).then(function(localOptions) {
+            return Promise.all([
+                self.get(templateName, _.merge(options, localOptions) ), 
+                ready
+            ])
             .spread(function(output) {
                 return schemaApiService.validate(output, schemaName)
                     .then(function(result) {
@@ -91,12 +102,13 @@ function redfishValidatorFactory(
                         return output;
                     });
             });
+        });
     };
 
     RedfishValidator.prototype.makeOptions = function(req, res, identifier) {
         return {
             basepath: req.swagger.operation.api.basePath,
-            templateScope: ['global'],
+            templateScope: res.locals.scope,
             url: req.url,
             identifier: identifier
         };
@@ -157,7 +169,6 @@ function redfishValidatorFactory(
             res.status(status).json(output);
         });
     };
-
 
     RedfishValidator.prototype.getMessageRegistry = function(identifier) {
         if (identifier === 'Base.1.0.0') {

--- a/spec/lib/api/redfish-1.0/chassis-spec.js
+++ b/spec/lib/api/redfish-1.0/chassis-spec.js
@@ -11,6 +11,7 @@ describe('Redfish Chassis Root', function () {
     var taskProtocol;
     var fs;
     var validator;
+    var env;
 
     before('start HTTP server', function () {
         this.timeout(5000);
@@ -30,6 +31,9 @@ describe('Redfish Chassis Root', function () {
 
             taskProtocol = helper.injector.get('Protocol.Task');
             sinon.stub(taskProtocol);
+
+            env = helper.injector.get('Services.Environment');
+            sinon.stub(env, "get").resolves();
 
             var nodeFs = helper.injector.get('fs');
             fs = Promise.promisifyAll(nodeFs);
@@ -65,6 +69,7 @@ describe('Redfish Chassis Root', function () {
     after('stop HTTP server', function () {
         validator.validate.restore();
         redfish.render.restore();
+        env.get.restore();
         
         function restoreStubs(obj) {
             _(obj).methods().forEach(function (method) {

--- a/spec/lib/api/redfish-1.0/registry-spec.js
+++ b/spec/lib/api/redfish-1.0/registry-spec.js
@@ -9,6 +9,7 @@ describe('Redfish Registries', function () {
     var fs;
     var Promise;
     var template;
+    var env;
 
     // Skip reading the entry from Mongo and return the entry directly
     function redirectGet(entry) {
@@ -30,6 +31,8 @@ describe('Redfish Registries', function () {
             Promise = helper.injector.get('Promise');
             var nodeFs = helper.injector.get('fs');
             fs = Promise.promisifyAll(nodeFs);
+            env = helper.injector.get('Services.Environment');
+            sinon.stub(env, "get").resolves();
         });
     });
     beforeEach('set up mocks', function () {
@@ -48,6 +51,7 @@ describe('Redfish Registries', function () {
         validator.validate.restore();
         redfish.render.restore();
         template.get.restore();
+        env.get.restore();
         return helper.stopServer();
     });
 

--- a/spec/lib/api/redfish-1.0/session-service-spec.js
+++ b/spec/lib/api/redfish-1.0/session-service-spec.js
@@ -12,6 +12,7 @@ describe('Redfish Session Service', function () {
     var Constants;
     var template;
     var fs;
+    var env;
 
     // Skip reading the entry from Mongo and return the entry directly
     function redirectGet(entry) {
@@ -48,6 +49,9 @@ describe('Redfish Session Service', function () {
 
             Promise = helper.injector.get('Promise');
 
+            env = helper.injector.get('Services.Environment');
+            sinon.stub(env, "get").resolves();
+
             var nodeFs = helper.injector.get('fs');
             fs = Promise.promisifyAll(nodeFs);
 
@@ -82,6 +86,7 @@ describe('Redfish Session Service', function () {
         validator.validate.restore();
         redfish.render.restore();
         template.get.restore();
+        env.get.restore();
 
         function restoreStubs(obj) {
             _(obj).methods().forEach(function (method) {

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -233,6 +233,38 @@ describe('Redfish Systems Root', function () {
             });
     });
 
+    it('should return a valid system with sku', function() {
+        waterline.nodes.needByIdentifier.withArgs('1234abcd1234abcd1234abcd')
+        .resolves(Promise.resolve({
+            id: '1234abcd1234abcd1234abcd',
+            name: '1234abcd1234abcd1234abcd',
+            sku: 'sku-value'
+        }));
+
+        waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
+            node: '1234abcd1234abcd1234abcd',
+            source: 'dummysource',
+            data: catalogData
+        }));
+
+        waterline.workitems.findPollers.resolves([{
+            config: { command: 'chassis' }
+        }]);
+
+        taskProtocol.requestPollerCache.resolves([{
+            chassis: { power: "Unknown", uid: "Unknown"}
+        }]);
+
+        return helper.request().get('/redfish/v1/Systems/' + node.id)
+            .expect('Content-Type', /^application\/json/)
+            .expect(200)
+            .expect(function() {
+                expect(tv4.validate.called).to.be.true;
+                expect(validator.validate.called).to.be.true;
+                expect(redfish.render.called).to.be.true;
+            });
+    });
+    
     it('should 404 an invalid system', function() {
         return helper.request().get('/redfish/v1/Systems/bad' + node.id)
             .expect('Content-Type', /^application\/json/)

--- a/spec/lib/services/redfish-validator-service-spec.js
+++ b/spec/lib/services/redfish-validator-service-spec.js
@@ -8,6 +8,7 @@ describe("Redfish Validator Service", function() {
     var redfish;
     var template;
     var _;
+    var env;
     var testObj = {
         '@odata.context': '/redfish/v1/$metadata#Systems',
         '@odata.id': '/redfish/v1/Systems/',
@@ -32,6 +33,9 @@ describe("Redfish Validator Service", function() {
         template = helper.injector.get('Templates');
         _ = helper.injector.get('_');
 
+        env = helper.injector.get('Services.Environment');
+        sinon.stub(env, "get").resolves();
+
         sinon.stub(template, "get").resolves({contents: JSON.stringify(testObj)});
     });
 
@@ -41,6 +45,7 @@ describe("Redfish Validator Service", function() {
 
     helper.after(function () {
         template.get.restore();
+        env.get.restore();
     });
 
     it('should get and render without validation', function() {

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -206,6 +206,7 @@ paths:
           required: true
           type: string
           description: node identifier
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -238,6 +239,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -270,6 +272,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
         - name: socket
           in: path
           required: true
@@ -307,6 +310,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -340,6 +344,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
         - name: index
           in: path
           required: true
@@ -377,6 +382,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -410,6 +416,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -442,6 +449,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -475,6 +483,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
         - name: entryId
           in: path
           required: true
@@ -511,6 +520,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -542,6 +552,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
         - name: payload
           in: body
           required: true
@@ -578,6 +589,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -609,6 +621,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
         - name: payload
           in: body
           required: true
@@ -646,6 +659,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
       responses:
         200:
           description: Success
@@ -678,6 +692,7 @@ paths:
           in: path
           required: true
           type: string
+          x-param-handler: sku
         - name: index
           in: path
           required: true

--- a/swagger_config/default.yaml
+++ b/swagger_config/default.yaml
@@ -40,6 +40,7 @@ swagger:
       - onError: json_error_handler
       - cors
       - swagger_params_parser
+      - swagger_locals
       - swagger_authn
       - swagger_authz
       - swagger_security


### PR DESCRIPTION
- Add parameter handler fittings to perform parameter translation/setup
  functions and add a handler that will extract a node id and setup the
  res.locals.scope to enable northbound sku views.
- Update redfish template scope to use the pre-established res.locals.scope
- Update redfish rendering to add sku/env as done in common-api-presenter