### PR TITLE
Change body parser to allow post files upto 2MB

### DIFF
--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -196,8 +196,8 @@ function httpServiceFactory(
             skuService.static(req, res, next);
         });
 
-        // Parse request body. Limit set to 1MB
-        app.use(bodyParser.json({limit: '1mb'}));
+        // Parse request body. Limit set to 50MB
+        app.use(bodyParser.json({limit: '50mb'}));
 
         // Default Static Directory
         app.use(express.static('./static/http'));


### PR DESCRIPTION
Partial fix of ODR-620 about failure to update BIOS FW. In flash-quanta-bios-graph.js, after finishing FW update, the task POST the result (similar as stdout, >1M) to RackHD. In previous code, on-http refused this request, while the task is waiting for the response from nodes and never ends.

In current skupack implementation, there is no this problem since the output didn't return to RackHD. It is a fix for OnRack 1.2.0 who doesn't apply skupack and keeps using  flash-quanta-bios-graph.js

Removing the return value in on-tasks/ is also another solution, but enlarging the data size here can provide more flexibility for future usage.