### PR TITLE
Add API callbacks to ESXi installer

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -78,6 +78,28 @@ server 1.vmware.pool.ntp.org
 __NTP_CONFIG__
 /sbin/chkconfig ntpd on
 
+# Download the service to callback to RackHD after OS installation/reboot completion
+# %firstboot ends with a reboot, this script will run afterwards to signify completion
+# of the installer and all reboot steps.
+#
+# The approved method for adding startup commands is to write to /etc/rc.local.d/local.sh, 
+# which is a pre-existing file with a sticky bit set by VisorFS. You can't just create new
+# files and expect them to stick around, even if you set a sticky bit yourself.
+# The /sbin/auto-backup.sh script will ensure the changes are persisted across reboots and
+# MUST be executed after making any changes.
+#
+# See these links for more information:
+# http://www.virtuallyghetto.com/2011/08/how-to-persist-configuration-changes-in.html
+# http://blogs.vmware.com/vsphere/2011/09/how-often-does-esxi-write-to-the-boot-disk.html
+# https://communities.vmware.com/message/1273849#1273849
+#
+# NOTE: this method only works for ESXi 5.1 or greater. For older versions, the changes
+# must be written to /etc/rc.local instead.
+#
+# NOTE: this script will execute right away as a result of writing it to local.sh
+# along with executing on every subsequent boot
+wget http://<%=server%>:<%=port%>/api/common/templates/<%=rackhdCallbackScript%> -O /etc/rc.local.d/local.sh
+
 #backup ESXi configuration to persist it
 /sbin/auto-backup.sh
 
@@ -165,9 +187,6 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
     <%=n%>
   <% }); %>
 <% } %>
-
-#signify ORA the installation completed
-/usr/bin/wget -s http://<%=server%>:<%=port%>/api/common/templates/renasar-ansible.pub
 
 #reboot the system after host configuration
 esxcli system shutdown reboot -d 10 -r "Rebooting after first boot host configuration"

--- a/data/templates/esx.rackhdcallback
+++ b/data/templates/esx.rackhdcallback
@@ -1,0 +1,22 @@
+#!/bin/sh
+# esx       callback to rackhd post installation API hook
+# description: calls back to rackhd post installation API hook
+
+echo "Attempting to call back to RackHD ESX installer"
+
+# *sigh*, busybox shell does not support {1..30}. Retry 30 times with 1 second
+# sleep in between.
+for retry in $(awk 'BEGIN { for ( i=0; i<30; i++ ) { print i; } }');
+do
+    wget -s http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>
+    if [ "$?" -ne 0 ];
+    then
+        echo "Failed to connect to RackHD API callback, retrying"
+        sleep 1
+    else
+        exit 0
+    fi
+done;
+
+echo "Exceeded retries connecting to RackHD API callback. Exiting with failure code 1"
+exit 1


### PR DESCRIPTION
This addresses an issue where we end up doing SSH validation before we're ready during an ESXi install. These changes add a script that hits an API route to verify the OS is up and running during the `%firstboot` phase of installation and on post installation reboot.

ESXi is much, much more annoying when it comes to creating custom services, or making persistent changes of any kind, so this isn't quite as clean as the solution for the CentOS installer (https://github.com/RackHD/on-http/pull/279), but it's the same pattern. The mechanisms used here assume ESXi 5.1 or greater (for older versions, we'd need to write to `/etc/rc.local` instead of `/etc/rc.local.d/local.sh`).

Requires https://github.com/RackHD/on-taskgraph/pull/102 and https://github.com/RackHD/on-tasks/pull/209

@RackHD/corecommitters @heckj @zyoung51 @VulpesArtificem @johren @stuart-stanley @richav1 @amymullins 