### PR TITLE
add support for Api proxy

### DIFF
--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -41,7 +41,7 @@ function profilesRouterFactory (
      */
 
     router.get('/profiles', function (req, res) {
-        return profileApiService.setLookup(req.query)
+        return profileApiService.setLookup(req)
         .then(function() {
             var macs = req.query.mac || req.query.macs;
             if (macs) {

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -231,12 +231,20 @@ function CommonApiPresenterFactory(
         var self = this;
         var scope = self.res.locals.scope;
         var config = CommonApiPresenter.configCache;
-        var baseUri = 'http://' + config.apiServerAddress + ':' + config.apiServerPort + '/api/current';
+        var apiServerAddress = self.req.get(constants.HttpHeaders.ApiProxyIp) ||
+                                                      config.apiServerAddress || 
+                                                      '10.1.1.1';
+        var apiServerPort = self.req.get(constants.HttpHeaders.ApiProxyPort) || 
+                                                        config.apiServerPort || 
+                                                        80;
+        var serverUri = 'http://' + apiServerAddress + ':' + apiServerPort;
+        var baseUri = serverUri + '/api/current';
+        
         graphContext = graphContext || {};
 
         return Promise.props({
-            server: config.apiServerAddress || '10.1.1.1',
-            port: config.apiServerPort || 80,
+            server: apiServerAddress,
+            port: apiServerPort,
             ipaddress: self.res.locals.ipAddress,
             netmask: config.dhcpSubnetMask || '255.255.255.0',
             gateway: config.dhcpGateway || '10.1.1.1',
@@ -245,7 +253,7 @@ function CommonApiPresenterFactory(
             env: Env.get('config', {}, scope),
             // Build structure that mimics the task renderContext
             api: {
-                server: 'http://' + config.apiServerAddress + ':' + config.apiServerPort,
+                server: serverUri,
                 base: baseUri,
                 files: baseUri + '/files',
                 nodes: baseUri + '/nodes'

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -21,6 +21,11 @@ var bodyParser = require('body-parser');
  *                             if unavailable
  */
 function remoteAddress(req) {
+    
+    if(req.get("X-Real-IP")) {
+        return req.get("X-Real-IP");
+    }
+    
     if (req.ip) {
         return req.ip;
     }

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -22,7 +22,8 @@ di.annotate(profileApiServiceFactory,
         '_',
         'Profiles',
         'Services.Environment',
-        'Http.Services.Swagger'
+        'Http.Services.Swagger',
+        'Constants'
     )
 );
 function profileApiServiceFactory(
@@ -38,7 +39,8 @@ function profileApiServiceFactory(
     _,
     profiles,
     Env,
-    swaggerService
+    swaggerService,
+    Constants,
 ) {
 
     var logger = Logger.initialize(profileApiServiceFactory);
@@ -71,7 +73,8 @@ function profileApiServiceFactory(
         return _.flattenDeep([macs]);
     };
 
-    ProfileApiService.prototype.setLookup = function(query) {
+    ProfileApiService.prototype.setLookup = function(req) {
+        var query = req.query;
         if (query.mac && query.ip) {
             return waterline.nodes.findByIdentifier(this.getMacs(query.mac))
             .then(function (node) {
@@ -80,6 +83,14 @@ function profileApiServiceFactory(
                         query.ip,
                         query.mac
                     );
+                }
+            }).then(function () {
+                if ( req.get(Constants.HttpHeaders.ApiProxyIp) ) {
+                    var proxy =  'http://%s:%s'.format(
+                        req.get(Constants.HttpHeaders.ApiProxyIp),
+                        req.get(Constants.HttpHeaders.ApiProxyPort)
+                    );
+                    return waterline.lookups.upsertProxyToMacAddress(proxy, query.mac);
                 }
             });
         }
@@ -135,6 +146,13 @@ function profileApiServiceFactory(
             };
         }
 
+        // If there is an api proxy add it to the context
+        lookupService.nodeIdToProxy(node.id).then( function(proxy) {
+            if(proxy) {
+                configuration.context = {proxy: proxy};
+            }
+        });
+        
         // The nested workflow holds the lock against the nodeId in this case,
         // so don't add it as a target to the outer workflow context
         return workflowApiService.createAndRunGraph(configuration, null)

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -40,7 +40,7 @@ function profileApiServiceFactory(
     profiles,
     Env,
     swaggerService,
-    Constants,
+    Constants
 ) {
 
     var logger = Logger.initialize(profileApiServiceFactory);

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -84,13 +84,15 @@ function profileApiServiceFactory(
                         query.mac
                     );
                 }
-            }).then(function () {
-                if ( req.get(Constants.HttpHeaders.ApiProxyIp) ) {
+            }).then(function (node) {
+                if ( node && req.get(Constants.HttpHeaders.ApiProxyIp) ) {
                     var proxy =  'http://%s:%s'.format(
                         req.get(Constants.HttpHeaders.ApiProxyIp),
                         req.get(Constants.HttpHeaders.ApiProxyPort)
                     );
                     return waterline.lookups.upsertProxyToMacAddress(proxy, query.mac);
+                } else {
+                    return node;
                 }
             });
         }

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -17,7 +17,8 @@ di.annotate(workflowApiServiceFactory,
         'Promise',
         'Constants',
         '_',
-        'Services.Environment'
+        'Services.Environment',
+        'Services.Lookup'
     )
 );
 
@@ -31,7 +32,8 @@ function workflowApiServiceFactory(
     Promise,
     Constants,
     _,
-    env
+    env,
+    lookupService
 ) {
     var logger = Logger.initialize(workflowApiServiceFactory);
 
@@ -65,11 +67,20 @@ function workflowApiServiceFactory(
                 throw new Error("Unable to run multiple task graphs against a single target.");
             }
             var context = configuration.context || {};
-            if (node) {
-                context = _.defaults(context, { target: node.id });
-            }
-            return self.createActiveGraph(
+            return Promise.resolve().then(function() {
+                if(node) {
+                    context = _.defaults(context, { target: node.id });
+                    return lookupService.nodeIdToProxy(node.id);
+                } else {
+                    return undefined;
+                }
+            }).then(function(proxy) {
+                if(proxy) {
+                    context.proxy = proxy;
+                }
+                return self.createActiveGraph(
                         definition, configuration.options, context, configuration.domain, true);
+            });
         })
         .then(function(graph) {
             self.runTaskGraph(graph.instanceId, configuration.domain);

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -82,6 +82,7 @@ describe("Http.Services.Api.Profiles", function () {
             .then(function() {
                 expect(lookupService.setIpAddress).to.be.calledOnce;
                 expect(waterline.lookups.upsertProxyToMacAddress).to.not.be.called;
+                expect(result).to.not.be.undefined;
             });
         });
 
@@ -94,6 +95,7 @@ describe("Http.Services.Api.Profiles", function () {
             .then(function() {
                 expect(lookupService.setIpAddress).to.be.calledOnce;
                 expect(waterline.lookups.upsertProxyToMacAddress).to.be.calledOnce;
+                expect(result).to.not.be.undefined;
             });
         });
 
@@ -105,9 +107,10 @@ describe("Http.Services.Api.Profiles", function () {
             this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress').resolves();
             this.sandbox.stub(lookupService, 'setIpAddress').resolves();
             return profileApiService.setLookup(req)
-            .then(function() {
+            .then(function(result) {
                 expect(lookupService.setIpAddress).to.not.be.called;
                 expect(waterline.lookups.upsertProxyToMacAddress).to.be.calledOnce;
+                expect(result).to.be.undefined;
             });
         });
 

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -61,6 +61,17 @@ describe("Http.Services.Api.Profiles", function () {
     describe("setLookup", function() {
         var node;
         var proxy;
+        var nodeRes = {
+            id: 'id',
+            ip: 'ip',
+            mac: 'mac'
+        };
+        var proxyRes = {
+            id: 'id',
+            ip: 'ip',
+            mac: 'mac',
+            proxy: 'proxy'
+        };
         var req = {
             query: {
                 'ip':'ip',
@@ -75,27 +86,29 @@ describe("Http.Services.Api.Profiles", function () {
 
         it("setLookup should add IP lookup entry for new node", function() {
             this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
-            this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress').resolves();
-            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
+            this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress')
+                .resolves(proxyRes);
+            this.sandbox.stub(lookupService, 'setIpAddress').resolves(nodeRes);
  
             return profileApiService.setLookup(req)
-            .then(function() {
+            .then(function(result) {
                 expect(lookupService.setIpAddress).to.be.calledOnce;
                 expect(waterline.lookups.upsertProxyToMacAddress).to.not.be.called;
-                expect(result).to.not.be.undefined;
+                expect(result).to.deep.equal(nodeRes);
             });
         });
 
         it("setLookup should add IP lookup entry and proxy for new node", function() {
             proxy = '12.1.1.1';
             this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
-            this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress').resolves();
-            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
+            this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress')
+                .resolves(proxyRes);
+            this.sandbox.stub(lookupService, 'setIpAddress').resolves(nodeRes);
             return profileApiService.setLookup(req)
-            .then(function() {
+            .then(function(result) {
                 expect(lookupService.setIpAddress).to.be.calledOnce;
                 expect(waterline.lookups.upsertProxyToMacAddress).to.be.calledOnce;
-                expect(result).to.not.be.undefined;
+                expect(result).to.deep.equal(proxyRes);
             });
         });
 
@@ -109,7 +122,7 @@ describe("Http.Services.Api.Profiles", function () {
             return profileApiService.setLookup(req)
             .then(function(result) {
                 expect(lookupService.setIpAddress).to.not.be.called;
-                expect(waterline.lookups.upsertProxyToMacAddress).to.be.calledOnce;
+                expect(waterline.lookups.upsertProxyToMacAddress).to.not.be.called;
                 expect(result).to.be.undefined;
             });
         });
@@ -118,9 +131,10 @@ describe("Http.Services.Api.Profiles", function () {
             this.sandbox.stub(lookupService, 'setIpAddress').resolves();
             this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress').resolves();
             return profileApiService.setLookup({query: {macs:'macs'}})
-            .then(function() {
+            .then(function(result) {
                 expect(lookupService.setIpAddress).to.not.be.called;
                 expect(waterline.lookups.upsertProxyToMacAddress).to.not.be.called;
+                expect(result).to.be.undefined;
             });
         });
 

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -155,7 +155,10 @@ describe('Http.Services.Api.Workflows', function () {
             expect(store.findActiveGraphForTarget).to.have.been.calledWith('testnodeid');
             expect(workflowApiService.createActiveGraph).to.have.been.calledOnce;
             expect(workflowApiService.createActiveGraph).to.have.been.calledWith(
-                graphDefinition, { test: 1 }, { target: 'testnodeid', test: 2, proxy: 'proxy' }, 'test'
+                graphDefinition, 
+                { test: 1 }, 
+                { target: 'testnodeid', test: 2, proxy: 'proxy' }, 
+                'test'
             );
             expect(workflowApiService.runTaskGraph).to.have.been.calledOnce;
             expect(workflowApiService.runTaskGraph)

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -134,6 +134,36 @@ describe('Http.Services.Api.Workflows', function () {
         });
     });
 
+    it('should create and run a graph against a node with a proxy', function () {
+        workflowApiService.findGraphDefinitionByName.resolves(graphDefinition);
+        workflowApiService.createActiveGraph.resolves(graph);
+        workflowApiService.runTaskGraph.resolves();
+        store.findActiveGraphForTarget.resolves();
+        waterline.lookups.findOneByTerm.resolves({id: 'testnodeid', proxy: 'proxy'});
+
+        return workflowApiService.createAndRunGraph({
+            name: 'Graph.Test',
+            options: { test: 1 },
+            context: { test: 2 },
+            domain: 'test'
+        }, 'testnodeid')
+        .then(function() {
+            expect(workflowApiService.findGraphDefinitionByName).to.have.been.calledOnce;
+            expect(workflowApiService.findGraphDefinitionByName)
+                .to.have.been.calledWith('Graph.Test');
+            expect(store.findActiveGraphForTarget).to.have.been.calledOnce;
+            expect(store.findActiveGraphForTarget).to.have.been.calledWith('testnodeid');
+            expect(workflowApiService.createActiveGraph).to.have.been.calledOnce;
+            expect(workflowApiService.createActiveGraph).to.have.been.calledWith(
+                graphDefinition, { test: 1 }, { target: 'testnodeid', test: 2, proxy: 'proxy' }, 'test'
+            );
+            expect(workflowApiService.runTaskGraph).to.have.been.calledOnce;
+            expect(workflowApiService.runTaskGraph)
+                .to.have.been.calledWith(graph.instanceId, 'test');
+            expect(env.get).to.not.be.called;
+        });
+    });
+
     it('should create and run a graph against a node with a sku', function () {
         workflowApiService.findGraphDefinitionByName.resolves(graphDefinition);
         workflowApiService.createActiveGraph.resolves(graph);

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -31,6 +31,9 @@ describe('Http.Services.Api.Workflows', function () {
         waterline.nodes = {
             needByIdentifier: sinon.stub().resolves({ id: 'testnodeid' })
         };
+        waterline.lookups = {
+           findOneByTerm: sinon.stub().resolves() 
+        };
         waterline.graphobjects = {
             needByIdentifier: sinon.stub().resolves({ id: 'testgraphid', _status: 'pending' }),
             find: sinon.stub().resolves(),


### PR DESCRIPTION
In order to support running the RackHD on-taskgraph and on-http services on a host that does not have Layer-2 network access to the PXE network we need a host that does have access to the PXE network and can proxy requests to the southbound API endpoint over a management network.

The proxy server, nginx in my POC, adds headers to the requests coming from the PXE client that contain headers that will be used during profile, template, and task rendering.

The headers are
X-Real-IP - the actual IP address of the PXE client
X-RackHD-api-proxy-ip - The IP address of the API proxy server
X-RackHD-api-proxy-port - The port of the API proxy server

The proxy server URL is added to the lookup record for the PXE client so that it can be used during task rendering since the original HTTP request is not available at that time.

This is one of three pull requests. There will also be subsequent changes to on-core  and on-tasks to support this.

on-core PR: https://github.com/RackHD/on-core/pull/131
on-tasks PR: https://github.com/RackHD/on-tasks/pull/185

[test-coverage.tar.gz](https://github.com/RackHD/on-http/files/255454/test-coverage.tar.gz)
