### PR TITLE
Master-Delete-Tag option for all nodes with a specified tagName

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -85,7 +85,7 @@ var nodesPatchTagById = controller(function(req) {
 
 var nodesMasterDelTagById = controller(function(req) {
     return nodes.masterDelTagById(req.swagger.params.tagName.value);
-})
+});
 
 module.exports = {
     nodesGetAll: nodesGetAll,

--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -80,7 +80,7 @@ var nodesDelTagById = controller(function(req) {
 
 var nodesPatchTagById = controller(function(req) {
     return nodes.addTagsById(req.swagger.params.identifier.value,
-                             req.swagger.params.body.value.tags);
+                             req.body.tags);
 });
 
 var nodesMasterDelTagById = controller(function(req) {

--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -79,9 +79,13 @@ var nodesDelTagById = controller(function(req) {
 });
 
 var nodesPatchTagById = controller(function(req) {
-    return nodes.addTagsById(req.swagger.params.identifier.value, 
+    return nodes.addTagsById(req.swagger.params.identifier.value,
                              req.swagger.params.body.value.tags);
 });
+
+var nodesMasterDelTagById = controller(function(req) {
+    return nodes.masterDelTagById(req.swagger.params.tagName.value);
+})
 
 module.exports = {
     nodesGetAll: nodesGetAll,
@@ -101,5 +105,6 @@ module.exports = {
     nodesDelActiveWorkflowById: nodesDelActiveWorkflowById,
     nodesGetTagsById: nodesGetTagsById,
     nodesDelTagById: nodesDelTagById,
-    nodesPatchTagById: nodesPatchTagById
+    nodesPatchTagById: nodesPatchTagById,
+    nodesMasterDelTagById: nodesMasterDelTagById
 };

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -520,18 +520,11 @@ function nodeApiServiceFactory(
         .then(function() {
             return waterline.nodes.findByTag(tagName);
         })
-        .then(function(nodes) {
-            nodes.map(function (node) {
-                return waterline.nodes.remTags(node.id, tagName);
-            })
-            return nodes;
-        })
-        .then(function(nodes) {
-            var nodeIdlist = nodes.map(function(node){
-                return node.id;
-            })
-            return nodeIdlist;
-        })
+        .map(function(node) {
+            return waterline.nodes.remTags(node.id, tagName)
+                .then(function()
+                {return node.id; });
+        });
     };
 
 

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -515,7 +515,7 @@ function nodeApiServiceFactory(
      */
     NodeApiService.prototype.masterDelTagById = function(tagName) {
         return Promise.resolve().then(function() {
-                assert.string(tagName, 'tag must be a string');
+            assert.string(tagName, 'tag must be a string');
         })
         .then(function() {
             return waterline.nodes.findByTag(tagName);

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -509,6 +509,33 @@ function nodeApiServiceFactory(
     };
 
     /**
+     * Remove the tag from a list of nodes
+     * @param  {String}     tagName
+     * @return {Promise}
+     */
+    NodeApiService.prototype.masterDelTagById = function(tagName) {
+        return Promise.resolve().then(function() {
+                assert.string(tagName, 'tag must be a string');
+        })
+        .then(function() {
+            return waterline.nodes.findByTag(tagName);
+        })
+        .then(function(nodes) {
+            nodes.map(function (node) {
+                return waterline.nodes.remTags(node.id, tagName);
+            })
+            return nodes;
+        })
+        .then(function(nodes) {
+            var nodeIdlist = nodes.map(function(node){
+                return node.id;
+            })
+            return nodeIdlist;
+        })
+    };
+
+
+    /**
      * Get a list of tags applied to the specified id
      * @param  {String}     id
      * @return {Promise}    Resolves to an array of tags
@@ -522,6 +549,7 @@ function nodeApiServiceFactory(
         })
         .then(function (node) {
             return node.tags;
+
         });
     };
 

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -686,7 +686,7 @@ describe('Http.Api.Nodes', function () {
             sinon.stub(nodesApi, 'getTagsById').resolves([]);
             sinon.stub(nodesApi, 'addTagsById').resolves([]);
             sinon.stub(nodesApi, 'removeTagsById').resolves([]);
-            sinon.stub(nodesApi, 'masterDelTagById').resolves([]);
+            sinon.stub(nodesApi, 'masterDelTagById').resolves(['1234abcd1234abcd1234abcd', '5678efgh5678efgh5678efgh']);
         });
 
         after(function() {
@@ -728,10 +728,10 @@ describe('Http.Api.Nodes', function () {
             return helper.request().delete('/api/2.0/nodes/tags/name')
                 .expect('Content-Type', /^application\/json/)
                 .expect(200)
-                .expect(function() {
+                .expect(function(res) {
                     expect(nodesApi.masterDelTagById).to.have.been.calledWith('name');
-                });
+                    expect(res.body).to.deep.equal(['1234abcd1234abcd1234abcd','5678efgh5678efgh5678efgh']);
+                })
         });
-
     });
 });

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -686,12 +686,14 @@ describe('Http.Api.Nodes', function () {
             sinon.stub(nodesApi, 'getTagsById').resolves([]);
             sinon.stub(nodesApi, 'addTagsById').resolves([]);
             sinon.stub(nodesApi, 'removeTagsById').resolves([]);
+            sinon.stub(nodesApi, 'masterDelTagById').resolves([]);
         });
 
         after(function() {
             nodesApi.getTagsById.restore();
             nodesApi.addTagsById.restore();
             nodesApi.removeTagsById.restore();
+            nodesApi.masterDelTagById.restore();
         });
 
         it('should call getTagsById', function() {
@@ -719,6 +721,15 @@ describe('Http.Api.Nodes', function () {
                 .expect(200)
                 .expect(function() {
                     expect(nodesApi.removeTagsById).to.have.been.calledWith('123', 'name');
+                });
+        });
+
+        it('should call masterDelTagById', function() {
+            return helper.request().delete('/api/2.0/nodes/tags/name')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function() {
+                    expect(nodesApi.masterDelTagById).to.have.been.calledWith('name');
                 });
         });
 

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -686,7 +686,8 @@ describe('Http.Api.Nodes', function () {
             sinon.stub(nodesApi, 'getTagsById').resolves([]);
             sinon.stub(nodesApi, 'addTagsById').resolves([]);
             sinon.stub(nodesApi, 'removeTagsById').resolves([]);
-            sinon.stub(nodesApi, 'masterDelTagById').resolves(['1234abcd1234abcd1234abcd', '5678efgh5678efgh5678efgh']);
+            sinon.stub(nodesApi, 'masterDelTagById')
+                .resolves(['1234abcd1234abcd1234abcd', '5678efgh5678efgh5678efgh']);
         });
 
         after(function() {
@@ -730,8 +731,9 @@ describe('Http.Api.Nodes', function () {
                 .expect(200)
                 .expect(function(res) {
                     expect(nodesApi.masterDelTagById).to.have.been.calledWith('name');
-                    expect(res.body).to.deep.equal(['1234abcd1234abcd1234abcd','5678efgh5678efgh5678efgh']);
-                })
+                    expect(res.body).to.deep.equal
+                    (['1234abcd1234abcd1234abcd','5678efgh5678efgh5678efgh']);
+                });
         });
     });
 });

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -10,6 +10,7 @@ describe("Http.Services.Api.Nodes", function () {
     var updateByIdentifier;
     var create;
     var needByIdentifier;
+    var findByTag;
     var findActiveGraphForTarget;
     var computeNode;
     var enclosureNode;
@@ -736,8 +737,16 @@ describe("Http.Services.Api.Nodes", function () {
     });
 
     describe('Tagging', function() {
+
         var node = {
-            id: '1234abcd1234abcd1234abce'
+            id: '1234abcd1234abcd1234abcd',
+            name: 'name1',
+            type: 'compute',
+        };
+        var node1 = {
+            id: '5678efgh5678efgh5678efgh',
+            name: 'name1',
+            type: 'compute',
         };
 
         before(function() {
@@ -816,6 +825,17 @@ describe("Http.Services.Api.Nodes", function () {
                     expect(e).to.have.property('name').that.equals('AssertionError');
                     expect(waterline.nodes.findByTag).to.not.be.called;
                     expect(needByIdentifier).to.not.be.called;
+                });
+        });
+
+        it('should call waterline to get list of nodes and remove the specified' +
+            ' tag', function() {
+            var tagName = 'name1';
+            waterline.nodes.findByTag.resolves([node, node1]);
+            return nodeApiService.masterDelTagById(tagName)
+                .then(function() {
+                    expect(waterline.nodes.remTags).to.have.been.calledWith(node.id,tagName);
+                    expect(waterline.nodes.remTags).to.have.been.calledWith(node1.id,tagName);
                 });
         });
     });

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -10,7 +10,6 @@ describe("Http.Services.Api.Nodes", function () {
     var updateByIdentifier;
     var create;
     var needByIdentifier;
-    var findByTag;
     var findActiveGraphForTarget;
     var computeNode;
     var enclosureNode;
@@ -740,12 +739,12 @@ describe("Http.Services.Api.Nodes", function () {
 
         var node = {
             id: '1234abcd1234abcd1234abcd',
-            name: 'name1',
+            tags: ['name1'],
             type: 'compute',
         };
         var node1 = {
             id: '5678efgh5678efgh5678efgh',
-            name: 'name1',
+            tags: ['name1'],
             type: 'compute',
         };
 

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -1494,6 +1494,36 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+
+  /nodes/tags/{tagName}:
+    x-swagger-router-controller: nodes
+    delete:
+      operationId: nodesMasterDelTagById
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Delete specified tag from all nodes.
+      description: |
+        Delete specified tag from all nodes.
+      parameters:
+        - name: tagName
+          in: path
+          description: The tag identifier
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: Delete successful
+        404:
+          description: The tag name identifier was not found.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
   /nodes/{identifier}:
     x-swagger-router-controller: nodes
     get:
@@ -1597,6 +1627,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+
   /nodes/{identifier}/tags:
     x-swagger-router-controller: nodes
     get:


### PR DESCRIPTION
* Add swagger API monorail 2.0 support in nodes.js for masterDelTagById
* Add support for masterDelTagById in nodes-api-service.js
* Update monorail-2.0.yaml for master-delete-tag option under /nodes/tags/{tagName}
