### PR TITLE
Modify template/profile rendering to add options that are normally

### DIFF
--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -51,7 +51,7 @@ function profilesRouterFactory (
                     } else {
                         return profileApiService.renderProfileFromTaskOrNode(node)
                         .then(function (render) {
-                            presenter(req, res).renderProfile(render.profile, render.options);
+                            presenter(req, res).renderProfile(render.profile, render.options, 200, render.context);
                         });
                     }
                 });

--- a/lib/api/1.1/southbound/templates.js
+++ b/lib/api/1.1/southbound/templates.js
@@ -51,7 +51,10 @@ function templatesRouterFactory (
                 return workflowApiService.findActiveGraphForTarget(node.id)
                     .then(function(taskGraphInstance) {
                         if (taskGraphInstance) {
-                            return taskProtocol.requestProperties(node.id);
+                            return Promise.props({
+                                options: taskProtocol.requestProperties(node.id),
+                                context: taskGraphInstance.context
+                            });
                         } else {
                             return Promise.reject(
                                 new Error("Unable to find active graph for node " +
@@ -67,7 +70,10 @@ function templatesRouterFactory (
             presenter(req, res)
                 .renderTemplate(
                     req.params.identifier,
-                    properties
+                    properties.options,
+                    200,
+                    properties.context
+
                 );
         })
         .catch(function (err) {

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -203,7 +203,7 @@ function CommonApiPresenterFactory(
          * the EJS renderer.
          * @param  {Integer} [status]  An optional HTTP status code.
          */
-        CommonApiPresenter.prototype.renderTemplate = function (name, options, status) {
+        CommonApiPresenter.prototype.renderTemplate = function (name, options, status, graphContext) {
             var self = this;
 
             options = options || {};
@@ -211,24 +211,17 @@ function CommonApiPresenterFactory(
             var scope = self.res.locals.scope;
 
             var promises = [
-                Promise.props({
-                    server: configuration.get('apiServerAddress', '10.1.1.1'),
-                    port: configuration.get('apiServerPort', 80),
-                    ipaddress: self.res.locals.ipAddress,
-                    netmask: configuration.get('dhcpSubnetMask', '255.255.255.0'),
-                    gateway: configuration.get('dhcpGateway', '10.1.1.1'),
-                    macaddress: lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
-                    sku: Env.get('config', {}, [ scope[0] ]),
-                    env: Env.get('config', {}, scope)
-                }),
+                self._buildContext(graphContext),
                 templates.get(name, scope),
             ];
 
             Promise.all(promises).spread(function (localOptions, template) {
                 var output;
 
+                options = _.merge({}, options, localOptions);
+                
                 try {
-                    output = ejs.render(template.contents, _.merge(options, localOptions));
+                    output = ejs.render(template.contents, options);
                 } catch (err) {
                     return self.renderError(err, options);
                 }
@@ -248,7 +241,7 @@ function CommonApiPresenterFactory(
          * the EJS renderer.
          * @param  {Integer} status  An optional HTTP status code.
          */
-        CommonApiPresenter.prototype.renderProfile = function (profile, options, status) {
+        CommonApiPresenter.prototype.renderProfile = function (profile, options, status, graphContext) {
             var self = this;
             var scope = self.res.locals.scope;
 
@@ -256,16 +249,7 @@ function CommonApiPresenterFactory(
             status = status || 200;
 
             var promises = [
-                Promise.props({
-                    server: configuration.get('apiServerAddress', '10.1.1.1'),
-                    port: configuration.get('apiServerPort', 80),
-                    ipaddress: self.res.locals.ipAddress,
-                    netmask: configuration.get('dhcpSubnetMask', '255.255.255.0'),
-                    gateway: configuration.get('dhcpGateway', '10.1.1.1'),
-                    macaddress: lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
-                    sku: Env.get('config', {}, [ scope[0] ]),
-                    env: Env.get('config', {}, scope)
-                }),
+                self._buildContext(graphContext),
                 profiles.get(profile, true, scope)
             ];
 
@@ -284,8 +268,7 @@ function CommonApiPresenterFactory(
                 function (localOptions, contents, boilerPlate, errorPlate) {
                     var output = null;
 
-                    options = _.merge(options, localOptions);
-
+                    options = _.merge({}, options, localOptions);
                     try {
                         // Render the requested profile + options.
                         output = ejs.render(boilerPlate + contents, options);
@@ -315,6 +298,41 @@ function CommonApiPresenterFactory(
                 self.renderError(err);
             });
         };
+
+        CommonApiPresenter.prototype._buildContext = function(graphContext) {
+            var self = this;
+            var scope = self.res.locals.scope;
+            var config = CommonApiPresenter.configCache;
+            var baseUri = 'http://' + config.apiServerAddress + ':' + config.apiServerPort + '/api/current';
+            graphContext = graphContext || {};
+
+            return Promise.props({
+                server: config.apiServerAddress || '10.1.1.1',
+                port: config.apiServerPort || 80,
+                ipaddress: self.res.locals.ipAddress,
+                netmask: config.dhcpSubnetMask || '255.255.255.0',
+                gateway: config.dhcpGateway || '10.1.1.1',
+                macaddress: lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
+                sku: Env.get('config', {}, [ scope[0] ]),
+                env: Env.get('config', {}, scope),
+                // Build structure that mimics the task renderContext
+                api: {
+                    server: 'http://' + config.apiServerAddress + ':' + config.apiServerPort,
+                    base: baseUri,
+                    files: baseUri + '/files',
+                    nodes: baseUri + '/nodes'
+                },
+                context: graphContext,
+                task: {
+                    nodeId: graphContext.target
+                }
+            });
+        };
+
+        // NOTE: getAll() has turned out to be a perf bottleneck, taking up to 40ms in
+        // some cases. Until we make configuration updates dynamic, just cache this
+        // at startup to avoid performance issues.
+        CommonApiPresenter.configCache = configuration.getAll();
 
         return new CommonApiPresenter(req, res);
     }

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -178,55 +178,37 @@ function profileApiServiceFactory(
         return workflowApiService.findActiveGraphForTarget(node.id)
         .then(function (taskgraphInstance) {
             if (taskgraphInstance) {
-                return taskProtocol.requestProfile(node.id)
-                .then(function(profile) {
-                    return [profile, taskProtocol.requestProperties(node.id)];
+                return Promise.props({
+                    profile: taskProtocol.requestProfile(node.id),
+                    properties: taskProtocol.requestProperties(node.id),
+                    context: taskgraphInstance.context
                 })
-                .spread(function (profile, properties) {
-                    return {
-                        profile: profile || 'redirect.ipxe',
-                        options: self.convertProperties(properties)
-                    };
-                })
-                .catch(function (e) {
-                    logger.warning("Unable to retrieve workflow properties.", {
-                        error: e,
-                        id: node.id,
-                        taskgraphInstance: taskgraphInstance
-                    });
-                    return {
-                        profile: 'error.ipxe',
-                        options: {
-                            error: 'Unable to retrieve workflow properties.'
-                        }
-                    };
-                });
             } else {
-                if (_.has(node, 'bootSettings')) {
-                    if (_.has(node.bootSettings, 'options') &&
-                            _.has(node.bootSettings, 'profile')) {
-                        return {
-                            profile: node.bootSettings.profile,
-                            options: node.bootSettings.options
-                        };
-                    } else {
-                        return {
-                            profile: 'error.ipxe',
-                            options: {
-                                error: 'Unable to retrieve node bootSettings.'
-                            }
-                        };
-                    }
-                }
-                else {
-                    return {
-                        profile: 'error.ipxe',
-                        options: {
-                            error: 'Unable to locate active workflow or there is no bootSettings.'
-                        }
-                    };
-                }
+                return Promise.resolve({
+                    profile: _.get(node, 'bootSettings.profile', 'error.ipxe'),
+                    options: _.get(node, 'bootSettings.options', {
+                        error: 'Unable to retrieve node bootSettings'
+                    })
+                });
             }
+        })
+        .then(function(obj) {
+            return {
+                profile: obj.profile || 'redirect.ipxe',
+                options: obj.properties ? self.convertProperties(obj.properties) : obj.options
+            }
+        })
+        .catch(function (e) {
+            logger.warning("Unable to retrieve workflow properties.", {
+                error: e,
+                id: node.id
+            });
+            return {
+                profile: 'error.ipxe',
+                options: {
+                    error: 'Unable to retrieve workflow properties.'
+                }
+            };
         });
     };
 

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -184,7 +184,7 @@ describe("Http.Services.Api.Profiles", function () {
             var bootSettingsFailure = {
                 profile: 'error.ipxe',
                 options: {
-                    error: 'Unable to retrieve node bootSettings.'
+                    error: 'Unable to retrieve node bootSettings'
                 }
             };
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
@@ -217,7 +217,7 @@ describe("Http.Services.Api.Profiles", function () {
             var activeGraphFailure = {
                 profile: 'error.ipxe',
                 options: {
-                    error: 'Unable to locate active workflow or there is no bootSettings.'
+                    error: 'Unable to retrieve node bootSettings'
                 }
             };
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
@@ -234,9 +234,9 @@ describe("Http.Services.Api.Profiles", function () {
         it("render profile pass when having active graph and render succeed", function() {
             var node = { id: 'test' };
 
-            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(true);
+            this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves({context: true});
             this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
-            this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
+            this.sandbox.stub(taskProtocol, 'requestProperties').resolves({});
 
             return profileApiService.renderProfileFromTaskOrNode(node)
             .then(function(result) {


### PR DESCRIPTION
exposed to task templates:

- api.server: set to full API server URI
- api.base: set to API base URI
- api.files: set to File API base URI
- api.nodes: set to Nodes API base URI
- context: set to the graph context
- task.nodeId: set to the nodeId of the current graph