### PR TITLE
Tag bugfixes

### DIFF
--- a/lib/api/1.1/northbound/tags.js
+++ b/lib/api/1.1/northbound/tags.js
@@ -14,7 +14,8 @@ di.annotate(tagsRouterFactory, new di.Inject(
         'Http.Services.Api.Nodes',
         'Http.Services.RestApi',
         '_',
-        'Promise'
+        'Promise',
+        'Errors'
     )
 );
 
@@ -23,7 +24,8 @@ function tagsRouterFactory (
     Nodes, 
     rest, 
     _, 
-    Promise
+    Promise,
+    Errors
 ) {
     var router = express.Router();
 
@@ -59,20 +61,25 @@ function tagsRouterFactory (
      * @apiDescription Create a tag with rules
      * @apiName post-tags
      * @apiGroup tags
-     * @apiSuccess (Success 200) {json} Information about the tag created
+     * @apiSuccess (Success 201) {json} Information about the tag created
      */
     router.post('/tags', parser.json(), rest(function (req) {
         return Tags.findTags({name: req.body.name})
             .then(function(tag) {
                 if(_.isEmpty(tag)) {
                     return Tags.createTag(req.body)
-                        .then(function() {
-                            return Tags.regenerateTags();
-                        });
+                    .then(function() {
+                        return Tags.regenerateTags();
+                    });
+                } else {
+                    // TODO: Replace with HttpError after errors are refactored
+                    var err = new Errors.BaseError('tag name already exists');
+                    err.status = 409;
+                    throw err;
                 }
             })
             .then(function() {
-                return req.body;
+                return Tags.getTag(req.body.name);
             });
     }, { renderOptions: { success: 201 } }));
 

--- a/lib/api/2.0/tags.js
+++ b/lib/api/2.0/tags.js
@@ -7,6 +7,7 @@ var controller = injector.get('Http.Services.Swagger').controller;
 var nodes = injector.get('Http.Services.Api.Nodes');
 var tags = injector.get('Http.Services.Api.Tags');
 var _ = injector.get('_'); // jshint ignore:line
+var Errors = injector.get('Errors');
 
 var getAllTags = controller(function(req) {
     return tags.findTags(req.query);
@@ -18,9 +19,14 @@ var createTag = controller({success: 201}, function(req) {
             return tags.createTag(req.swagger.params.body.value).then(function() {
                 return tags.regenerateTags();
             });
+        } else {
+            // TODO: Replace with HttpError after errors are refactored
+            var err = new Errors.BaseError('tag name already exists');
+            err.status = 409;
+            throw err;
         }
     }).then(function() {
-        return req.swagger.params.body.value;
+        return tags.getTag(req.swagger.params.body.value.name);
     });
 });
 

--- a/lib/services/tags-api-service.js
+++ b/lib/services/tags-api-service.js
@@ -11,14 +11,16 @@ di.annotate(tagApiServiceFactory,
     new di.Inject(
         'Services.Waterline',
         'Promise',
-        'Http.Services.Api.Workflows'
+        'Http.Services.Api.Workflows',
+        'Errors'
     )
 );
 
 function tagApiServiceFactory(
     waterline,
     Promise,
-    workflowApiService
+    workflowApiService,
+    Errors
 ) {
     function TagApiService() {
     }
@@ -28,11 +30,25 @@ function tagApiServiceFactory(
     };
 
     TagApiService.prototype.getTag = function(name) {
-        return waterline.tags.findOne({name: name});
+        name = decodeURI(name);
+        return waterline.tags.findOne({name: name})
+        .then(function(tag) {
+            if(!tag) {
+                throw new Errors.NotFoundError('name ' + name + ' was not found');
+            }
+            return tag;
+        });
     };
 
     TagApiService.prototype.destroyTag = function(name) {
-        return waterline.tags.destroy({name: name});
+        name = decodeURI(name);
+        return waterline.tags.findOne({name: name})
+        .then(function(tag) {
+            if(!tag) {
+                throw new Errors.NotFoundError('name ' + name + ' was not found');
+            }
+            return waterline.tags.destroy({name: name});
+        });
     };
 
     TagApiService.prototype.createTag = function(options) {

--- a/spec/lib/api/1.1/tags-spec.js
+++ b/spec/lib/api/1.1/tags-spec.js
@@ -96,6 +96,13 @@ describe('Http.Api.Tags', function () {
         });
     });
 
+    it('should 409 when the tag already exists', function () {
+        waterline.tags.find.resolves([input]);
+        return helper.request().post('/api/1.1/tags')
+        .send(input)
+        .expect(409);
+    });
+
     it('should contain the tag in GET /tags', function () {
         return helper.request().get('/api/1.1/tags')
         .expect('Content-Type', /^application\/json/)
@@ -111,12 +118,34 @@ describe('Http.Api.Tags', function () {
         });
     });
 
+    it('should return a tag from GET /tags/:id with special characters', function () {
+        return helper.request().get('/api/1.1/tags/tag ^name^')
+        .expect('Content-Type', /^application\/json/)
+        .expect(200, input)
+        .then(function() {
+            expect(waterline.tags.findOne).to.have.been.calledWith({ name: 'tag ^name^' });
+        });
+    });
+    
+    it('should 404 an invalid tag from GET /tags/:id', function () {
+        waterline.tags.findOne.resolves();
+        return helper.request().get('/api/1.1/tags/bad-tag-name')
+        .expect('Content-Type', /^application\/json/)
+        .expect(404);
+    });
+
     it('should destroy a tag', function() {
         return helper.request().delete('/api/1.1/tags/tag-name')
         .expect(204)
         .then(function() {
             expect(waterline.tags.destroy).to.have.been.called;
         });
+    });
+
+    it('should 404 an invalid tag destroy', function() {
+        waterline.tags.findOne.resolves();
+        return helper.request().delete('/api/1.1/tags/tag-name')
+        .expect(404);
     });
 });
 


### PR DESCRIPTION
- Handle special characters in tag name
- Return 404 on GET/DELETE when tag resource does not exist
- Return 409 on POST when tag resource already exists

Resolves https://github.com/RackHD/RackHD/issues/179, resolves https://github.com/RackHD/RackHD/issues/180
