### PR TITLE
Add back bootif param

### DIFF
--- a/data/profiles/install-ubuntu.ipxe
+++ b/data/profiles/install-ubuntu.ipxe
@@ -2,5 +2,5 @@ echo Starting Ubuntu x64 installer for ${hostidentifier}
 set base-url <%=repo%>/dists/<%=version%>/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64
 kernel ${base-url}/linux
 initrd ${base-url}/initrd.gz
-imgargs linux auto=true url=http://<%=server%>:<%=port%>/api/common/templates/ubuntu-preseed hostname=<%=hostname%> log_host=<%=server%> interface=auto console=<%=comport%>,115200n8 console=tty0
+imgargs linux auto=true url=http://<%=server%>:<%=port%>/api/common/templates/ubuntu-preseed hostname=<%=hostname%> log_host=<%=server%> BOOTIF=01-<%=macaddress%> interface=auto console=<%=comport%>,115200n8 console=tty0
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell


### PR DESCRIPTION
The BOOTIF param (which is originally there) was deleted accidently. This cause the net install fail on DHCP step for multi NIC. 
Verified this on physical node

@RackHD/corecommitters 