### PR TITLE
Script changes to data/templates/set_bmc_credentials.sh

### DIFF
--- a/data/templates/set_bmc_credentials.sh
+++ b/data/templates/set_bmc_credentials.sh
@@ -4,7 +4,7 @@ channel=''
 function set_channel()
 {
     for i in {1..15}; do
-        ipmitool -I lanplus -H 172.31.128.2 -U admin -P admin user list $i &>/dev/null
+        ipmitool user list $i &>/dev/null
         status=$?
         if [ "$status" -eq "0" ] ; then
             channel=$i
@@ -13,7 +13,11 @@ function set_channel()
     done
 }
 set_channel
-
+echo "channel number is" $channel
+if [ -z "${channel}" ]; then
+ echo "Channel number was not set correctly, exiting script"
+exit
+fi
 echo " Getting the user list"
 cmdReturn=$(ipmitool user list $channel)
 myarray=(${cmdReturn//$'\n'/ })

--- a/data/templates/set_bmc_credentials.sh
+++ b/data/templates/set_bmc_credentials.sh
@@ -1,9 +1,23 @@
 #!/usr/bin/env bash
 
+channel=''
+function set_channel()
+{
+    for i in {1..15}; do
+        ipmitool -I lanplus -H 172.31.128.2 -U admin -P admin user list $i &>/dev/null
+        status=$?
+        if [ "$status" -eq "0" ] ; then
+            channel=$i
+            break
+        fi
+    done
+}
+set_channel
+
 echo " Getting the user list"
-cmdReturn=$(ipmitool user list)
+cmdReturn=$(ipmitool user list $channel)
 myarray=(${cmdReturn//$'\n'/ })
-cmdReturn1=$(ipmitool user summary)
+cmdReturn1=$(ipmitool user summary $channel)
 myarray1=(${cmdReturn1//$'\n'/ })
 userNumber=${myarray1[8]}
 user=$(<%=user%>)
@@ -19,7 +33,7 @@ for x in $cmdReturn; do
    echo "Username already present, overwriting existing user"
    ipmitool user set name $userNumber <%=user%>
    ipmitool user set password $userNumber <%=password%>
-   ipmitool channel setaccess 1 $userNumber callin=on ipmi=on link=on privilege=4
+   ipmitool channel setaccess $channel $userNumber callin=on ipmi=on link=on privilege=4
    ipmitool user enable $userNumber
    check=$((check + 1))
   exit
@@ -33,7 +47,7 @@ if [ $check == 0 ]; then
  userNumber=$((userNumber + 1))
  ipmitool user set name $userNumber <%=user%>
  ipmitool user set password $userNumber <%=password%>
- ipmitool channel setaccess 1 $userNumber callin=on ipmi=on link=on privilege=4
+ ipmitool channel setaccess $channel $userNumber callin=on ipmi=on link=on privilege=4
  ipmitool user enable $userNumber
 exit
 fi

--- a/data/templates/set_bmc_credentials.sh
+++ b/data/templates/set_bmc_credentials.sh
@@ -16,7 +16,7 @@ set_channel
 echo "channel number is" $channel
 if [ -z "${channel}" ]; then
  echo "Channel number was not set correctly, exiting script"
-exit
+exit 1
 fi
 echo " Getting the user list"
 cmdReturn=$(ipmitool user list $channel)


### PR DESCRIPTION
* check the ipmi channel that's available
* use it to issue the ipmi commands
* Linked to gitHub issue :
Resolves https://github.com/RackHD/on-http/issues/211
