### PR TITLE
Add consumes application/json to 1.1 swagger spec

### DIFF
--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -12,6 +12,8 @@ produces:
   # x-gzip explicitly for files once the bugs listed 
   #   in comments below are fixed by swagger team.
   - application/x-gzip
+consumes:
+  - application/json
 securityDefinitions:
   auth_token:
     type: apiKey


### PR DESCRIPTION
The swagger spec for the 1.1 API is missing a consumes section
for application/json. Code generated with Swagger tooling then
does not properly marshal JSON data when doing things like POST.