### PR TITLE
[redfish] Add Redfish EventService resource

### DIFF
--- a/data/templates/redfish.1.0.0.eventdestination.json
+++ b/data/templates/redfish.1.0.0.eventdestination.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "<%= basepath %>/$metadata#EventService/Members/Subscriptions/Members/$entity",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#EventService.1.0.0.EventDestination",
+    "Id": "<%= subscription.Id %>",
+    "Name": "Event Subscription Destination",
+    "Destination": "<%= subscription.Destination %>",
+    "EventTypes": <%- JSON.stringify(subscription.EventTypes) %>,
+    "Context": "<%= subscription.Context %>",
+    "Protocol": "<%= subscription.Protocol %>"
+}

--- a/data/templates/redfish.1.0.0.eventdestinationcollection.json
+++ b/data/templates/redfish.1.0.0.eventdestinationcollection.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context" : "<%= basepath %>/$metadata#EventService/Members/Events/$entity",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
+    "Name": "Event Subscription Collection",
+    "Members@odata.count": <%= subscriptions.length %>,
+    "Members": [
+        <% subscriptions.forEach(function(subscription, i, arr) { %>
+            {
+                "@odata.id": "<%= basepath %>/EventService/Subscriptions/<%=subscription.Id%>"
+            }
+            <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
+        <% }); %>
+    ]
+    
+}

--- a/data/templates/redfish.1.0.0.eventservice.1.0.0.json
+++ b/data/templates/redfish.1.0.0.eventservice.1.0.0.json
@@ -1,0 +1,26 @@
+{
+    "@odata.context" : "<%= basepath %>/$metadata/EventService",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#EventService.1.0.0.EventService",
+    "Id": "EventService",
+    "Name": "Event Service",
+    "Status": {},
+    "EventTypesForSubscription": [                
+        "StatusChange",
+        "ResourceUpdated",
+        "ResourceAdded",
+        "ResourceRemoved",
+        "Alert"
+    ],
+    "DeliveryRetryAttempts": <%= retryAttempts %>,
+    "DeliveryRetryIntervalSeconds": <%= timeoutInSeconds %>,
+    "ServiceEnabled": true,
+    "Actions": {
+        "#EventService.SubmitTestEvent": {
+            "target": "<%= basepath %>/EventService/Actions/EventService.SubmitTestEvent"
+        }
+    },
+    "Subscriptions": {
+        "@odata.id": "<%= basepath %>/EventService/Subscriptions"
+    }
+}

--- a/lib/api/redfish-1.0/event-service.js
+++ b/lib/api/redfish-1.0/event-service.js
@@ -1,0 +1,266 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+var urlParse = require('url-parse');
+var injector = require('../../../index.js').injector;
+var redfish = injector.get('Http.Api.Services.Redfish');
+var schemaApi = injector.get('Http.Api.Services.Schema');
+var Promise = injector.get('Promise'); // jshint ignore:line
+var _ = injector.get('_');  // jshint ignore:line
+var Constants = injector.get('Constants');
+var RedfishTool = injector.get('JobUtils.RedfishTool');
+var controller = injector.get('Http.Services.Swagger').controller;
+var Errors = injector.get('Errors');
+var messenger = injector.get('Services.Messenger');
+var Logger = injector.get('Logger');
+var uuid = injector.get('uuid');
+var timeoutInSeconds = 10;
+var retryAttempts = 3;
+var eventSubscriptions = {};
+var subscription;
+var logger = Logger.initialize('event-service');
+
+var eventListener = function(callback) {
+    if(subscription) {
+        return subscription;
+    }
+    return messenger.subscribe(
+        Constants.Protocol.Exchanges.Events.Name,
+        'poller.alert.#',
+        function(data) {
+            callback(data);
+        }
+    ).then(function(sub) {
+        subscription = sub;
+        return subscription;
+    });
+};
+
+var sendClient = function(client, retry, data) {
+    return client.clientRequest(client.settings.root, 'POST', data)
+    .catch(function(error) {
+        if(0 !== retry) {
+            logger.warning('Send Error', {
+                error:error,
+                settings:client.settings,
+                retry:retry
+            });
+            sendClient(client, retry - 1);
+        }
+    });
+};
+
+var eventCallback = function(events) {
+    return _.forEach(events.value, function(event) {
+        var clients;
+        if(event.reading.sdrType === 'Threshold') {
+            clients = _.filter(eventSubscriptions, _.matches({EventTypes:["Alert"]}));
+            return _.forEach(clients, function(client) {
+                var record = {};
+                var parse = urlParse(client.Destination);
+                var tool = new RedfishTool();
+                tool.settings.host = parse.host.split(':')[0];
+                tool.settings.port = parse.port;
+                tool.settings.root = parse.pathname;
+                tool.settings.recvTimeoutMs = timeoutInSeconds * 1000;
+                record.MemberId = event.node;
+                record.EventType = "Alert";
+                record.EventId = event.reading.sensorId;
+                record.EventTimestamp = new Date().toISOString();
+                record.Severity = event.reading.status;
+                record.Message = event.reading.entryIdName + ' ' + 
+                    event.reading.sensorReading + ' ' + 
+                    (event.reading.sensorReadingUnits ? event.reading.sensorReadingUnits : '');
+                record.MessageId = "Alert.1.0." + 
+                    event.reading.sensorId.replace(/[^A-Za-z0-9.]/g,''); 
+                return schemaApi.validate(record, 'Event.1.0.0.json#/definitions/EventRecord')
+                .then(function(result) {
+                    if(result.error) {
+                        throw new Error(result.error);
+                    }
+                    return sendClient(tool, retryAttempts, record);
+                });
+            });
+        }
+        if(event.reading.sdrType === 'Discrete') {
+            clients = _.filter(eventSubscriptions, _.matches({EventTypes:["StatusChange"]}));
+            return _.forEach(clients, function(client) {
+                var record = {};
+                var parse = urlParse(client.Destination);
+                var tool = new RedfishTool();
+                tool.settings.host = parse.host.split(':')[0];
+                tool.settings.port = parse.port;
+                record.MemberId = event.node;
+                record.EventType = "StatusChange";
+                record.EventId = event.reading.sensorId;
+                record.EventTimestamp = new Date().toISOString();
+                record.Message = event.reading.entryIdName + ', statesAsserted: ' + 
+                    event.reading.statesAsserted.toString();
+                record.MessageId = "StatusChange.1.0." + 
+                    event.reading.sensorId.replace(/[^A-Za-z0-9.]/g,'');
+                return schemaApi.validate(record, 'Event.1.0.0.json#/definitions/EventRecord')
+                .then(function(result) {
+                    if(result.error) {
+                        throw new Error(result.error);
+                    }
+                    return sendClient(tool, retryAttempts, record);
+                });
+            });
+        }
+    });
+};
+
+var eventServiceRoot = controller(function(req, res) {
+    var options = redfish.makeOptions(req, res);
+    return Promise.resolve()
+    .then(function() {
+        options.timeoutInSeconds = timeoutInSeconds;
+        options.retryAttempts = retryAttempts;
+        return redfish.render('redfish.1.0.0.eventservice.1.0.0.json',
+                'EventService.1.0.0.json#/definitions/EventService',
+                options);
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+var getEventsCollection = controller(function(req, res) {
+    var options = redfish.makeOptions(req, res);
+    return Promise.resolve()
+    .then(function() {
+        options.subscriptions = _.values(eventSubscriptions);
+        return redfish.render('redfish.1.0.0.eventdestinationcollection.json',
+                'EventDestinationCollection.json#/definitions/EventDestinationCollection',
+                options);
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+var createSubscription = controller(function(req, res) {
+    var options = redfish.makeOptions(req, res);
+    var event = req.swagger.params.payload.value;
+    return schemaApi.validate(event, 
+        'EventDestination.1.0.0.json#/definitions/EventDestination'
+    )
+    .then(function validatePayload(result) {
+        if(result.error) {
+            throw new Error(result.error);
+        }
+        var index = _.findIndex(_.values(eventSubscriptions), function(subscription) {
+            return subscription.Destination === event.Destination;
+        });
+        
+        if(index > -1) {
+            var err = new Errors.BaseError('EventDestination Exists');
+            err.status = 409;
+            throw err;
+        }
+        event.Id = uuid('v4');
+        _.set(eventSubscriptions, event.Id, event);
+        return event;
+    })
+    .then(function(output) {
+        eventListener(eventCallback);
+        res.setHeader('Location', 
+            options.basepath + '/EventService/Subscription/' + output.Id
+        );
+        res.status(201).json(output);
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+var testEvent = controller(function(req, res) {
+    return Promise.resolve()
+    .then(function() {
+        return _.forEach(_.values(eventSubscriptions), function(subscription) {
+            var record = {};
+            var parse = urlParse(subscription.Destination);
+            var tool = new RedfishTool();
+            tool.settings.host = parse.host.split(':')[0];
+            tool.settings.port = parse.port;
+            record.MemberId = subscription.Id;
+            record.EventType = 'Alert';
+            record.EventId = '0';
+            record.EventTimestamp = new Date().toISOString();
+            record.Message = 'Generated TestEvent to ' + subscription.Destination;
+            record.MessageId = 'TestEvent.1.0.0';
+            return schemaApi.validate(record, 'Event.1.0.0.json#/definitions/EventRecord')
+            .then(function(result) {
+                if(result.error) {
+                    throw new Error(result.error);
+                }
+                return sendClient(tool, retryAttempts, record);
+            });
+        });
+    })
+    .then(function() {
+        res.status(200);
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+var getEvent = controller(function(req, res) {
+    var options = redfish.makeOptions(req, res);
+    var id = req.swagger.params.index.value;
+    return Promise.resolve()
+    .then(function() {
+        var event = _.get(eventSubscriptions, id);
+        if(_.isUndefined(event)) {
+            throw new Errors.NotFoundError(
+                'EventDestination ' + id + ' Not Found'
+            );       
+        }
+        options.subscription = event;
+        return redfish.render('redfish.1.0.0.eventdestination.json',
+                'EventDestination.1.0.0.json#/definitions/EventDestination',
+                options);
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+var deleteEvent = controller(function(req, res) {
+    var id = req.swagger.params.index.value;
+    return Promise.resolve()
+    .then(function() {
+        var event = _.get(eventSubscriptions, id);
+        if(_.isUndefined(event)) {
+            throw new Errors.NotFoundError(
+                'EventDestination ' + id + ' Not Found'
+            );       
+        }
+        delete eventSubscriptions[id];
+    })
+    .then(function() {
+        if(!_.keys(eventSubscriptions).length) {
+            if(subscription) {
+                subscription.dispose();
+                subscription = undefined;
+            }
+        }
+        res.status(200);
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+module.exports = {
+    eventServiceRoot: eventServiceRoot,
+    createSubscription: createSubscription,
+    getEventsCollection: getEventsCollection,
+    getEvent: getEvent,
+    deleteEvent: deleteEvent,
+    testEvent: testEvent,
+    eventListener: eventListener,
+    sendClient: sendClient,
+    eventCallback: eventCallback
+};

--- a/lib/api/redfish-1.0/event-service.js
+++ b/lib/api/redfish-1.0/event-service.js
@@ -45,7 +45,7 @@ var sendClient = function(client, retry, data) {
                 settings:client.settings,
                 retry:retry
             });
-            sendClient(client, retry - 1);
+            return sendClient(client, retry - 1);
         }
     });
 };

--- a/lib/api/redfish-1.0/event-service.js
+++ b/lib/api/redfish-1.0/event-service.js
@@ -47,6 +47,7 @@ var sendClient = function(client, retry, data) {
             });
             return sendClient(client, retry - 1);
         }
+        throw error;
     });
 };
 
@@ -79,6 +80,9 @@ var eventCallback = function(events) {
                         throw new Error(result.error);
                     }
                     return sendClient(tool, retryAttempts, record);
+                })
+                .catch(function(error) {
+                    throw error;
                 });
             });
         }
@@ -104,6 +108,9 @@ var eventCallback = function(events) {
                         throw new Error(result.error);
                     }
                     return sendClient(tool, retryAttempts, record);
+                })
+                .catch(function(error) {
+                    throw error;
                 });
             });
         }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "swagger-tools": "~0.9.11",
     "tar": "~2.2.1",
     "tv4": "~1.2.7",
-    "ws": "^0.8.0"
+    "ws": "^0.8.0",
+    "url-parse": "~1.1.1"
   },
   "devDependencies": {
     "apidoc": "^0.12.1",

--- a/spec/lib/api/redfish-1.0/event-service-spec.js
+++ b/spec/lib/api/redfish-1.0/event-service-spec.js
@@ -1,0 +1,191 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Redfish Event Service', function () {
+    var tv4;
+    var validator;
+    var redfish;
+    var Promise;
+    var Constants;
+    var messenger;
+    var subscription;
+    var identifier;
+    var eventDestination = {
+        Destination: 'http://1.1.1.1:8080',
+        EventTypes: ['Alert', 'StatusChange'],
+        Context: 'Event Context',
+        Protocol: 'Redfish'
+    };
+    var events = {
+        value: [{
+            node: 'xyz',
+            reading: {
+                status: 'statusData',
+                entryIdName: 'entryIdData',
+                sensorReading: 'sensorReadingData',
+                sensorReadingUnits: 'sensorReadingUnitsData',
+                sensorId: 'sensorIdData',
+                sdrType: 'Threshold'
+            }
+        }]
+    };
+    
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        function redfishTool() {
+            this.clientRequest = sinon.stub(); // jshint ignore:line
+        }
+        helper.setupInjector([
+            helper.di.simpleWrapper(redfishTool,'JobUtils.RedfishTool')
+        ]);
+
+        return helper.startServer([]).then(function () {
+            Constants = helper.injector.get('Constants');
+            Promise = helper.injector.get('Promise');
+            
+            redfish = helper.injector.get('Http.Api.Services.Redfish');
+            sinon.spy(redfish, 'render');
+            
+            validator = helper.injector.get('Http.Api.Services.Schema');
+            sinon.spy(validator, 'validate');
+            
+            var Subscription = helper.injector.get('Subscription');
+            subscription = new Subscription({},{});
+            
+            messenger = helper.injector.get('Services.Messenger');
+            sinon.stub(messenger);
+            messenger.subscribe = sinon.spy(function(name,exchange,callback) {
+                callback(eventDestination);
+                return Promise.resolve(subscription);
+            });
+        });
+    });
+
+    beforeEach('set up mocks', function () {
+        tv4 = require('tv4');
+        sinon.spy(tv4, "validate");
+        validator.validate.reset();
+        redfish.render.reset();
+    });
+
+    afterEach('tear down mocks', function () {
+        tv4.validate.restore();
+    });
+
+    after('stop HTTP server', function () {
+        validator.validate.restore();
+        redfish.render.restore();
+        function restoreStubs(obj) {
+            _(obj).methods().forEach(function (method) {
+                if (obj[method] && obj[method].restore) {
+                  obj[method].restore();
+                }
+            }).value();
+        }
+        restoreStubs(messenger);
+        return helper.stopServer();
+    });
+
+    it('should return a valid event service root', function () {
+        return helper.request().get('/redfish/v1/EventService')
+        .expect('Content-Type', /^application\/json/)
+        .expect(200)
+        .expect(function() {
+            expect(tv4.validate.called).to.be.true;
+            expect(validator.validate.called).to.be.true;
+            expect(redfish.render.called).to.be.true;
+        });
+    });
+   
+    it('should create a valid subscription', function() {
+        return helper.request().post('/redfish/v1/EventService/Subscriptions')
+        .send(eventDestination)
+        .expect('Content-Type', /^application\/json/)
+        .expect(201)
+        .expect(function(res) {
+            expect(tv4.validate.called).to.be.true;
+            expect(subscription).to.be.fullfilled;
+            identifier = res.body.Id;
+        });
+    });
+        
+    it('should fail to create existing subscription', function() {
+        return helper.request().post('/redfish/v1/EventService/Subscriptions')
+        .send(eventDestination)
+        .expect('Content-Type', /^application\/json/)
+        .expect(409)
+        .expect(function() {
+            expect(tv4.validate.called).to.be.true;
+        });
+    });
+           
+    it('should return a valid subscription collection', function() {
+        return helper.request().get('/redfish/v1/EventService/Subscriptions')
+        .expect('Content-Type', /^application\/json/)
+        .expect(200)
+        .expect(function() {
+            expect(tv4.validate.called).to.be.true;
+            expect(validator.validate.called).to.be.true;
+            expect(redfish.render.called).to.be.true;
+        });
+    });
+    
+    it('should return a valid subscription', function() {    
+        return helper.request().get(
+            '/redfish/v1/EventService/Subscriptions/' + identifier
+        )
+        .expect('Content-Type', /^application\/json/)
+        .expect(200)
+        .expect(function(res) {
+            expect(tv4.validate.called).to.be.true;
+            expect(validator.validate.called).to.be.true;
+            expect(redfish.render.called).to.be.true;
+            expect(res.body.Id).to.equal(identifier);
+        });
+    });
+    
+    it('should fail on invalid subscription', function() {    
+        return helper.request().get(
+            '/redfish/v1/EventService/Subscriptions/xyz'
+        )
+        .expect('Content-Type', /^application\/json/)
+        .expect(404);
+    });
+    
+    it('should submit test event', function() {
+        return helper.request().post(
+            '/redfish/v1/EventService/Actions/EventService.SubmitTestEvent'
+        )
+        .send([])
+        .expect(200)
+        .expect(function() {
+            expect(tv4.validate.called).to.be.true;
+        });
+    });
+    
+    it('should handle alert event', function() {
+        var eventService = helper.require('/lib/api/redfish-1.0/event-service.js');
+        expect(eventService.eventCallback(events)).to.be.fullfilled;
+    });
+    
+    it('should handle status event', function() {
+        var eventService = helper.require('/lib/api/redfish-1.0/event-service.js');
+        events.value[0].reading.sdrType = 'Discrete';
+        events.value[0].reading.statesAsserted = ['AssertedState']; 
+        expect(eventService.eventCallback(events)).to.be.fullfilled;
+    });
+    
+    it('should delete a valid subscription', function() {    
+        return helper.request()
+        .delete('/redfish/v1/EventService/Subscriptions/' + identifier)
+        .expect(200);
+    });
+    
+    it('should fail to delete an ivalid subscription', function() {    
+        return helper.request()
+        .delete('/redfish/v1/EventService/Subscriptions/xyz')
+        .expect(404);
+    });
+});

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -784,6 +784,109 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /EventService/Subscriptions:
+    x-swagger-router-controller: event-service
+    get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: retrieve collection of subscribed events
+      operationId: getEventsCollection
+      tags: [ "/redfish/v1" ]
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/EventDestinationCollection_EventDestinationCollection"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        501:
+          $ref: "#/responses/status_501"  
+    post:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: retrieve collection of subscribed events
+      operationId: createSubscription
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: payload
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/EventDestination.1.0.0_EventDestination"
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/EventDestinationCollection_EventDestinationCollection"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        501:
+          $ref: "#/responses/status_501"  
+  /EventService/Subscriptions/{index}:
+    x-swagger-router-controller: event-service
+    get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: retrieve specific event subscription
+      operationId: getEvent
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/EventDestination.1.0.0_EventDestination"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        501:
+          $ref: "#/responses/status_501"    
+    delete:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: delete specific event subscription
+      operationId: deleteEvent
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: index
+          in: path
+          required: true
+          type: string
+      responses:
+        200:
+          description: Success
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        501:
+          $ref: "#/responses/status_501"   
+  /EventService/Actions/EventService.SubmitTestEvent:
+    x-swagger-router-controller: event-service
+    post:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: submit a test event action
+      operationId: testEvent
+      tags: [ "/redfish/v1" ]
+      responses:
+        200:
+          description: Success
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        501:
+          $ref: "#/responses/status_501"        
   /AccountService/Accounts/{name}:
     x-swagger-router-controller: account-service
     get:
@@ -2311,6 +2414,82 @@ definitions:
         $ref: '#/definitions/Resource_Oem'
         description: This is the manufacturer/provider specific extension moniker
           used to divide the Oem object into sections.
+    type: object
+  EventDestination.1.0.0_EventDestination:
+    description: This is the base type for resources and referenceable members.
+    properties:
+      '@odata.context':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.id':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.type':
+        readOnly: true
+        type: string
+      Context:
+        description: A client-supplied string that is stored with the event destination
+          subscription.
+        type: string
+      Description:
+        description: Provides a description of this resource and is used for commonality  in
+          the schema definitions.
+        readOnly: true
+        type: string
+      Destination:
+        description: The URI of the destination Event Service.
+        readOnly: true
+        type: string
+      EventTypes:
+        description: This property shall contain the types of events that shall be
+          sent to the desination.
+        items:
+          enum:
+          - StatusChange
+          - ResourceUpdated
+          - ResourceAdded
+          - ResourceRemoved
+          - Alert
+          type: string
+        readOnly: true
+        type: array
+      HttpHeaders:
+        description: This is for setting HTTP headers, such as authorization information.  This
+          object will be null on a GET.
+        items:
+          $ref: '#/definitions/EventDestination.1.0.0_HttpHeaderProperty'
+        type: array
+      Id:
+        description: Uniquely identifies the resource within the collection of like
+          resources.
+        readOnly: true
+        type: string
+      Name:
+        description: The name of the resource or array element.
+        readOnly: true
+        type: string
+      Oem:
+        $ref: '#/definitions/Resource_Oem'
+        description: This is the manufacturer/provider specific extension moniker
+          used to divide the Oem object into sections.
+      Protocol:
+        description: The protocol type of the event connection.
+        enum:
+        - Redfish
+        readOnly: true
+        type: string
+    required:
+    - Destination
+    - EventTypes
+    - Context
+    - Protocol
+    type: object
+  EventDestination.1.0.0_HttpHeaderProperty:
+    description: The value of the HTTP header is the property value.  The header name
+      is the property name.
+    properties: {}
     type: object
   EventDestinationCollection_EventDestinationCollection:
     properties:
@@ -5055,6 +5234,7 @@ definitions:
         description: Provides a description of this resource and is used for commonality  in
           the schema definitions.
         readOnly: true
+        type: string
       Members:
         description: Contains the members of this collection.
         items:

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -784,6 +784,25 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /EventService:
+    x-swagger-router-controller: event-service
+    get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: retrieve list of policies used by event service listeners
+      operationId: eventServiceRoot
+      tags: [ "/redfish/v1" ]
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/EventService.1.0.0_EventService"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        501:
+          $ref: "#/responses/status_501"
   /EventService/Subscriptions:
     x-swagger-router-controller: event-service
     get:
@@ -967,25 +986,6 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
-  /EventService:
-    x-swagger-router-controller: unimplemented
-    get:
-      x-privileges: [ 'Login' ]
-      x-authentication-type: [ 'redfish', 'basic' ]
-      summary: retrieve list of policies used by event service listeners
-      operationId: unimplemented
-      tags: [ "/redfish/v1" ]
-      responses:
-        200:
-          description: Success
-          schema:
-            $ref: "#/definitions/EventService.1.0.0_EventService"
-        401:
-          $ref: "#/responses/status_401"
-        403:
-          $ref: "#/responses/status_403"
-        501:
-          $ref: "#/responses/status_501"
   /Managers:
     x-swagger-router-controller: unimplemented
     get:


### PR DESCRIPTION
- Added POST /EventService/Subscription route to subscribe to events
- Added GET /EventService to get the root EventService resource
- Added GET /EventService/Subscription/:id route to get subscription resource collection or specific resource
- Added DELETE /EventService/Subscription/:id to delete an existing subscription resource
- Added POST /EventService/Actions/EventService.SubmitTestEvent
- Added poller alert listener, publish EventService types StatusChange (discrete) and Alert (threshold)
- Added unit-tests

@RackHD/corecommitters @zyoung51 @uppalk1 @tannoa2 @geoff-reid @keedya 
