### PR TITLE
Modify files/:filename/latest to return the latest file

### DIFF
--- a/lib/api/1.1/northbound/files.js
+++ b/lib/api/1.1/northbound/files.js
@@ -90,7 +90,7 @@ function filesRouterFactory (Logger, configuration, fileService, assert) {
 
         return fileService.verify(query)
         .then(function(metadata) {
-            return metadata[0].uuid;
+            return metadata[metadata.length - 1].uuid;
         })
         .then(function(uuid) {
             return fileService.get(uuid);
@@ -279,7 +279,7 @@ function filesRouterFactory (Logger, configuration, fileService, assert) {
 
         return fileService.verify(query)
         .then(function(metadata) {
-            res.json(200,  metadata[0].md5);
+            res.json(200,  metadata[metadata.length - 1].md5);
         })
         .catch(function(err) {
             logger.warning("Failure serving file request", { error: err });

--- a/lib/services/files/file-plugin.js
+++ b/lib/services/files/file-plugin.js
@@ -104,7 +104,7 @@ function factory(Promise, waterline, uuid, assert,  _) {
         assert.object(fileObj, "file Object");
 
         return new Promise(function (resolve, reject) {
-            waterline.files.find(fileObj)
+            waterline.files.find({where: fileObj, sort: 'updatedAt DESC'})
             .exec(function(err, fileArray) {
                 err ? reject(err) : resolve(fileArray);
             });

--- a/lib/services/files/file-plugin.js
+++ b/lib/services/files/file-plugin.js
@@ -104,7 +104,7 @@ function factory(Promise, waterline, uuid, assert,  _) {
         assert.object(fileObj, "file Object");
 
         return new Promise(function (resolve, reject) {
-            waterline.files.find({where: fileObj, sort: 'updatedAt DESC'})
+            waterline.files.find(fileObj)
             .exec(function(err, fileArray) {
                 err ? reject(err) : resolve(fileArray);
             });


### PR DESCRIPTION
Fix ODR-605 about "Web UI / POST BIOSImage / API not selecting latest image with same basename uploaded for install". 
Metadata array got from on-http file service is in the time order based on waterline mechanism. Change waterline find method to return the list in sorted manner.