### PR TITLE
Monorail API return arrays

### DIFF
--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -9,7 +9,7 @@ schemes:
 basePath: /api/1.1
 produces:
   - application/json
-  # x-gzip explicitly for files once the bugs listed 
+  # x-gzip explicitly for files once the bugs listed
   #   in comments below are fixed by swagger team.
   - application/x-gzip
 securityDefinitions:
@@ -60,8 +60,8 @@ paths:
       responses:
         200:
           description: |
-            single library poller 
-          schema: 
+            single library poller
+          schema:
             type: object
         404:
           description: |
@@ -130,8 +130,8 @@ paths:
       responses:
         200:
           description: |
-            Specifics of the specified poller 
-          schema: 
+            Specifics of the specified poller
+          schema:
             type: object
         404:
           description: |
@@ -160,8 +160,8 @@ paths:
       responses:
         200:
           description: |
-            Specifics of the patched poller 
-          schema: 
+            Specifics of the patched poller
+          schema:
             type: object
         404:
           description: |
@@ -190,7 +190,7 @@ paths:
       responses:
         204:
           description: |
-            Poller delete successfully 
+            Poller delete successfully
         404:
           description: |
             There is no poller with specified identifier.
@@ -220,7 +220,7 @@ paths:
         200:
           description: |
             data for poller
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -272,7 +272,7 @@ paths:
         200:
           description: |
             single template
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -302,7 +302,7 @@ paths:
         200:
           description: |
             return template
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -370,7 +370,7 @@ paths:
         200:
           description: |
             sku to create
-          schema: 
+          schema:
             type: object
         500:
           description: |
@@ -401,7 +401,7 @@ paths:
         200:
           description: |
             return sku
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -431,7 +431,7 @@ paths:
         200:
           description: |
             sku to patch
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -466,7 +466,7 @@ paths:
         204:
           description: |
             return all skus
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -553,7 +553,7 @@ paths:
         200:
           description: |
             return profile
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -583,7 +583,7 @@ paths:
         200:
           description: |
             profile to put
-          schema: 
+          schema:
             type: object
         500:
           description: |
@@ -594,7 +594,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /obms/library:
     get:
       summary: |
@@ -636,18 +636,18 @@ paths:
         200:
           description: |
             return OBM service
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The obm service with the identifier was not found 
+            The obm service with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /workflows/library:
     get:
       summary: |
@@ -758,12 +758,12 @@ paths:
         200:
           description: |
             Add tasks to task library
-          schema: 
+          schema:
             type: object
         500:
           description: |
             Error problem was encountered, task was not written.
-          schema: 
+          schema:
             $ref: '#/definitions/Error'
         default:
           description: Upload failed
@@ -788,7 +788,7 @@ paths:
         200:
           description: |
             Fetch workflows
-          schema: 
+          schema:
             type: object
         default:
           description: Unexpected error
@@ -833,12 +833,12 @@ paths:
         200:
           description: |
             Fetch workflows
-          schema: 
+          schema:
             type: object
         500:
           description: |
             Error problem was encountered, workflow was not written.
-          schema: 
+          schema:
             $ref: '#/definitions/Error'
         default:
           description: Upload failed
@@ -867,7 +867,7 @@ paths:
         200:
           description: |
             the workflow that was created
-          schema: 
+          schema:
             type: object
         default:
           description: Unexpected error
@@ -895,11 +895,11 @@ paths:
         200:
           description: |
             Fetch currently running workflows for specified node
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -927,11 +927,11 @@ paths:
         200:
           description: |
             Canceled workflows for specified node
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -966,7 +966,7 @@ paths:
               type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -1003,11 +1003,11 @@ paths:
         200:
           description: |
             the workflow that was created
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -1017,7 +1017,7 @@ paths:
   /nodes/{macaddress}/dhcp/whitelist:
     post:
       summary: |
-        Add a whitelist of specified mac address 
+        Add a whitelist of specified mac address
       description: |
         Add a whitelist of specified mac address
       parameters:
@@ -1041,11 +1041,11 @@ paths:
         201:
           description: |
             the add was successful and it returns the whitelist
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -1076,14 +1076,14 @@ paths:
             delete completed successfully
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-    
+
   /nodes/{identifier}/pollers:
     get:
       summary: |
@@ -1112,14 +1112,14 @@ paths:
               type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /nodes/{identifier}/catalogs/{source}:
     get:
       summary: |
@@ -1149,11 +1149,11 @@ paths:
           description: |
             specific source catalog of specified node, |
             empty object if none exist.
-          schema: 
+          schema:
             type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
@@ -1189,14 +1189,14 @@ paths:
               type: object
         404:
           description: |
-            The node with the identifier was not found 
+            The node with the identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /nodes/{identifier}/obm/identify:
     get:
       summary: |
@@ -1219,7 +1219,7 @@ paths:
       responses:
         200:
           description: obm identity light settings
-          schema: 
+          schema:
             type: object
         404:
           description: |
@@ -1248,7 +1248,7 @@ paths:
           description: |
             obm settings to apply.
           required: true
-          schema: 
+          schema:
             type: boolean
       tags:
         - nodes
@@ -1319,7 +1319,7 @@ paths:
           description: |
             obm settings to apply.
           required: true
-          schema: 
+          schema:
             type: object
       tags:
         - nodes
@@ -1359,7 +1359,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         404:
           description: The node with the identifier was not found.
@@ -1414,7 +1414,7 @@ paths:
           description: |
             object patches to apply.
           required: true
-          schema: 
+          schema:
             type: object
       tags:
         - nodes
@@ -1446,7 +1446,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         400:
           description: invalidAttributes - 1 attribute is invalid
@@ -1502,7 +1502,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1552,7 +1552,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1577,7 +1577,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1608,7 +1608,7 @@ paths:
           description: array of all
           schema:
             type: array
-            items: 
+            items:
               type: object
         default:
           description: Unexpected error
@@ -1659,8 +1659,8 @@ paths:
         - files
         - get
       responses:
-# https://github.com/swagger-api/swagger-spec/issues/260 means we can't 
-# describe the return of a file easily today until jsonspec and swagger 
+# https://github.com/swagger-api/swagger-spec/issues/260 means we can't
+# describe the return of a file easily today until jsonspec and swagger
 # are "fixed"
         200:
           description: The file requested

--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -34,7 +34,9 @@ paths:
           description: |
             list of all pollers
           schema:
-            type: object
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -84,7 +86,9 @@ paths:
           description: |
             list of all pollers
           schema:
-            type: object
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -241,7 +245,9 @@ paths:
           description: |
             list of possible templates
           schema:
-            type: object
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -344,8 +350,10 @@ paths:
         200:
           description: |
              list of skus
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -490,8 +498,10 @@ paths:
         200:
           description: |
             return nodes associated with that sku
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             There is no sku with identifier.
@@ -515,8 +525,10 @@ paths:
         200:
           description: |
             list of possible profiles
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -596,8 +608,10 @@ paths:
         200:
           description: |
             get list of possible OBM services
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -647,13 +661,15 @@ paths:
         200:
           description: |
             List all workflows available to run
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  
+
   /workflows/library/{injectableName}:
     get:
       summary: |
@@ -672,8 +688,10 @@ paths:
         200:
           description: |
             List all workflows available to run
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -691,8 +709,10 @@ paths:
         200:
           description: |
             List workflow tasks library
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -712,8 +732,10 @@ paths:
         200:
           description: |
             Fetch tasks from task library
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -786,8 +808,10 @@ paths:
         200:
           description: |
             Fetch workflows
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         default:
           description: Unexpected error
           schema:
@@ -936,8 +960,10 @@ paths:
         200:
           description: |
             all workflows for specified node, empty object if none exist.
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found 
@@ -1080,8 +1106,10 @@ paths:
         200:
           description: |
             all pollers of specified node, empty object if none exist.
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found 
@@ -1155,8 +1183,10 @@ paths:
         200:
           description: |
             all catalogs of specified node, empty object if none exist.
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found 
@@ -1258,8 +1288,10 @@ paths:
       responses:
         200:
           description: obm settings
-          schema: 
-            type: object
+          schema:
+            type: array
+            items:
+              type: object
         404:
           description: |
             The node with the identifier was not found or has no obm settings.
@@ -1726,7 +1758,7 @@ paths:
         - get
       responses:
         200:
-          description: An array of configuration objects
+          description: configuration object
           schema:
             type: object
         default:
@@ -1802,9 +1834,7 @@ paths:
         200:
           description: A single catalog
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/catalog'
+            $ref: '#/definitions/catalog'
         default:
           description: NotFound error
   /dhcp:
@@ -1845,9 +1875,7 @@ paths:
         200:
           description: A single lease
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/lease'
+            $ref: '#/definitions/lease'
         default:
           description: NotFound error
     delete:


### PR DESCRIPTION
Two commits in this one.

The main one stems from working with generated swagger code, and finding that most of the GET APIs actually return lists/arrays of objects, but the swagger definition is just `type: object` for a schema.  however, the `GET` for `/nodes` is defined correctly.  Fix this by putting in the correct schema for GET calls that return lists.

Conversely, there were a couple of schemas that said they return lists when they actually return a single object.

The second commit removes extraneous whitespace throughout the YAML file. It was getting hard to work with the YAML files in various editors because of the extra spaces throughout the file. Split that out into a second commit in case you don't accept whitespace fixes.

I have more PRs coming to fix the YAML file here -- depending on the order they are merged, re-basing on my side will be necessary.