### PR TITLE
Remove use of common_api_presenter for tasks 2.0 route

### DIFF
--- a/lib/api/2.0/tasks.js
+++ b/lib/api/2.0/tasks.js
@@ -9,25 +9,9 @@ var taskProtocol = injector.get('Protocol.Task');
 var Errors = injector.get('Errors');
 var presenter = injector.get('common-api-presenter');
 
-function getBootstrap (req, res) {
-    tasksApiService.getNode(req.swagger.params.macAddress.value)
-        .then(function (node) {
-             if (node) {
-                presenter(req, res)
-                    .renderTemplate(
-                        'bootstrap.js',
-                        {
-                            identifier: node.id
-                        }
-                    );
-            } else {
-                presenter(req, res).renderNotFound();
-            }
-        })
-        .catch(function (err) {
-            presenter(req, res).renderError(err);
-        });
-}
+var getBootstrap = controller( function (req, res) {
+    return tasksApiService.getBootstrap(req, res, req.swagger.params.macAddress.value);
+});
 
 var getTasksById = controller( {send204OnEmpty:true}, function (req){
     return tasksApiService.getTasks(req.swagger.params.identifier.value)

--- a/lib/fittings/swagger_render.js
+++ b/lib/fittings/swagger_render.js
@@ -19,7 +19,7 @@ module.exports = function create(fittingDef) {
                 {
                     status = 204;
                 }
-                context.response.status(status).json(context.response.body);
+                context.response.status(status).send(context.response.body);
             } else {
                 swag.renderer(template, context.request.swagger.options.rendererOptions, next)
                 .then(function (renderedOutput) {

--- a/lib/services/task-api-service.js
+++ b/lib/services/task-api-service.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var di = require('di');
+var ejs = require('ejs');
 
 module.exports = taskApiServiceFactory;
 di.annotate(taskApiServiceFactory, new di.Provide('Http.Services.Api.Tasks'));
@@ -12,14 +13,23 @@ di.annotate(taskApiServiceFactory,
         'Services.Waterline',
         'Errors',
         'Util',
-        'Logger'
+        'Services.Configuration',
+        'Services.Lookup',
+        'Services.Environment',
+        'Promise',
+        'Templates'
     )
 );
 function taskApiServiceFactory(
     taskProtocol,
     waterline,
     Errors,
-    util
+    util,
+    configuration,
+    lookupService,
+    Env,
+    Promise,
+    templates
 ) {
 
     function NoActiveTaskError(message) {
@@ -47,6 +57,35 @@ function taskApiServiceFactory(
         .then(function() {
             return taskProtocol.requestCommands(identifier);
         });
+    };
+
+    TaskApiService.prototype.getBootstrap = function (req, res, macAddress) {
+        var scope = res.locals.scope;
+        return this.getNode(macAddress).then(function (node) {
+                if (node) {
+
+                    var promises = [
+                        Promise.props({
+                            identifier: node.id,
+                            server: configuration.get('apiServerAddress', '10.1.1.1'),
+                            port: configuration.get('apiServerPort', 80),
+                            ipaddress: res.locals.ipAddress,
+                            netmask: configuration.get('dhcpSubnetMask', '255.255.255.0'),
+                            gateway: configuration.get('dhcpGateway', '10.1.1.1'),
+                            macaddress: lookupService.ipAddressToMacAddress(res.locals.ipAddress),
+                            sku: Env.get('config', {}, [scope[0]]),
+                            env: Env.get('config', {}, scope)
+                        }),
+                        templates.get('bootstrap.js', scope),
+                    ];
+
+                    return Promise.all(promises).spread(function (options, template) {
+                        return ejs.render(template.contents, options);
+                    });
+                } else {
+                    throw new Errors.NotFoundError('Node not found');
+                }
+            });
     };
 
     return new TaskApiService();

--- a/spec/lib/api/2.0/tasks-spec.js
+++ b/spec/lib/api/2.0/tasks-spec.js
@@ -96,11 +96,11 @@ describe('Http.Api.Tasks', function () {
                 .expect(404);
         });
 
-        it("should render a 500 if tasksApiService.getNode errors", function() {
+        it("should render a 400 if tasksApiService.getNode errors", function() {
             tasksApiService.getNode.rejects(new Error('asdf'));
             return helper.request()
                 .get('/api/2.0/tasks/bootstrap.js?macAddress=00:11:22:33:44:55')
-                .expect(500);
+                .expect(400);
         });
     });
 


### PR DESCRIPTION
Remove the use of the common_api_presenter from the tasks 2.0 route.  This allows us to use the swagger renderer to generate the responses instead.  