### PR TITLE
Return 204 if no workflow is active

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -61,7 +61,7 @@ var nodesPostWorkflowById = controller({success: 201}, function(req) {
     return nodes.setNodeWorkflow(config, req.swagger.params.identifier.value);
 });
 
-var nodesGetActiveWorkflowById = controller(function(req) {
+var nodesGetActiveWorkflowById = controller({ send204OnEmpty: true }, function(req) {
     return nodes.getActiveNodeWorkflowById(req.swagger.params.identifier.value);
 });
 


### PR DESCRIPTION
Fix a bug causing 200 to be returned from GET /api/2.0/nodes/:id/workflows/active if no workflow is active.  Return 204 instead.