### PR TITLE
Fix ubuntu templates issues

### DIFF
--- a/data/templates/install-ubuntu/post-install-ubuntu.sh
+++ b/data/templates/install-ubuntu/post-install-ubuntu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # create SSH key for root
-<% if (undefined !== rootSshKey) { -%>
+<% if ('undefined' !== typeof rootSshKey && null !== rootSshKey) { -%>
 mkdir /root/.ssh
 echo <%=rootSshKey%> > /root/.ssh/authorized_keys
 chown -R root:root /root/.ssh

--- a/data/templates/install-ubuntu/ubuntu-preseed
+++ b/data/templates/install-ubuntu/ubuntu-preseed
@@ -144,6 +144,8 @@ d-i grub-installer/only_debian boolean true
 # OS, which is less safe as it might not be able to boot that other OS.
 d-i grub-installer/with_other_os boolean true
 
+d-i grub-installer/bootdev string <%=installDisk%>
+
 # Avoid that last message about the install being complete.
 d-i finish-install/reboot_in_progress note
 


### PR DESCRIPTION
- Fix error when rootSshKey not defined in post install script
- Add grub-installer/bootdev section in preseed to prevent installer interrupt question such as below

   > [ Install the GRUB boot loader on a hard disk ]

   > You need to make the newly installed system bootable, by installing the GRUB boot loader on a       bootable device. The usual way to do this is to install GRUB on the master boot record of your first hard drive. If you prefer, you can install GRUB elsewhere on the drive, or to another drive, or even to a floppy.

   > The device should be specified as a device in /dev. Below are some examples:

   > "/dev/sda" will install GRUB to the master boot record of your first hard drive;
   > "/dev/sda2" will use the second partition of your first hard drive;


@RackHD/corecommitters @pengz1 @sunnyqianzhang 