### PR TITLE
Assert workflows are running when created

### DIFF
--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -276,6 +276,7 @@ describe('Http.Services.Api.Workflows', function () {
             expect(workflowApiService.createGraph).to.have.been.calledWith(
                 graphDefinition, null, null, null);
             expect(_graph).to.equal(graph);
+            expect(_graph._status).to.equal('running');
             expect(persistStub).to.have.been.calledOnce;
         });
     });


### PR DESCRIPTION
~~Related to https://github.com/RackHD/on-core/pull/140 and a little related to https://github.com/RackHD/on-http/pull/246 (in order for the unit tests to pass)~~

Tests that a graph is created in a "running" state.
~~Adds the `true` argument which tells `graph.persist` this is a new graph.~~