### PR TITLE
Fix RackHD github issue #183 about ESXi chainload

### DIFF
--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -1,8 +1,7 @@
 iseq ${platform} efi && goto is_efi || goto not_efi
 
 :not_efi
-set 209:string http://<%=server%>:<%=port%>/api/common/templates/esx-pxelinux-cfg
-chain tftp://<%=server%>/undionly.kkpxe
+kernel <%=mbootFile%> -c http://<%=server%>:<%=port%>/api/common/templates/<%=esxBootConfigTemplate%> BOOTIF=01-${netX/mac}
 boot
 
 :is_efi


### PR DESCRIPTION
resolves https://github.com/RackHD/RackHD/issues/183    it's also related to ODR-629
this PR change chain load sequence from monorail-undionly.kpxe -> undionly.kkpxe -> mboot.c32  to monorail-undionly.kpxe->mboot.c32 to avoid the network or NIC driver problem of undionly.kkpxe(syslinux's gPXE)  also simplify the chain load process. 

So now chain load ESXi installer kernel 'mboot.c32' by iPXE(monorail-undionly.kpxe) not by gPXE(syslinux's undonly.kkpxe) the difference is that gPXE has some default environment variable that would be the implicit parameters for booting mboot.c32 such as BOOTIF, SYSUUID,... (this could be seen from gPXE's source code and bootup logs) , but iPXE don't have, For chain loading ESXi installler's mboot.c32, after validation, only BOOTIF parameter is needed to boot mboot.c32 successfully for iPXE. just as shown in PR.

Testing: ESXi 5.5 is tested on Quanta T41, DELL C6320. and ESXi 6.0 is tested on Quanta T41, DELL C6320, Rinjin,  Other platforms is not tested yet. assume it also works on other platforms that previously works, because mboot.c32 is the same with before. the only difference is gPXE changed to iPXE

Although undionly.kkpxe binary and syslinux(on-imagebuilder) is not used by RackHD after this PR, leave them there for a while until there's no other issues. 

@RackHD/rackhd_dev @RackHD/corecommitters @johren 
