### PR TITLE
API 2.0 /views route

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ di.annotate(Runner, new di.Inject(
         'Services.Configuration',
         'Profiles',
         'Templates',
+        'Views',
         'fileService',
         'Promise',
         'Http.Services.SkuPack',
@@ -26,6 +27,7 @@ function Runner(
     configuration,
     profiles,
     templates,
+    views,
     fileService,
     Promise,
     skuPack,
@@ -36,7 +38,7 @@ function Runner(
     function start() {
         return core.start()
             .then(function() {
-                return Promise.all([profiles.load(), templates.load()]);
+                return Promise.all([profiles.load(), templates.load(), views.load()]);
             })
             .then(function() {
                 return fileService.start({

--- a/data/views/sample.json
+++ b/data/views/sample.json
@@ -1,0 +1,3 @@
+{
+    "message": "sample"
+}

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function onHttpContextFactory(di, directory) {
 
         injectables: _.flattenDeep([
             helper.requireGlob(__dirname + '/lib/api/login/*.js'),
+            helper.requireGlob(__dirname + '/lib/api/view/*.js'),
             helper.requireGlob(__dirname + '/lib/api/1.1/**/*.js'),
             helper.requireGlob(__dirname + '/lib/services/**/*.js'),
             helper.requireGlob(__dirname + '/lib/serializables/**/*.js'),

--- a/lib/api/2.0/views.js
+++ b/lib/api/2.0/views.js
@@ -1,0 +1,99 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var views = injector.get('Views');
+var Promise = injector.get('Promise');
+var Errors = injector.get('Errors');
+var _ = injector.get('_');
+var bodyParser = require('body-parser');
+
+/**
+* @api {get} /api/2.0/views GET /views
+* @apiVersion 2.0.0
+* @apiDescription Get list of views
+* @apiName views-get
+* @apiGroup views
+* @apiSuccess {json} List of all views or if there are none an empty collection.
+*/
+var viewsGet = controller(function() {
+    return views.getAll();
+});
+
+/**
+* @api {get} /api/2.0/views/:identifier GET /views/:identifier
+* @apiVersion 2.0.0
+* @apiDescription get a specific view
+* @apiName views-getById
+* @apiGroup views
+* @apiParam {String} name of view
+* @apiSuccess {json} view with specified identifier.
+* @apiError NotFound There is no view with specified name
+*/
+var viewsGetById = controller(function(req) {
+    return views.get(req.swagger.params.identifier.value)
+    .then(function(view) {
+        if (_.isEmpty(view)) {
+            throw new Errors.NotFoundError(
+                'Could not find ' + req.swagger.params.identifier.value
+            );
+        }
+        return view;
+    });
+});
+
+/**
+* @api {put} /api/2.0/views/:identifier PUT /views/:identifer
+* @apiVersion 2.0.0
+* @apiDescription create or update a view
+* @apiName views-put
+* @apiGroup views
+* @apiParam {String} name of view
+* @apiSuccess {json} created or updated view.
+* @apiError Error was encountered, view is unchanged.
+*/
+var viewsPut = controller(function(req, res) {
+    var contentType = req.get('Content-Type');
+
+    var parsers = {
+        'application/octet-stream': Promise.promisify(bodyParser.raw({type: '*/*'})),
+        'text/plain': Promise.promisify(bodyParser.text({type: '*/*'}))
+    };
+
+    if (!_(parsers).has(contentType)) {
+        throw Errors.BadRequestError(contentType + ' is not a valid data type');
+    }
+
+    return parsers[contentType](req, res).then(function() {
+        return views.put(req.swagger.params.identifier.value, req.body.toString());
+    });
+});
+
+/**
+* @api {delete} /api/2.0/views/:identifier DELETE /views/:identifier
+* @apiVersion 2.0.0
+* @apiDescription Unlink specified view
+* @apiName views-delete
+* @apiGroup views
+* @apiParam {String} name of view
+* @apiError NotFound There is no view with specified name
+*/
+var viewsDelete = controller({send204OnEmpty: true}, function(req, res) {
+    return views.unlink(req.swagger.params.identifier.value)
+    .then(function(view) {
+        if (_.isEmpty(view)) {
+            throw new Errors.NotFoundError(
+                'Could not delete ' + req.swagger.params.identifier.value
+            );
+        }
+    });
+});
+
+module.exports = {
+    viewsGet: viewsGet,
+    viewsGetById: viewsGetById,
+    viewsPut: viewsPut,
+    viewsDelete: viewsDelete
+};

--- a/lib/api/2.0/views.js
+++ b/lib/api/2.0/views.js
@@ -80,7 +80,7 @@ var viewsPut = controller(function(req, res) {
 * @apiParam {String} name of view
 * @apiError NotFound There is no view with specified name
 */
-var viewsDelete = controller({send204OnEmpty: true}, function(req, res) {
+var viewsDelete = controller({send204OnEmpty: true}, function(req) {
     return views.unlink(req.swagger.params.identifier.value)
     .then(function(view) {
         if (_.isEmpty(view)) {

--- a/lib/api/view/view.js
+++ b/lib/api/view/view.js
@@ -1,6 +1,8 @@
 // Copyright 2015, EMC, Inc.
 var di = require('di');
 
+'use strict';
+
 module.exports = viewServiceFactory;
 
 di.annotate(viewServiceFactory, new di.Provide('Views'));

--- a/lib/api/view/view.js
+++ b/lib/api/view/view.js
@@ -1,0 +1,25 @@
+// Copyright 2015, EMC, Inc.
+var di = require('di');
+
+module.exports = viewServiceFactory;
+
+di.annotate(viewServiceFactory, new di.Provide('Views'));
+di.annotate(viewServiceFactory, new di.Inject(
+        'Constants',
+        'DbRenderableContent',
+        'Util'
+));
+
+function viewServiceFactory(Constants, DbRenderable, Util) {
+    Util.inherits(ViewService, DbRenderable);
+
+    function ViewService() {
+        DbRenderable.call(this, {
+            directory: Constants.Views.Directory,
+            collectionName: 'views'
+        });
+    }
+
+    return new ViewService();
+}
+

--- a/spec/lib/api/2.0/views-spec.js
+++ b/spec/lib/api/2.0/views-spec.js
@@ -1,0 +1,147 @@
+// Copyright 2015, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Views', function () {
+    var viewsProtocol;
+    var _;
+
+    before('start HTTP server', function () {
+        this.timeout(10000);
+        viewsProtocol = {
+            load: sinon.stub(),
+            getAll: sinon.stub(),
+            get: sinon.stub(),
+            put: sinon.stub(),
+            unlink: sinon.stub()
+        };
+
+        return helper.startServer([
+            dihelper.simpleWrapper(viewsProtocol, 'Views')
+        ]).then(function() {
+            _ = helper.injector.get('_');
+        });
+    });
+
+    beforeEach('reset stubs', function () {
+        _(viewsProtocol).methods().forEach(function (method) {
+            if (_(viewsProtocol).has(method)) {
+              viewsProtocol[method].reset();
+            }
+        }).value();
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    describe('2.0 Views', function() {
+        // should create a view (octet-stream)
+        it('should get all views', function() {
+            var views = [
+                {name: 'foo', content: 'foo', scope: 'global'},
+                {name: 'bar', content: 'bar', scope: 'global'}
+            ];
+            viewsProtocol.getAll.resolves(views);
+            return helper.request().get('/api/2.0/views')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function(res) {
+                    _(res.body).forEach(function(view, i) {
+                        expect(view).to.deepEqual(views[i])
+                    });
+                    expect(viewsProtocol.getAll).to.have.been.calledOnce;
+                });
+        });
+
+        it('should get one view', function() {
+            var view = {name: 'foo', content: 'foo', scope: 'global'};
+
+            viewsProtocol.get.resolves(view);
+            return helper.request().get('/api/2.0/views/foo')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function(res) {
+                    expect(res.body).to.deep.equal(view);
+                    expect(viewsProtocol.get).to.have.been.calledOnce;
+                    expect(viewsProtocol.get).to.have.been.calledWith('foo');
+                });
+        });
+
+        it('should fail to get non-existant view', function() {
+            viewsProtocol.get.resolves();
+            return helper.request().get('/api/2.0/views/foo')
+                .expect('Content-Type', /^application\/json/)
+                .expect(404)
+                .expect(function(res) {
+                    expect(viewsProtocol.get).to.have.been.calledOnce;
+                    expect(viewsProtocol.get).to.have.been.calledWith('foo');
+                });
+        });
+
+        it('should create a text/plain view', function() {
+            var view = {name: 'foo', content: 'foo', scope: 'global'};
+
+            viewsProtocol.put.resolves(view);
+            return helper.request().put('/api/2.0/views/foo')
+                .set('Content-Type', 'text/plain')
+                .send('{ "message": "hello" }')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function(res) {
+                    expect(res.body).to.deep.equal(view);
+                    expect(viewsProtocol.put).to.have.been.calledOnce;
+                });
+        });
+
+        it('should create an application/octet-stream view', function() {
+            var view = {name: 'foo', content: 'foo', scope: 'global'};
+            var req = helper.request().put('/api/2.0/views/foo');
+
+            viewsProtocol.put.resolves(view);
+            req.set('Content-Type', 'application/octet-stream');
+            req.write(Buffer('{ "message": "hello" }', 'ascii'));
+            req.end(function(err, res) {
+                expect(res.get('Content-Type')).to.match(/^application\/json/);
+                expect(res.status).to.equal(200);
+                expect(res.body).to.deep.equal(view);
+                expect(viewsProtocol.put).to.have.been.calledOnce;
+            });
+        });
+
+        it('should reject invalid data type', function() {
+            return helper.request().put('/api/2.0/views/foo')
+                .set('Content-Type', 'text/html')
+                .send('{ "message": "hello" }')
+                .expect('Content-Type', /^application\/json/)
+                .expect(400)
+                .expect(function(res) {
+                    expect(viewsProtocol.put).not.to.have.been.called;
+                });
+        });
+
+        it('should delete a view', function() {
+            var view = {name: 'foo', content: 'foo', scope: 'global'};
+
+            viewsProtocol.unlink.resolves(view);
+            return helper.request().delete('/api/2.0/views/foo')
+                .expect(204)
+                .expect(function(res) {
+                    expect(viewsProtocol.unlink).to.have.been.calledOnce;
+                    expect(viewsProtocol.unlink).to.have.been.calledWith('foo');
+                });
+        });
+
+        it('should fail to delete non-existant view', function() {
+            viewsProtocol.unlink.resolves();
+            return helper.request().delete('/api/2.0/views/foo')
+                .expect('Content-Type', /^application\/json/)
+                .expect(404)
+                .expect(function(res) {
+                    expect(viewsProtocol.unlink).to.have.been.calledOnce;
+                    expect(viewsProtocol.unlink).to.have.been.calledWith('foo');
+                });
+        });
+    });
+});

--- a/spec/lib/api/2.0/views-spec.js
+++ b/spec/lib/api/2.0/views-spec.js
@@ -48,8 +48,8 @@ describe('Http.Api.Views', function () {
                 .expect('Content-Type', /^application\/json/)
                 .expect(200)
                 .expect(function(res) {
-                    _(res.body).forEach(function(view, i) {
-                        expect(view).to.deepEqual(views[i])
+                    res.body.forEach(function(view, i) {
+                        expect(view).to.deep.equal(views[i]);
                     });
                     expect(viewsProtocol.getAll).to.have.been.calledOnce;
                 });
@@ -74,7 +74,7 @@ describe('Http.Api.Views', function () {
             return helper.request().get('/api/2.0/views/foo')
                 .expect('Content-Type', /^application\/json/)
                 .expect(404)
-                .expect(function(res) {
+                .expect(function() {
                     expect(viewsProtocol.get).to.have.been.calledOnce;
                     expect(viewsProtocol.get).to.have.been.calledWith('foo');
                 });
@@ -101,7 +101,7 @@ describe('Http.Api.Views', function () {
 
             viewsProtocol.put.resolves(view);
             req.set('Content-Type', 'application/octet-stream');
-            req.write(Buffer('{ "message": "hello" }', 'ascii'));
+            req.write(new Buffer('{ "message": "hello" }', 'ascii'));
             req.end(function(err, res) {
                 expect(res.get('Content-Type')).to.match(/^application\/json/);
                 expect(res.status).to.equal(200);
@@ -116,7 +116,7 @@ describe('Http.Api.Views', function () {
                 .send('{ "message": "hello" }')
                 .expect('Content-Type', /^application\/json/)
                 .expect(400)
-                .expect(function(res) {
+                .expect(function() {
                     expect(viewsProtocol.put).not.to.have.been.called;
                 });
         });
@@ -127,7 +127,7 @@ describe('Http.Api.Views', function () {
             viewsProtocol.unlink.resolves(view);
             return helper.request().delete('/api/2.0/views/foo')
                 .expect(204)
-                .expect(function(res) {
+                .expect(function() {
                     expect(viewsProtocol.unlink).to.have.been.calledOnce;
                     expect(viewsProtocol.unlink).to.have.been.calledWith('foo');
                 });
@@ -138,7 +138,7 @@ describe('Http.Api.Views', function () {
             return helper.request().delete('/api/2.0/views/foo')
                 .expect('Content-Type', /^application\/json/)
                 .expect(404)
-                .expect(function(res) {
+                .expect(function() {
                     expect(viewsProtocol.unlink).to.have.been.calledOnce;
                     expect(viewsProtocol.unlink).to.have.been.calledWith('foo');
                 });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -377,6 +377,116 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /views:
+    x-swagger-router-controller: views
+    get:
+      operationId: viewsGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        get all views
+      description: |
+        get all views
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            all views
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /views/{identifier}:
+    x-swagger-router-controller: views
+    get:
+      operationId: viewsGetById
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        get view with specified identifier
+      description: |
+        get view with specified identifier
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Name of view to get
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            single view
+          schema:
+            type: object
+        404:
+          description: |
+            There is no view with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      operationId: viewsPut
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      consumes:
+        - text/plain
+        - application/octet-stream
+      summary: |
+        put a single view
+      description: |
+        put a single view
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Name of view to create or update
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            return template
+          schema:
+            type: object
+    delete:
+      operationId: viewsDelete
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        put a single view
+      description: |
+        put a single view
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            Name of view to delete
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        204:
+          description: |
+            return template
+          schema:
+            type: object
+        404:
+          description: |
+            There is no view with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /skus/pack:
     x-swagger-router-controller: skus
     post:


### PR DESCRIPTION
Views are a collection of ejs templates used for rendering resources into views.  The intent of this change is to logically separate templates used for workflows from templates used for presentation of resources.  Additional PRs to integrate views with the render fitting and to add views for various resources are forthcoming.

Depends on https://github.com/RackHD/on-core/pull/109