### PR TITLE
Fix swagger spec 11

### DIFF
--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -728,7 +728,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - workflow
         - task
@@ -802,7 +803,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - workflow
         - put
@@ -836,7 +838,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - workflow
         - post
@@ -969,7 +972,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - nodes
         - workflow
@@ -1006,7 +1010,8 @@ paths:
         - name: body
           in: body
           required: false
-          type: object
+          schema:
+            type: object
       tags:
         - nodes
         - dhcp
@@ -1568,7 +1573,8 @@ paths:
           description: |
             object patches to apply.
           required: true
-          type: object
+          schema:
+            type: object
       tags:
         - lookups
         - get
@@ -1743,7 +1749,8 @@ paths:
         - name: body
           in: body
           required: true
-          type: object
+          schema:
+            type: object
       tags:
         - config
         - patch

--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -677,6 +677,7 @@ paths:
         default:
           description: Unexpected error
           schema:
+            $ref: '#/definitions/Error'
 
   /workflows/tasks/library:
     get:


### PR DESCRIPTION
Add misising schema reference for default case that was left out in f708e0e9084a51e6ca02876f2b6f3ee39273d310

Fix swagger spec for body params:
According to the swagger spec, when defining parameters if `in` is `body`
then the `schema` field is required. Using `type` in the current way is
invalid, and actually crashes go-swagger.