### PR TITLE
Bump mocha timeout to 10000 to mitigate potential jenkins issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "doc": "./node_modules/.bin/jsdoc lib/api/1.1/northbound -r -d docs",
-    "test": "./node_modules/.bin/mocha $(find spec -name '*-spec.js') -R spec --require spec/helper.js",
+    "test": "./node_modules/.bin/mocha --timeout 10000 $(find spec -name '*-spec.js') -R spec --require spec/helper.js",
     "install": "./install-web-ui.sh && ./install-swagger-ui.sh",
     "apidoc": "./node_modules/.bin/apidoc -i lib/api/1.1/northbound -f '.*\\.js$' -o build/apidoc"
   },


### PR DESCRIPTION
Proposing a potential way to address what could be jenkins timeout issues when loading modules in mocha "before" blocks.

@RackHD/corecommitters @tldavies @davidzuhn 