### PR TITLE
fix unit-test: eventually should not be together with reject

### DIFF
--- a/spec/lib/services/pollers-api-service-spec.js
+++ b/spec/lib/services/pollers-api-service-spec.js
@@ -52,7 +52,7 @@ describe("Http.Services.Api.Pollers", function () {
         it('should return error if poller informations is not found', function () {
             var mockPollerError = new Errors.NotFoundError("Could not find workitem with identifier");
             waterline.workitems.find.rejects(mockPollerError);
-            return pollerService.getPollers().should.eventually.be.rejectedWith(mockPollerError);
+            return pollerService.getPollers().should.be.rejectedWith(mockPollerError);
         });
 
     });
@@ -88,7 +88,7 @@ describe("Http.Services.Api.Pollers", function () {
         it("should return error if specific poller info is not found", function () {
             var mockPollerError = new Errors.NotFoundError("Could not find workitem with identifier");
             waterline.workitems.needByIdentifier.rejects(mockPollerError);
-            return pollerService.getPollersById().should.eventually.be.rejectedWith(mockPollerError);
+            return pollerService.getPollersById().should.be.rejectedWith(mockPollerError);
         });
 
     });
@@ -130,7 +130,7 @@ describe("Http.Services.Api.Pollers", function () {
         it("Throws error when  postPollers runs with invalid input", function() {
             var mockPollerError = new Errors.ValidationError("Validation errors");
             waterline.workitems.create.rejects(mockPollerError);
-            return pollerService.postPollers().should.eventually.be.rejectedWith(mockPollerError);
+            return pollerService.postPollers().should.be.rejectedWith(mockPollerError);
         });
     });
 


### PR DESCRIPTION
I had found an odd problem, if putting the `eventually` together with `reject` in an unit-testing assertion, both positive and negative judgement will pass. Please see this issue for detail: https://github.com/RackHD/RackHD/issues/54.

I tend to think `Chai-as-Promise` need to fix this, as people is difficult to realize this problem. I will submit an issue for `Chai-as-Promise`. However, at present, we should avoid to write `eventually` with `reject`.

@RackHD/corecommitters @srinia6 @iceiilin @WangWinson @pengz1 @sunnyqianzhang @zyoung51 