### PR TITLE
Dockerfile refactor removes extra node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,10 +7,14 @@
 .travis.yml
 build-package.bash
 debianstatic/
+extra/
 Dockerfile
 Gruntfile.js
 HWIMO-*
 LICENSE
 migrate.js
+node_modules/
 README.md
 spec/
+static/web-ui/
+static/swagger-ui/

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ static/http/
 static/smb/
 static/tftp/
 static/web-ui/
+static/swagger-ui/
 
 build/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,19 @@
 
 FROM rackhd/on-core
 
-RUN mkdir -p /RackHD/on-http
+COPY . /RackHD/on-http/
 WORKDIR /RackHD/on-http
 
-COPY ./package.json /tmp/
-RUN cd /tmp \
-  && ln -s /RackHD/on-core /tmp/node_modules/on-core \
-  && ln -s /RackHD/on-core/node_modules/di /tmp/node_modules/di \
-  && npm install --ignore-scripts --production
-
-COPY . /RackHD/on-http/
-RUN cp -a -f /tmp/node_modules /RackHD/on-http/
-
-RUN cd /RackHD/on-http && npm install apidoc && npm run apidoc
-
-RUN apk add --update unzip \
+RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-core ./node_modules/on-core \
+  && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
+  && npm install --ignore-scripts --production \
+  && npm install apidoc && npm run apidoc \
+  && echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+  && apk add --update ipmitool@testing unzip \
   && /RackHD/on-http/install-web-ui.sh \
   && /RackHD/on-http/install-swagger-ui.sh
 
-EXPOSE 9080
-EXPOSE 9090
-
+EXPOSE 9080 9090
 VOLUME /RackHD/on-http/static/http/common
-
 CMD [ "node", "/RackHD/on-http/index.js" ]


### PR DESCRIPTION
Removes extra copy of node_modules directory which reduces the size of the docker image.

Also adds `static/swagger-ui` to `.gitignore`.