### PR TITLE
Post to lookups with static ip and newly created MAC

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -34,6 +34,22 @@ rootpw <%=rootPlainPassword%>
 reboot
 
 %firstboot --interpreter=busybox
+postLookup () {
+  echo "Attempting postLookup operation on $1" >> /vmfs/volumes/datastore1/firstboot.log
+  mac=`esxcli --debug --formatter=csv network ip interface list | grep $1 | awk -F, '{print $3}'`
+  if [ "<%=version%>" == "5.5" ]; then
+    mac=`esxcli --debug --formatter=csv network ip interface list | grep $1 | awk -F, '{print $2}'`
+  fi
+  BODY="{"
+  BODY=$BODY"\"macAddress\": \"$mac\","
+  BODY=$BODY"\"ipAddress\": \"$2\","
+  BODY=$BODY"\"node\": \"<%=task.nodeId%>\""
+  BODY=$BODY"}"
+  BODYLEN=$(echo -n ${BODY} | wc -c )
+  echo ${BODY} >> /vmfs/volumes/datastore1/firstboot.log
+  echo -ne "POST /api/1.1/lookups HTTP/1.0\r\nHost: $2\r\nContent-Type: application/json\r\nContent-Length: ${BODYLEN}\r\n\r\n${BODY}" | nc -i 3 <%=server%> <%=port%>
+}
+
 # enable VHV (Virtual Hardware Virtualization to run nested 64bit Guests + Hyper-V VM)
 grep -i "vhv.enable" /etc/vmware/config || echo "vhv.enable = \"TRUE\"" >> /etc/vmware/config
 
@@ -78,31 +94,6 @@ server 1.vmware.pool.ntp.org
 __NTP_CONFIG__
 /sbin/chkconfig ntpd on
 
-# Download the service to callback to RackHD after OS installation/reboot completion
-# %firstboot ends with a reboot, this script will run afterwards to signify completion
-# of the installer and all reboot steps.
-#
-# The approved method for adding startup commands is to write to /etc/rc.local.d/local.sh, 
-# which is a pre-existing file with a sticky bit set by VisorFS. You can't just create new
-# files and expect them to stick around, even if you set a sticky bit yourself.
-# The /sbin/auto-backup.sh script will ensure the changes are persisted across reboots and
-# MUST be executed after making any changes.
-#
-# See these links for more information:
-# http://www.virtuallyghetto.com/2011/08/how-to-persist-configuration-changes-in.html
-# http://blogs.vmware.com/vsphere/2011/09/how-often-does-esxi-write-to-the-boot-disk.html
-# https://communities.vmware.com/message/1273849#1273849
-#
-# NOTE: this method only works for ESXi 5.1 or greater. For older versions, the changes
-# must be written to /etc/rc.local instead.
-#
-# NOTE: this script will execute right away as a result of writing it to local.sh
-# along with executing on every subsequent boot
-wget http://<%=server%>:<%=port%>/api/common/templates/<%=rackhdCallbackScript%> -O /etc/rc.local.d/local.sh
-
-#backup ESXi configuration to persist it
-/sbin/auto-backup.sh
-
 #enter maintenance mode
 esxcli system maintenanceMode set -e true
 
@@ -144,6 +135,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
           esxcli network ip interface ipv4 set -i <%=vmkname%> -I <%=n.ipv4.ipAddr%> -N <%=n.ipv4.netmask%> -t static
           esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%> 
           esxcli network vswitch standard portgroup set -p <%=n.device%>.<%=vid%> -v <%=vid %>
+          postLookup <%=vmkname%> <%=n.ipv4.ipAddr%>
         <% }); %>
       <% } else { %>
         <% vmkname = 'vmk' + vmkid++ %>
@@ -152,6 +144,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
         esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>
         esxcli network ip interface ipv4 set -i <%=vmkname%> -I <%=n.ipv4.ipAddr%> -N <%=n.ipv4.netmask%> -t static
         esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%> 
+        postLookup <%=vmkname%> <%=n.ipv4.ipAddr%>
       <% } %>
     <% } %>
     <% if( undefined !== n.ipv6 ) { %>
@@ -187,6 +180,36 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
     <%=n%>
   <% }); %>
 <% } %>
+
+# signify ORA the installation completed, the 60s sleep is to wait for the LRU to timeout
+# the stale entries that it latched prior to the lookups loading above being set.  Without
+# the sleep, the completionUri hit below will not publish to the correct AMQP channel
+sleep 60
+
+# Download the service to callback to RackHD after OS installation/reboot completion
+# %firstboot ends with a reboot, this script will run afterwards to signify completion
+# of the installer and all reboot steps.
+#
+# The approved method for adding startup commands is to write to /etc/rc.local.d/local.sh, 
+# which is a pre-existing file with a sticky bit set by VisorFS. You can't just create new
+# files and expect them to stick around, even if you set a sticky bit yourself.
+# The /sbin/auto-backup.sh script will ensure the changes are persisted across reboots and
+# MUST be executed after making any changes.
+#
+# See these links for more information:
+# http://www.virtuallyghetto.com/2011/08/how-to-persist-configuration-changes-in.html
+# http://blogs.vmware.com/vsphere/2011/09/how-often-does-esxi-write-to-the-boot-disk.html
+# https://communities.vmware.com/message/1273849#1273849
+#
+# NOTE: this method only works for ESXi 5.1 or greater. For older versions, the changes
+# must be written to /etc/rc.local instead.
+#
+# NOTE: this script will execute right away as a result of writing it to local.sh
+# along with executing on every subsequent boot
+wget http://<%=server%>:<%=port%>/api/common/templates/<%=rackhdCallbackScript%> -O /etc/rc.local.d/local.sh
+
+#backup ESXi configuration to persist it
+/sbin/auto-backup.sh
 
 #reboot the system after host configuration
 esxcli system shutdown reboot -d 10 -r "Rebooting after first boot host configuration"

--- a/lib/api/1.1/southbound/router.js
+++ b/lib/api/1.1/southbound/router.js
@@ -25,6 +25,7 @@ function internalApiFactory (injector) {
         router.use(injector.get(require('./files')));
         router.use(injector.get(require('./tasks')));
         router.use(injector.get(require('./templates')));
+        router.use(injector.get(require('../northbound/lookups')));
     };
 
     router.unMountAllRouters = function(){


### PR DESCRIPTION
To resolve an issue where the template cannot be rendered because the information
is not in the lookups table.  This change will post to /lookups as the entries
are created, setting the static ip, mac, nodeid relationship in the database, so
the entry can be found when the template is requested to signal the completion of
the kickstart.