### PR TITLE
change all 'vlanId' to 'vlanIds'

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -100,8 +100,8 @@ echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/ne
   <% ipv6 = 0 %>
   <% networkDevices.forEach(function(n) { %>
     <% if( undefined != n.ipv4 ) { %>
-      <% if( undefined != n.ipv4.vlanId ) { %>
-        <% n.ipv4.vlanId.forEach(function(vid) { %>
+      <% if( undefined != n.ipv4.vlanIds ) { %>
+        <% n.ipv4.vlanIds.forEach(function(vid) { %>
           echo "Configuring vlan <%=vid%> on <%=n.device%>"
           sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
           sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
@@ -126,8 +126,8 @@ echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/ne
       <% } %>
     <% } %>
     <% if( undefined != n.ipv6 ) { %>
-      <% if( undefined != n.ipv6.vlanId ) { %>
-        <% n.ipv6.vlanId.forEach(function(vid) { %>
+      <% if( undefined != n.ipv6.vlanIds ) { %>
+        <% n.ipv6.vlanIds.forEach(function(vid) { %>
           echo "Configuring vlan <%=vid%> on <%=n.device%>"
           sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
           sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -16,8 +16,8 @@ rootpw <%=rootPlainPassword%>
     <% if( n.device.substring(0,5) === 'vmnic' ) { %>
       <% if(typeof n.ipv4 !== 'undefined') { %>
         <% ipopts = '--ip=' + n.ipv4.ipAddr + ' --gateway=' + n.ipv4.gateway + ' --netmask=' + n.ipv4.netmask %>
-        <% if (typeof n.ipv4.vlanId !== 'undefined' ) { %>
-          <% ipopts += ' --vlandid=' + n.ipv4.vlanId[0] %>
+        <% if (typeof n.ipv4.vlanIds !== 'undefined' ) { %>
+          <% ipopts += ' --vlandid=' + n.ipv4.vlanIds[0] %>
         <% } %>
         network --bootproto=static --device=<%=n.device%> <%=ipopts%>
       <% } else { %>
@@ -113,8 +113,8 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 <% if( undefined !== networkDevices ) { %>
   <% networkDevices.forEach(function(n) { %>
     <% if( undefined !== n.ipv4 ) { %>
-      <% if( undefined !== n.ipv4.vlanId ) { %>
-        <% n.ipv4.vlanId.forEach(function(vid) { %>
+      <% if( undefined !== n.ipv4.vlanIds ) { %>
+        <% n.ipv4.vlanIds.forEach(function(vid) { %>
           <% vmkname = 'vmk' + vmkid++ %>
           esxcli network vswitch standard portgroup add -p <%=n.device%>.<%=vid%> -v "<%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>"
           esxcli network ip interface remove -i <%=vmkname%>
@@ -133,8 +133,8 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
       <% } %>
     <% } %>
     <% if( undefined !== n.ipv6 ) { %>
-      <% if( undefined !== n.ipv6.vlanId ) { %>
-        <% n.ipv6.vlanId.forEach(function(vid) { %>
+      <% if( undefined !== n.ipv6.vlanIds ) { %>
+        <% n.ipv6.vlanIds.forEach(function(vid) { %>
           <% vmkname = 'vmk' + vmkid++ %>
           esxcli network vswitch standard portgroup add -p <%=n.device%>.<%=vid%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
           esxcli network ip interface remove -i <%=vmkname%>

--- a/data/templates/install-ubuntu/ubuntu-interfaces
+++ b/data/templates/install-ubuntu/ubuntu-interfaces
@@ -2,8 +2,8 @@
     <%_ for (p in n) { _%>
         <%_ ip = n[p]; _%>
         <%_ if (['ipv4', 'ipv6'].indexOf(p) === -1 || undefined == ip) continue; _%>
-        <%_ if (undefined !== ip.vlanId) { _%>
-            <%_ ip.vlanId.forEach(function(vid) { _%>
+        <%_ if (undefined !== ip.vlanIds) { _%>
+            <%_ ip.vlanIds.forEach(function(vid) { _%>
 auto <%=n.device%>.<%=vid%>
 iface <%=n.device%>.<%=vid%> inet static
 address <%=ip.ipAddr%>

--- a/data/templates/suse-autoinst.xml
+++ b/data/templates/suse-autoinst.xml
@@ -61,8 +61,8 @@
   <% ipv6 = 0 %>
   <% networkDevices.forEach(function(n) { %>
     <% if( undefined != n.ipv4 ) { %>
-      <% if( undefined != n.ipv4.vlanId ) { %>
-        <% n.ipv4.vlanId.forEach(function(vid) { %>
+      <% if( undefined != n.ipv4.vlanIds ) { %>
+        <% n.ipv4.vlanIds.forEach(function(vid) { %>
         <interface>
           <bootproto>none</bootproto>
           <startmode>auto</startmode>
@@ -85,8 +85,8 @@
       <% } %>
     <% } %>
     <% if( undefined != n.ipv6 ) { %>
-      <% if( undefined != n.ipv6.vlanId ) { %>
-        <% n.ipv6.vlanId.forEach(function(vid) { %>
+      <% if( undefined != n.ipv6.vlanIds ) { %>
+        <% n.ipv6.vlanIds.forEach(function(vid) { %>
         <interface>
           <bootproto>none</bootproto>
           <startmode>auto</startmode>


### PR DESCRIPTION
1. old 'vlanId' should not be used anymore, 'vlanIds' is recommanded now. but 'vlanId' is still supported with  deprecated message.

2. this PR is integrated with https://github.com/RackHD/on-tasks/pull/215

@RackHD/corecommitters @yyscamper @anhou   @panpan0000 please review.