### PR TITLE
API and SKU pack changes for new template loader.

### DIFF
--- a/lib/api/1.1/northbound/profiles.js
+++ b/lib/api/1.1/northbound/profiles.js
@@ -75,21 +75,15 @@ function profilesRouterFactory (
      *     }
      */
 
-    router.put('/profiles/library/:identifier',
-        function (req, res, next) {
-            if (req.get('Content-Type') === 'application/octet-stream') {
-               parser.raw({type: '*/*'})(req, res, next);
-            } else {
-                parser.text({type: '*/*'})(req, res, next);
-            }
-        },
-        function (req, res) {
-            profiles.put(req.params.identifier, req.body.toString()).then(function () {
-                res.status(200).send();
-            }).catch(function (error) {
-                res.status(500).json(error);
-            });
+    router.put('/profiles/library/:identifier', function(req, res) {
+        return profiles.put(req.params.identifier, req)
+        .then(function(profile) {
+            res.status(200).json(profile);
+        })
+        .catch(function(err) {
+            res.status(500).json(err);
         });
+    });
 
     return router;
 }

--- a/lib/api/1.1/northbound/templates.js
+++ b/lib/api/1.1/northbound/templates.js
@@ -74,20 +74,15 @@ function templatesRouterFactory (
      *     }
      */
 
-    router.put('/templates/library/:identifier',
-        function (req, res, next) {
-            if (req.get('Content-Type') === 'application/octet-stream') {
-               parser.raw({type: '*/*'})(req, res, next);
-            } else {
-                parser.text({type: '*/*'})(req, res, next);
-            }
-        }, function (req, res) {
-            templates.put(req.params.identifier, req.body.toString()).then(function () {
-                res.status(200).send();
-            }).catch(function (error) {
-                res.status(500).json(error);
-            });
+    router.put('/templates/library/:identifier', function(req, res) {
+        return templates.put(req.params.identifier, req)
+        .then(function(template) {
+            res.status(200).json(template);
+        })
+        .catch(function(err) {
+            res.status(500).json(err);
         });
+    });
 
     return router;
 }

--- a/lib/api/2.0/views.js
+++ b/lib/api/2.0/views.js
@@ -55,20 +55,7 @@ var viewsGetById = controller(function(req) {
 * @apiError Error was encountered, view is unchanged.
 */
 var viewsPut = controller(function(req, res) {
-    var contentType = req.get('Content-Type');
-
-    var parsers = {
-        'application/octet-stream': Promise.promisify(bodyParser.raw({type: '*/*'})),
-        'text/plain': Promise.promisify(bodyParser.text({type: '*/*'}))
-    };
-
-    if (!_(parsers).has(contentType)) {
-        throw Errors.BadRequestError(contentType + ' is not a valid data type');
-    }
-
-    return parsers[contentType](req, res).then(function() {
-        return views.put(req.swagger.params.identifier.value, req.body.toString());
-    });
+    return views.put(req.swagger.params.identifier.value, req);
 });
 
 /**

--- a/lib/services/sku-pack-service.js
+++ b/lib/services/sku-pack-service.js
@@ -310,8 +310,8 @@ function skuPackServiceFactory(
                     var httpTemplateRoot = skuRoot + path.resolve('/', conf.httpTemplateRoot);
                     return self.loader.getAll(httpTemplateRoot)
                     .then(function(templates) {
-                        return _.map(templates,function(contents,name) {
-                            return Templates.put(name, contents, skuId);
+                        return _.map(templates,function(file, name) {
+                            return Templates.loadFile(name, file.path, file.contents, skuId);
                         });
                     });
                 }
@@ -320,8 +320,8 @@ function skuPackServiceFactory(
                     var httpProfileRoot = skuRoot + path.resolve('/', conf.httpProfileRoot);
                     return self.loader.getAll(httpProfileRoot)
                     .then(function(profiles) {
-                        return _.map(profiles,function(contents,name) {
-                            return Profiles.put(name, contents, skuId);
+                        return _.map(profiles,function(file, name) {
+                            return Profiles.loadFile(name, file.path, file.contents, skuId);
                         });
                     });
                 }

--- a/spec/lib/api/1.1/profiles-spec.js
+++ b/spec/lib/api/1.1/profiles-spec.js
@@ -108,7 +108,6 @@ describe('Http.Api.Profiles', function () {
             .then(function () {
                 expect(profiles.put).to.have.been.calledOnce;
                 expect(profiles.put).to.have.been.calledWith('123');
-                expect(profiles.put.firstCall.args[1]).to.deep.equal('echo\n');
             });
         });
 
@@ -121,8 +120,6 @@ describe('Http.Api.Profiles', function () {
             .then(function () {
                 expect(profiles.put).to.have.been.calledOnce;
                 expect(profiles.put).to.have.been.calledWith('123');
-                //console.log(profiles.put.firstCall.args[1]);
-                expect(profiles.put.firstCall.args[1]).to.deep.equal('echo\n');
             });
         });
 

--- a/spec/lib/api/1.1/templates-spec.js
+++ b/spec/lib/api/1.1/templates-spec.js
@@ -104,7 +104,6 @@ describe('Http.Api.Templates', function () {
             .then(function () {
                 expect(templates.put).to.have.been.calledOnce;
                 expect(templates.put).to.have.been.calledWith('123');
-                expect(templates.put.firstCall.args[1]).to.deep.equal('test_template_cmd\n');
             });
         });
 
@@ -118,7 +117,6 @@ describe('Http.Api.Templates', function () {
             .then(function () {
                 expect(templates.put).to.have.been.calledOnce;
                 expect(templates.put).to.have.been.calledWith('123');
-                expect(templates.put.firstCall.args[1]).to.deep.equal('test_template_cmd\n');
             });
         });
 

--- a/spec/lib/services/sku-pack-service-spec.js
+++ b/spec/lib/services/sku-pack-service-spec.js
@@ -285,6 +285,10 @@ describe("SKU Pack Service", function() {
         beforeEach(function() {
             workflowApiService.defineTask.reset();
             workflowApiService.defineTaskGraph.reset();
+            waterline.templates.findOne = sinon.stub().resolves();
+            waterline.profiles.findOne = sinon.stub().resolves();
+            waterline.templates.destroy = sinon.stub().resolves([]);
+            waterline.profiles.destroy = sinon.stub().resolves([]);
         });
 
         after(function() {
@@ -324,8 +328,10 @@ describe("SKU Pack Service", function() {
         it('should unregister a pack', function() {
             waterline.taskdefinitions.destroy.resolves();
             waterline.graphdefinitions.destroy.resolves();
-            waterline.templates.destroy.resolves();
-            waterline.profiles.destroy.resolves();
+            waterline.templates.destroy.resolves([ { path: 'template' } ]);
+            waterline.profiles.destroy.resolves([ { path: 'profile' } ]);
+            waterline.templates.findOne.onCall(1).resolves({ path: 'template' });
+            waterline.profiles.findOne.onCall(1).resolves({ path: 'profile' });
             return skuService.start('./valid').then(function() {
                 return skuService.unregisterPack('a', skuAData);
             })


### PR DESCRIPTION
* Change PUT /api/1.1/templates and /profiles put to use new loader semantics.
* Change PUT /api/2.0/views to use new loader semantics.
* Changes to skupack service to use templates/profiles.loadFile rather than put.

This change is dependent on https://github.com/RackHD/on-core/pull/143.  Tests will not pass until both changes are merged.