### PR TITLE
Refactor config.json into sku model and cleanup error messages

### DIFF
--- a/lib/services/sku-pack-service.js
+++ b/lib/services/sku-pack-service.js
@@ -52,6 +52,14 @@ function skuPackServiceFactory(
     var logger = Logger.initialize(skuPackServiceFactory);
     var fs = Promise.promisifyAll(nodeFs);
     var rimrafAsync = Promise.promisify(rimraf);
+    var confProperties = [
+        'httpStaticRoot',
+        'httpTemplateRoot',
+        'httpProfileRoot',
+        'workflowRoot',
+        'taskRoot'
+    ];
+    var validConfProperties = confProperties.concat('skuConfig', 'version', 'description');
 
     function SkuPackService() {
         this.loader = new FileLoader();
@@ -126,7 +134,6 @@ function skuPackServiceFactory(
         var self = this;
         var name = uuid('v4');
         var tmpDir = tmp();
-        var skuName = '';
 
         return Promise.try(function() {
             assert.ok(req.headers['content-type']);
@@ -155,23 +162,21 @@ function skuPackServiceFactory(
             return new Promise(function(resolve, reject) {
                 start.pipe(zlib.createGunzip())
                 .on('error', function() {
-                    reject(new Errors.InternalServerError('Invalid gzip'));
+                    reject(new Errors.BadRequestError('Invalid gzip'));
                 })
                 .pipe(tar.Extract({path: tmpDir + '/' + name}))
                 .on('end', function() {
-                    return self.installPack(tmpDir + '/' + name,skuid)
-                        .spread(function(filename, contents) {
-                            skuName = path.basename(filename, '.json');
-                            return self.registerPack(filename, contents);
-                        })
-                        .then(function() {
-                            return self.regenerateSkus();
-                        }).then(function() {
-                            resolve({id: skuName});
+                    return self.installPack(tmpDir + '/' + name, skuid)
+                        .spread(function(skuId, contents) {
+                            return self.registerPack(skuId, contents)
+                            .then(function() {
+                                return self.regenerateSkus();
+                            }).then(function() {
+                                resolve({id: skuId});
+                            });
                         })
                         .catch(function(e) {
-                            reject(new Errors.InternalServerError(
-                                'Failed to serve file request:' + e.message));
+                            reject(new Errors.BadRequestError(e.message));
                         })
                         .finally(function() {
                             return Promise.all([
@@ -282,85 +287,93 @@ function skuPackServiceFactory(
      * @param  {String}     contents the file contents
      * @return {Promise[]}
      */
-    SkuPackService.prototype.registerPack = function(name, contents) {
+    SkuPackService.prototype.registerPack = function(skuId, contents) {
         var promises = [];
         var self = this;
-        if(path.extname(name) === '.json') {
-            var skuName = path.basename(name, '.json');
-            var skuRoot = self.confRoot + '/' + skuName;
-            try {
-                var conf = JSON.parse(contents);
+        var skuRoot = self.confRoot + '/' + skuId;
+
+        return waterline.skus.findOne({id: skuId})
+        .then(function(conf) {
+            if(!conf) {
+                throw new Errors.NotFoundError(skuId + ' was not found');
+            }
+
+            return Promise.try(function() {
                 // Add the static root if it is defined
-                if(conf.hasOwnProperty('httpStaticRoot')) {
-                    // directory references are relative to the skuName directory
+                if(conf.httpStaticRoot) {
+                    // directory references are relative to the skuId directory
                     var httpStaticRoot = skuRoot + path.resolve('/', conf.httpStaticRoot);
-                    self.skuHandlers[skuName] = express.static(httpStaticRoot);
+                    self.skuHandlers[skuId] = express.static(httpStaticRoot);
                 }
-
-                if(conf.hasOwnProperty('httpTemplateRoot')) {
+            }).then(function() {
+                if(conf.httpTemplateRoot) {
                     var httpTemplateRoot = skuRoot + path.resolve('/', conf.httpTemplateRoot);
-                    promises.push(self.loader.getAll(httpTemplateRoot)
-                        .then(function(templates) {
-                            return _.map(templates,function(contents,name) {
-                                return Templates.put(name, contents, skuName);
-                            });
-                        })
-                    );
-                }
-
-                if(conf.hasOwnProperty('httpProfileRoot')) {
-                    var httpProfileRoot = skuRoot + path.resolve('/', conf.httpProfileRoot);
-                    promises.push(self.loader.getAll(httpProfileRoot)
-                        .then(function(profiles) {
-                            return _.map(profiles,function(contents,name) {
-                                return Profiles.put(name, contents, skuName);
-                            });
-                        })
-                    );
-                }
-
-                var tasks = [];
-                var taskPromises = Promise.resolve([]);
-                if(conf.hasOwnProperty('taskRoot')) {
-                    var taskRoot = skuRoot + path.resolve('/', conf.taskRoot);
-                    taskPromises = loadWorkflowItems(skuName, taskRoot, waterline.taskdefinitions);
-                    taskPromises = taskPromises.map(function(contents) {
-                        var data = JSON.parse(contents);
-                        tasks.push(data.injectableName);
-                        data.injectableName = data.injectableName + '::' + skuName;
-                        return workflowApiService.defineTask(data);
+                    return self.loader.getAll(httpTemplateRoot)
+                    .then(function(templates) {
+                        return _.map(templates,function(contents,name) {
+                            return Templates.put(name, contents, skuId);
+                        });
                     });
                 }
-                promises.push(taskPromises);
-
-                if(conf.hasOwnProperty('workflowRoot')) {
-                    var workflowRoot = skuRoot + path.resolve('/', conf.workflowRoot);
-                    var workflowPromises = taskPromises.then(function() {
-                        return loadWorkflowItems(skuName, workflowRoot, waterline.graphdefinitions);
-                    }).map(function(contents) {
+            }).then(function() {
+                if(conf.httpProfileRoot) {
+                    var httpProfileRoot = skuRoot + path.resolve('/', conf.httpProfileRoot);
+                    return self.loader.getAll(httpProfileRoot)
+                    .then(function(profiles) {
+                        return _.map(profiles,function(contents,name) {
+                            return Profiles.put(name, contents, skuId);
+                        });
+                    });
+                }
+            }).then(function() {
+                var tasks = [];
+                if(conf.taskRoot) {
+                    var taskRoot = skuRoot + path.resolve('/', conf.taskRoot);
+                    return loadWorkflowItems(skuId, taskRoot)
+                    .map(function(contents) {
                         var data = JSON.parse(contents);
-                        var newName = data.injectableName + '::' + skuName;
-                        promises.push(Env.set(data.injectableName, newName, skuName));
+                        tasks.push(data.injectableName);
+                        data.injectableName = data.injectableName + '::' + skuId;
+                        return workflowApiService.defineTask(data);
+                    })
+                    .then(function(taskPromises) {
+                        return [tasks, taskPromises];
+                    });
+                }
+                return [ tasks ];
+            }).spread(function(tasks) {
+                var envConfig = {};
+                if(conf.workflowRoot) {
+                    var workflowRoot = skuRoot + path.resolve('/', conf.workflowRoot);
+                    return loadWorkflowItems(skuId, workflowRoot)
+                    .map(function(contents) {
+                        var data = JSON.parse(contents);
+                        var newName = data.injectableName + '::' + skuId;
+                        _.set(envConfig, data.injectableName, newName);
                         data.injectableName = newName;
                         _.forEach(getObjectsWithKey(data,'taskName'), function(item) {
                             if(tasks.indexOf(item.taskName) !== -1) {
-                                item.taskName = item.taskName + '::' + skuName;
+                                item.taskName = item.taskName + '::' + skuId;
                             }
                         });
                         return workflowApiService.defineTaskGraph(data);
+                    })
+                    .then(function(workflowPromises) {
+                        return [ envConfig, workflowPromises ];
                     });
-                    promises.push(workflowPromises);
                 }
-
-                if(conf.hasOwnProperty('skuConfig')) {
-                    promises.push(Env.set('config', conf.skuConfig, skuName));
+                return [ envConfig ];
+            }).spread(function(envConfig) {
+                var config = _.merge({}, conf.skuConfig || {}, envConfig);
+                if(!_.isEmpty(_.keys(config))) {
+                    return Env.set('config', config, skuId);
                 }
-
-            } catch (error) {
-                logger.warning('Unable to load sku configuration for ' + skuName);
-            }
-        }
-        return Promise.all(promises);
+            });
+        })
+        .catch(function(err) {
+            logger.warning('Unable to load sku configuration for ' + skuId + ':' + err.message);
+            throw err;
+        });
     };
 
 
@@ -370,22 +383,20 @@ function skuPackServiceFactory(
      * @param  {String}     contents the file contents
      * @return {Promise}
      */
-    SkuPackService.prototype.unregisterPack = function(skuid, contents) {
+    SkuPackService.prototype.unregisterPack = function(skuid, conf) {
         var promises = [];
         var self = this;
         var skuRoot = self.confRoot + '/' + skuid;
         var cleanup;
 
-        try {
-            var conf = JSON.parse(contents);
-
-            if(conf.hasOwnProperty('httpStaticRoot')) {
+        return Promise.try(function() {
+            if(conf.httpStaticRoot) {
                 if( skuid in self.skuHandlers ) {
                     delete self.skuHandlers[skuid];
                 }
             }
 
-            if(conf.hasOwnProperty('httpTemplateRoot')) {
+            if(conf.httpTemplateRoot) {
                 var httpTemplateRoot = skuRoot + path.resolve('/', conf.httpTemplateRoot);
                 cleanup = fs.readdirAsync(httpTemplateRoot).map(function(entry) {
                     return Templates.unlink(entry,skuid);
@@ -393,7 +404,7 @@ function skuPackServiceFactory(
                 promises.push(Promise.all(cleanup));
             }
 
-            if(conf.hasOwnProperty('httpProfileRoot')) {
+            if(conf.httpProfileRoot) {
                 var httpProfileRoot = skuRoot + path.resolve('/', conf.httpProfileRoot);
                 cleanup = fs.readdirAsync(httpProfileRoot).map(function(entry) {
                     return Profiles.unlink(entry,skuid);
@@ -401,22 +412,23 @@ function skuPackServiceFactory(
                 promises.push(Promise.all(cleanup));
             }
 
-            if(conf.hasOwnProperty('workflowRoot')) {
+            if(conf.workflowRoot) {
                 var workflowRoot = skuRoot + path.resolve('/', conf.workflowRoot);
                 cleanup = unloadWorkflowItems(skuid, workflowRoot, waterline.graphdefinitions);
                 promises.push(Promise.all(cleanup));
             }
 
-            if(conf.hasOwnProperty('taskRoot')) {
+            if(conf.taskRoot) {
                 var taskRoot = skuRoot + path.resolve('/', conf.taskRoot);
                 cleanup = unloadWorkflowItems(skuid, taskRoot, waterline.taskdefinitions);
                 promises.push(Promise.all(cleanup));
             }
-        } catch(error) {
+
+            return Promise.all(promises);
+        }).catch(function(error) {
             logger.warning('Unable to unregister sku configuration for ' + skuid);
             throw error;
-        }
-        return Promise.all(promises);
+        });
     };
 
     /**
@@ -427,14 +439,20 @@ function skuPackServiceFactory(
     SkuPackService.prototype.start = function(confRoot) {
         var self = this;
         self.confRoot = confRoot;
-
-        return self.loader.getAll(self.confRoot).then(function (conf) {
-            var promises = _.map(conf, function (contents, name) {
-                return self.registerPack(name,contents);
+        return Promise.try(function() {
+            assert.ok(!_.isUndefined(waterline.skus), 'skus model is undefined');
+            return waterline.skus.find({});
+        })
+        .then(function(skus) {
+            return Promise.map(skus, function(skuContents) {
+                return self.registerPack(skuContents.id, skuContents)
+                .catch(function() {
+                    logger.warning('Unable to startup pack for sku: ' + skuContents.id);
+                });
             });
-            return Promise.all(promises);
-        }).catch(function() {
-            logger.warning('Unable to startup sku pack service, check conf root: ' + confRoot);
+        })
+        .catch(function(err) {
+            logger.warning('Unable to startup sku pack service: ' + err);
         });
     };
 
@@ -444,28 +462,30 @@ function skuPackServiceFactory(
      * @param  {String}     fromRoot The path to the configuration file
      * @return {Promise}
      */
-    SkuPackService.prototype.validatePack = function(contents, fromRoot) {
-        try {
+    SkuPackService.prototype.validatePack = function(contents, fromRoot, options) {
+        options = options || {};
+
+        return Promise.try(function() {
             var conf = JSON.parse(contents);
-            return fs.readdirAsync(fromRoot).then(function(entries) {
-                var confProperties = [
-                    'httpStaticRoot',
-                    'httpTemplateRoot',
-                    'httpProfileRoot',
-                    'workflowRoot',
-                    'taskRoot'
-                ];
-                return confProperties.every(function(keyName) {
+            return fs.readdirAsync(fromRoot)
+            .then(function(entries) {
+                _.forEach(confProperties, function(keyName) {
                     if(_.has(conf, keyName) && _.indexOf(entries, conf[keyName] ) === -1)  {
-                        return false;
+                        throw new Errors.BadRequestError('invalid value for ' + keyName + ' in config.json');
                     }
-                    return true;
                 });
+            })
+            .then(function() {
+                if(options.validateSku) {
+                    if(!conf.hasOwnProperty('rules') || !conf.hasOwnProperty('name')) {
+                        throw new Errors.BadRequestError('rules or name is missing in config.json');
+                    }
+                }
             });
-        } catch(error) {
-            return Promise.reject(error);
-        }
-        return Promise.resolve(true);
+        })
+        .catch(function(err) {
+            throw new Errors.BadRequestError('invalid JSON in config.json: ' + err.message);
+        });
     };
 
     /**
@@ -477,63 +497,69 @@ function skuPackServiceFactory(
     SkuPackService.prototype.installPack = function(fromRoot, skuid) {
         var self = this;
         var contents;
-        var dst;
-        var installSKU;
         return fs.readFileAsync(fromRoot + '/config.json')
-            .then(function(fileContents) {
-                return [ fileContents, self.validatePack(fileContents, fromRoot) ];
-            })
-            .spread(function(fileContents) {
-                contents = fileContents;
-                if(skuid === undefined)  {
-                    var conf = JSON.parse(contents);
-                    if(!conf.hasOwnProperty('rules') || !conf.hasOwnProperty('name')) {
-                        throw new Error('rules or name is missing');
+        .then(function(fileContents) {
+            contents = fileContents;
+            return self.validatePack(fileContents, fromRoot, {
+                validateSku: !_.isUndefined(skuid)
+            });
+        })
+        .then(function() {
+            if(skuid === undefined)  {
+                var conf = JSON.parse(contents);
+                return waterline.skus.findOne({name: conf.name})
+                .then(function(entry) {
+                    if(entry) {
+                        var err = new Errors.BaseError('duplicate name found');
+                        err.status = 409;
+                        throw err;
                     }
-                    return waterline.skus.findOne({name: conf.name})
-                    .then(function(entry) {
-                        if(entry) {
-                            var err = new Errors.BaseError('duplicate name found');
-                            err.status = 409;
-                            throw err;
-                        }
-                        return waterline.skus.create({name: conf.name, rules: conf.rules})
-                        .then(function(sku) {
-                            return sku.id;
-                        });
-                    });
-                }
-                return skuid;
-            })
-            .then(function(skuID) {
-                return fs.statAsync(self.confRoot + '/' + skuID).then(function(stat) {
-                        if(stat.isDirectory())  {
-                            return self.deletePack(skuID);
-                        }
-                        return skuID;
-                    })
-                    .catch(function() {
-                        return skuID;
-                    });
-            })
-            .then(function(skuID) {
-                dst = self.confRoot + '/' + skuID;
-                installSKU = skuID;
-                return [skuID, fs.readdirAsync(fromRoot), fs.mkdirAsync(dst) ];
-            })
-            .spread(function(sku, entries) {
-                return Promise.map(entries, function(entry) {
-                    var src = fromRoot + '/' + entry;
-                    if( entry === 'config.json' ) {
-                        return fs.renameAsync(src, dst + '.json');
-                    } else {
-                        return fs.renameAsync(src, dst + '/' + entry);
-                    }
+                    return waterline.skus.create(_.pick(conf, ['name', 'rules', 'discoveryGraphName', 'discoveryGraphOptions'] ));
+                })
+                .then(function(sku) {
+                    return sku.id;
                 });
+            }
+            return skuid;
+        })
+        .then(function(skuId) {
+            return fs.statAsync(self.confRoot + '/' + skuId).then(function(stat) {
+                    if(stat.isDirectory())  {
+                        return self.deletePack(skuId);
+                    }
+                    return skuId;
+                })
+                .catch(function() {
+                    return skuId;
+                });
+        })
+        .then(function(skuId) {
+            var conf = JSON.parse(contents);
+            return [
+                skuId,
+                fs.readdirAsync(fromRoot), 
+                fs.mkdirAsync(self.confRoot + '/' + skuId),
+                waterline.skus.update({id: skuId}, _.pick(conf, validConfProperties))
+            ];
+        })
+        .spread(function(skuId, entries) {
+            var conf = JSON.parse(contents);
+            var properties = _.pick(conf, confProperties);
+            var dst = self.confRoot + '/' + skuId;
+            return Promise.filter(entries, function(entry) {
+                return -1 !== _.values(properties).indexOf(entry);
+            })
+            .map(function(entry) {
+                var src = fromRoot + '/' + entry;
+                return fs.renameAsync(src, dst + '/' + entry);
             })
             .then(function() {
-                return [dst + '.json', contents];
+                return skuId;
             });
+        })
+        .then(function(skuId) {
+            return [skuId, contents];
+        });
     };
 
 
@@ -545,39 +571,36 @@ function skuPackServiceFactory(
     SkuPackService.prototype.deletePack = function(skuid) {
         var self = this;
 
-        // We run as root, so double check the parameters before removing files
-        assert.ok(self.confRoot.length, 'confRoot is malformed');
-        assert.ok(skuid.length, 'skuid is malformed');
-        return fs.readFileAsync(self.confRoot + '/' + skuid + '.json')
-            .then(function(contents) {
-                return self.unregisterPack(skuid, contents);
-            })
-            .then(function() {
-                assert.ok(self.confRoot.length, 'confRoot is malformed');
-                return rimrafAsync(self.confRoot + '/' + skuid);
-            })
-            .then(function() {
-                assert.ok(self.confRoot.length, 'confRoot is malformed');
-                return fs.unlinkAsync(self.confRoot + '/' + skuid + '.json');
-            })
-            .then(function() {
-                return skuid;
-            });
+        return Promise.try(function() {
+            // We run as root, so double check the parameters before removing files
+            assert.ok(self.confRoot.length, 'confRoot is malformed');
+            assert.ok(skuid.length, 'skuid ' + skuid + ' is malformed');
+            return waterline.skus.findOne({id: skuid});
+        })
+        .then(function(conf) {
+            return [ conf, self.unregisterPack(skuid, conf) ];
+        })
+        .spread(function(conf) {
+            return waterline.skus.update({id: skuid}, _.omit(conf, validConfProperties));
+        })
+        .then(function() {
+            assert.ok(self.confRoot.length, 'confRoot is malformed');
+            return rimrafAsync(self.confRoot + '/' + skuid);
+        })
+        .then(function() {
+            return skuid;
+        });
     };
 
     SkuPackService.prototype.getPackInfo = function(skuid) {
         var self = this;
-        return self.loader.getAll(self.confRoot)
-        .then(function (conf) {
-            var skuConf = conf[skuid + '.json'];
-            if(skuConf) {
-                var json = JSON.parse(skuConf);
-                return {
-                    description: json.description || null,
-                    version: json.version || null
-                };
-            }
-            return null;
+        return waterline.skus.findOne({id: skuid})
+        .then(function(contents) {
+            contents = contents || {};
+            return {
+                description: contents.description || null,
+                version: contents.version || null
+            };
         });
     };
 
@@ -595,35 +618,28 @@ function skuPackServiceFactory(
         return res;
     }
 
-    function loadWorkflowItems(skuName, fromRoot, dbCatalog) {
+    function loadWorkflowItems(skuId, fromRoot) {
         return fs.readdirAsync(fromRoot)
-            .filter(function(entry) {
-                return fs.statSync(fromRoot + '/' + entry).isFile();
-            })
-            .map(function(entry) {
-                return fs.readFileAsync(fromRoot + '/' + entry);
-            })
-            .filter(function(contents) {
-                var data = JSON.parse(contents);
-                return dbCatalog.findOne({injectableName: data.injectableName + '::' + skuName})
-                    .then(function(item) {
-                        return !item;
-                    });
-            });
+        .filter(function(entry) {
+            return fs.statSync(fromRoot + '/' + entry).isFile();
+        })
+        .map(function(entry) {
+            return fs.readFileAsync(fromRoot + '/' + entry);
+        });
     }
 
-    function unloadWorkflowItems(skuName, fromRoot, dbCatalog) {
+    function unloadWorkflowItems(skuId, fromRoot, dbCatalog) {
         return fs.readdirAsync(fromRoot)
-            .filter(function(entry) {
-                return fs.statSync(fromRoot + '/' + entry).isFile();
-            })
-            .map(function(entry) {
-                return fs.readFileAsync(fromRoot + '/' + entry);
-            })
-            .map(function(contents) {
-                var data = JSON.parse(contents);
-                return dbCatalog.destroy({injectableName: data.injectableName + '::' + skuName});
-            });
+        .filter(function(entry) {
+            return fs.statSync(fromRoot + '/' + entry).isFile();
+        })
+        .map(function(entry) {
+            return fs.readFileAsync(fromRoot + '/' + entry);
+        })
+        .map(function(contents) {
+            var data = JSON.parse(contents);
+            return dbCatalog.destroy({injectableName: data.injectableName + '::' + skuId});
+        });
     }
 
     return new SkuPackService();

--- a/spec/lib/api/1.1/skus-spec.js
+++ b/spec/lib/api/1.1/skus-spec.js
@@ -118,7 +118,7 @@ describe('Http.Api.Skus', function () {
         it('should return the same sku from GET /skus/:id', function () {
             return helper.request().get('/api/1.1/skus/' + sku.id)
             .expect('Content-Type', /^application\/json/)
-            .expect(200, _.merge({}, sku, { packInfo: null }) );
+            .expect(200, _.merge({}, sku, { packInfo: { description: null, version: null } }) );
         });
 
         describe('PATCH /skus/:id', function () {

--- a/spec/lib/api/2.0/skus-spec.js
+++ b/spec/lib/api/2.0/skus-spec.js
@@ -118,7 +118,7 @@ describe('Http.Api.Skus', function () {
         it('should return the same sku from GET /skus/:id', function () {
             return helper.request().get('/api/2.0/skus/' + sku.id)
             .expect('Content-Type', /^application\/json/)
-            .expect(200, _.merge({}, sku, { packInfo: null }) );
+            .expect(200, _.merge({}, sku, { packInfo: { description: null, version: null } }) );
         });
 
         it('should 409 reposting the same sku', function() {


### PR DESCRIPTION
- Change InternalError errors to BadRequest when the issue arises due to
  bad data in the skupack file that is posted.
- Move the config.json properties into the model

@RackHD/corecommitters @uppalk1 @keedya @tannoa2 