### PR TITLE
Add callback API service to centos-ks installer

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -168,9 +168,15 @@ echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/ne
   chattr +i /etc/resolv.conf
 <% } %>
 
+# Download the service to callback to RackHD after OS installation/reboot completion
+/usr/bin/wget http://<%=server%>:<%=port%>/api/common/templates/<%=rackhdCallbackScript%> -O /etc/rc.d/init.d/<%=rackhdCallbackScript%>
+chmod +x /etc/rc.d/init.d/<%=rackhdCallbackScript%>
+# Enable the above service, it should auto-disable after running once
+chkconfig <%=rackhdCallbackScript%> on
+
 #signify ORA the installation completed
 /usr/bin/wget --spider http://<%=server%>:<%=port%>/api/common/templates/renasar-ansible.pub
 
-) 2>&1 >/root/install-post-sh.log
+) 2>&1 >>/root/install-post-sh.log
 EOF
 %end

--- a/data/templates/centos.rackhdcallback
+++ b/data/templates/centos.rackhdcallback
@@ -1,0 +1,31 @@
+#! /bin/bash
+#
+# centos.rackhdcallback       callback to rackhd post installation API hook
+#
+# description: calls back to rackhd post installation API hook
+#
+### BEGIN INIT INFO
+# Provides: centos.rackhdcallback
+# Required-Start:    $network
+# Default-Start:     3 4 5
+# Short-Description: Callback to rackhd post installation API hook
+# Description: Callback to rackhd post installation API hook
+### END INIT INFO
+
+
+# We can't really know when networking is actually up and running from
+# a simple "Required-Start: $network", so instead just use curl with
+# a bunch of retries and hope it works. We could use more sophisticated
+# dependency mechanisms provided by systemd, but ideally we can just use
+# a single script to service both CentOS 6.5 and CentOS 7 installs, hence
+# reasoning for using `wget --retry-connrefused` below. Using `curl --retry`
+# fails immediately because it only handles connection timeouts, not connection
+# refused cases.
+# See https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
+
+# Nothing wrong with set -e here since we're not doing anything complex
+set -e
+echo "Attempting to call back to RackHD CentOS installer"
+wget --retry-connrefused --waitretry=1 -t 30 http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>
+# Only run this once to verify the OS was installed, then disable it forever
+chkconfig centos.rackhdcallback off


### PR DESCRIPTION
This addresses an issue where we end up doing SSH validation *before* a reboot during a CentOS install. These changes add a "run-once" service that hits an API route to verify the OS is up and running post installation reboot.

Requires https://github.com/RackHD/on-taskgraph/pull/99 and RackHD/on-tasks#201

@RackHD/corecommitters @heckj @zyoung51 @VulpesArtificem @johren @stuart-stanley