### PR TITLE
Update tags-api-service and monorail-2.0.yaml 

### DIFF
--- a/lib/services/tags-api-service.js
+++ b/lib/services/tags-api-service.js
@@ -44,7 +44,7 @@ function tagApiServiceFactory(
         return Promise.map(waterline.nodes.find(node), function(node) {
             return workflowApiService.createAndRunGraph({
                 options: {
-                    defaults: {
+                    'generate-tag': {
                         nodeId: node.id
                     }
                 },

--- a/spec/lib/api/1.1/tags-spec.js
+++ b/spec/lib/api/1.1/tags-spec.js
@@ -88,7 +88,7 @@ describe('Http.Api.Tags', function () {
                 .to.have.been.calledWith({
                     name: 'Graph.GenerateTags',
                     options: {
-                        defaults: {
+                        'generate-tag': {
                             nodeId: node.id
                         }
                     }

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -2440,7 +2440,7 @@ paths:
             $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             The created tag
           schema:


### PR DESCRIPTION
Updates to tags-api-service to use "generate-tag" key for options
Update monorail-2.0.yaml for POST/tags response code to be 201