### PR TITLE
Update node definition for 1.1 swagger spec

### DIFF
--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -1895,14 +1895,12 @@ definitions:
     properties:
       id:
         type: string
-      profile:
-        type: string
       name:
         type: string
       obmSettings:
-        type: object
-      ipAddresses:
-        type: object
+        type: array
+      type:
+        type: string
       workflows:
         type: array
         items:
@@ -1912,9 +1910,20 @@ definitions:
         items:
           $ref: '#/definitions/catalog'
       sku:
-        $ref: '#/definitions/sku'
+        type: string
+      snmpSettings:
+        type: object
+      bootSettings:
+        type: object
+      sshSettings:
+        type: object
+      autoDiscover:
+        type: boolean
+      relations:
+        type: array
+      tags:
+        type: array
     required:
-    - profile
     - name
   graphobject:
     properties:


### PR DESCRIPTION
There are several missing fields for the `node` definition, and some that have the wrong type.  Fix those by doing the following:

- Add missing fields
- sku comes back as the ID/string, not as an object.
- obmSettings is an array not an object

Here is an example node object I get back from the API, to see that it matches:

```
    {
        "autoDiscover": false,
        "catalogs": [],
        "createdAt": "2016-05-18T18:40:30.298Z",
        "id": "573cb71ed11f55c1075ec878",
        "identifiers": [
            "08:00:27:2e:69:a6"
        ],
        "name": "08:00:27:2e:69:a6",
        "obmSettings": [
            {
                "config": {},
                "service": "noop-obm-service"
            }
        ],
        "relations": [
            {
                "relationType": "enclosedBy",
                "targets": [
                    "572434ae23947dd00a5d8533"
                ]
            }
        ],
        "sku": "572516a873b83ec515d32719",
        "tags": [],
        "type": "compute",
        "updatedAt": "2016-05-18T18:41:44.183Z",
        "workflows": []
    }
```

FWIW, this is the last change I've had floating around to submit for the 1.1 swagger spec.  Thanks for taking a look!