### PR TITLE
Remove decodeURIComponent and add sway 1.0.0 fix

### DIFF
--- a/lib/api/2.0/tags.js
+++ b/lib/api/2.0/tags.js
@@ -8,6 +8,19 @@ var nodes = injector.get('Http.Services.Api.Nodes');
 var tags = injector.get('Http.Services.Api.Tags');
 var _ = injector.get('_'); // jshint ignore:line
 var Errors = injector.get('Errors');
+var parseUrl = require('url').parse;
+
+function getTagName(req) {
+    //TODO: sway 1.0.0 implements a fix for this, but it is lacking in the ^0.6.0 versions
+    //      so we duplicate the 1.0.0 implementation here. 
+    // Ref: https://github.com/apigee-127/sway/commit/1b7acd9743aae2f2f94057d3f8911e2af72614f5
+    var pathObject = req.swagger.operation.pathObject;
+    var pathMatch = pathObject.regexp.exec(parseUrl(req.url).pathname);
+    var value = decodeURIComponent(pathMatch[_.findIndex(pathObject.regexp.keys, function(key) {
+        return key.name === 'tagName';
+    }) + 1]);
+    return value;
+}
 
 var getAllTags = controller(function(req) {
     return tags.findTags(req.query);
@@ -31,19 +44,19 @@ var createTag = controller({success: 201}, function(req) {
 });
 
 var getTag = controller(function(req) {
-    return tags.getTag(req.swagger.params.tagName.value);
+    return tags.getTag(getTagName(req));
 });
 
 var deleteTag = controller({success: 204}, function(req) {
-    return tags.destroyTag(req.swagger.params.tagName.value);
+    return tags.destroyTag(getTagName(req));
 });
 
 var getNodesByTag = controller(function(req) {
-    return nodes.getNodesByTag(req.swagger.params.tagName.value);
+    return nodes.getNodesByTag(getTagName(req));
 });
 
 var postWorkflowById = controller({success: 202}, function(req) {
-    return nodes.getNodesByTag(req.swagger.params.tagName.value).map(function(node) {
+    return nodes.getNodesByTag(getTagName(req)).map(function(node) {
         return nodes.setNodeWorkflow(node.id,
             req.swagger.params.name.value || req.swagger.params.body.value.name,
             req.swagger.params.body.value.options);

--- a/lib/services/tags-api-service.js
+++ b/lib/services/tags-api-service.js
@@ -30,7 +30,6 @@ function tagApiServiceFactory(
     };
 
     TagApiService.prototype.getTag = function(name) {
-        name = decodeURIComponent(name);
         return waterline.tags.findOne({name: name})
         .then(function(tag) {
             if(!tag) {
@@ -41,7 +40,6 @@ function tagApiServiceFactory(
     };
 
     TagApiService.prototype.destroyTag = function(name) {
-        name = decodeURIComponent(name);
         return waterline.tags.findOne({name: name})
         .then(function(tag) {
             if(!tag) {

--- a/spec/lib/api/2.0/tags-spec.js
+++ b/spec/lib/api/2.0/tags-spec.js
@@ -132,7 +132,7 @@ describe('Http.Api.Tags', function () {
                 .expect('Content-Type', /^application\/json/)
                 .expect(200, input)
                 .then(function() {
-                    expect(tagsApi.getTag).to.have.been.calledWith('tag%20name');
+                    expect(tagsApi.getTag).to.have.been.calledWith('tag name');
                 });
         });
 


### PR DESCRIPTION
The previous decodeURI, which was replaced by decodeURIComponent, was
masking an issue in sway.  This change removes the decodeURIComponent,
which is already being done by express and (attempted by) sway and
changes the 2.0 code to use the sway 1.0.0 fix.