### PR TITLE
2.0 API templates route and tests

### DIFF
--- a/lib/api/2.0/templates.js
+++ b/lib/api/2.0/templates.js
@@ -1,0 +1,92 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index').injector;
+var swagger = injector.get('Http.Services.Swagger');
+var controller = swagger.controller;
+var templates = injector.get('Templates');
+var taskProtocol = injector.get('Protocol.Task');
+var Errors = injector.get('Errors');
+var lookups = injector.get('Services.Lookup');
+var waterline = injector.get('Services.Waterline');
+var workflowApiService = injector.get('Http.Services.Api.Workflows');
+var _ = injector.get('_');
+
+// GET /templates/metadata
+var templatesMetaGet = controller(function() {
+    return templates.getAll();
+});
+
+// GET /templates/metadata/:name
+var templatesMetaGetByName = controller(function(req) {
+    return templates.getName(req.swagger.params.name.value,
+                             req.swagger.query.scope);
+});
+
+// GET /templates/:name
+var templatesGetByName = controller(function(req, res) {
+    return lookups.ipAddressToMacAddress(res.locals.ipAddress)
+    .then(function(mac) {
+        console.log(mac)
+        return waterline.nodes.needByIdentifier(mac);
+    })
+    .then(function(node) {
+        return Promise.all([
+            workflowApiService.findActiveGraphForTarget(node.id),
+            node
+        ]);
+    })
+    .spread(function(workflow, node) {
+        if (!workflow) {
+            throw new Errors.NotFoundError('no active workflow');
+        }
+        return Promise.all([
+            swagger.makeRenderableOptions(req, res, workflow.context),
+            taskProtocol.requestProperties(node.id)
+        ]);
+    })
+    .spread(function(options, properties) {
+        console.log(options);
+        console.log(properties);
+        return templates.render(
+            req.swagger.params.name.value,
+            _.merge({}, options, properties),
+           res.locals.scope
+        ) ;
+    });
+});
+
+// GET /templates/library/:name
+var templatesLibGet = controller(function(req, res) {
+    return templates.get(req.swagger.params.name.value,
+                         req.swagger.query.scope)
+    .then(function(template) {
+        if (!template || !template.contents) {
+            throw new Errors.NotFoundError('template not found');
+        }
+        return template.contents;
+    })
+});
+
+// PUT /templates/library/:name
+var templatesLibPut = controller(function(req, res) {
+    return templates.put(req.swagger.params.name.value, 
+                         req,
+                         req.swagger.query.scope);
+});
+
+// DELETE /templates/library/:name
+var templatesLibDelete = controller(function(req, res) {
+    return templates.unlink(req.swagger.params.name.value,
+                            req.swagger.query.scope);
+});
+
+module.exports = {
+    templatesMetaGet: templatesMetaGet,
+    templatesMetaGetByName: templatesMetaGetByName,
+    templatesGetByName: templatesGetByName,
+    templatesLibGet: templatesLibGet,
+    templatesLibPut: templatesLibPut,
+    templatesLibDelete: templatesLibDelete
+};

--- a/lib/api/2.0/templates.js
+++ b/lib/api/2.0/templates.js
@@ -28,7 +28,6 @@ var templatesMetaGetByName = controller(function(req) {
 var templatesGetByName = controller(function(req, res) {
     return lookups.ipAddressToMacAddress(res.locals.ipAddress)
     .then(function(mac) {
-        console.log(mac)
         return waterline.nodes.needByIdentifier(mac);
     })
     .then(function(node) {
@@ -47,8 +46,6 @@ var templatesGetByName = controller(function(req, res) {
         ]);
     })
     .spread(function(options, properties) {
-        console.log(options);
-        console.log(properties);
         return templates.render(
             req.swagger.params.name.value,
             _.merge({}, options, properties),

--- a/lib/api/2.0/templates.js
+++ b/lib/api/2.0/templates.js
@@ -11,7 +11,6 @@ var Errors = injector.get('Errors');
 var lookups = injector.get('Services.Lookup');
 var waterline = injector.get('Services.Waterline');
 var workflowApiService = injector.get('Http.Services.Api.Workflows');
-var _ = injector.get('_');
 
 // GET /templates/metadata
 var templatesMetaGet = controller(function() {
@@ -55,7 +54,7 @@ var templatesGetByName = controller(function(req, res) {
 });
 
 // GET /templates/library/:name
-var templatesLibGet = controller(function(req, res) {
+var templatesLibGet = controller(function(req) {
     return templates.get(req.swagger.params.name.value,
                          req.swagger.query.scope)
     .then(function(template) {
@@ -67,14 +66,14 @@ var templatesLibGet = controller(function(req, res) {
 });
 
 // PUT /templates/library/:name
-var templatesLibPut = controller(function(req, res) {
+var templatesLibPut = controller(function(req) {
     return templates.put(req.swagger.params.name.value,
                          req,
                          req.swagger.query.scope);
 });
 
 // DELETE /templates/library/:name
-var templatesLibDelete = controller(function(req, res) {
+var templatesLibDelete = controller(function(req) {
     return templates.unlink(req.swagger.params.name.value,
                             req.swagger.query.scope);
 });

--- a/lib/api/2.0/templates.js
+++ b/lib/api/2.0/templates.js
@@ -63,12 +63,12 @@ var templatesLibGet = controller(function(req, res) {
             throw new Errors.NotFoundError('template not found');
         }
         return template.contents;
-    })
+    });
 });
 
 // PUT /templates/library/:name
 var templatesLibPut = controller(function(req, res) {
-    return templates.put(req.swagger.params.name.value, 
+    return templates.put(req.swagger.params.name.value,
                          req,
                          req.swagger.query.scope);
 });

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -232,8 +232,8 @@ function swaggerFactory(
 
     function makeRenderableOptions(req, res, context) {
         var scope = res.locals.scope;
-        var apiServer = util.format('http://%s:%d', 
-            config.get('apiServerAddress'), 
+        var apiServer = util.format('http://%s:%d',
+            config.get('apiServerAddress'),
             config.get('apiServerPort')
         );
         var baseUri = util.format('%s/%s', apiServer, req.swagger.operation.api.basePath);
@@ -254,7 +254,6 @@ function swaggerFactory(
                 base: baseUri,
                 files: baseUri + '/files',
                 nodes: baseUri + '/nodes'
-            
             },
             context: context,
             task: {

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -17,7 +17,10 @@ di.annotate(swaggerFactory,
             di.Injector,
             'Views',
             'Assert',
-            'Http.Api.Services.Schema'
+            'Http.Api.Services.Schema',
+            'Services.Configuration',
+            'Services.Environment',
+            'Services.Lookup'
         )
     );
 
@@ -28,7 +31,10 @@ function swaggerFactory(
     injector,
     views,
     assert,
-    schemaApiService
+    schemaApiService,
+    config,
+    env,
+    lookupService
 ) {
     function _processError(err) {
         if (!util.isError(err) && err instanceof Object) {
@@ -224,11 +230,45 @@ function swaggerFactory(
         };
     }
 
+    function makeRenderableOptions(req, res, context) {
+        var scope = res.locals.scope;
+        var apiServer = util.format('http://%s:%d', 
+            config.get('apiServerAddress'), 
+            config.get('apiServerPort')
+        );
+        var baseUri = util.format('%s/%s', apiServer, req.swagger.operation.api.basePath);
+        context = context || {};
+
+        return Promise.props({
+            server: config.get('apiServerAddress', '10.1.1.1'),
+            port: config.get('apiServerPort', 80),
+            ipaddress: res.locals.ipAddress,
+            netmask: config.get('dhcpSubnetMask', '255.255.255.0'),
+            gateway: config.get('dhcpGateway', '10.1.1.1'),
+            macaddress: lookupService.ipAddressToMacAddress(res.locals.ipAddress),
+            sku: env.get('config', {}, [ scope[0] ]),
+            env: env.get('config', {}, scope),
+            // Build structure that mimics the task renderContext
+            api: {
+                server: apiServer,
+                base: baseUri,
+                files: baseUri + '/files',
+                nodes: baseUri + '/nodes'
+            
+            },
+            context: context,
+            task: {
+                nodeId: context.target
+            }
+        });
+    }
+
     return {
         controller: swaggerController,
         deserializer: swaggerDeserializer,
         serializer: swaggerSerializer,
         renderer: swaggerRenderer,
-        validator: swaggerValidator
+        validator: swaggerValidator,
+        makeRenderableOptions: makeRenderableOptions
     };
 }

--- a/spec/lib/api/2.0/templates-spec.js
+++ b/spec/lib/api/2.0/templates-spec.js
@@ -14,7 +14,8 @@ describe('Http.Api.Templates', function () {
     var findActiveGraphForTarget;
 
     before('start HTTP server', function () {
-        this.timeout(10000);
+        this.timeout(5000);
+
         return helper.startServer([
         ]);
     });
@@ -40,7 +41,7 @@ describe('Http.Api.Templates', function () {
 
         workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
         findActiveGraphForTarget = this.sandbox.stub(
-                workflowApiService, 'findActiveGraphForTarget');
+            workflowApiService, 'findActiveGraphForTarget');
 
 
         sinon.stub(workflowApiService, 'createActiveGraph').resolves({ instanceId: 'test' });
@@ -84,11 +85,11 @@ describe('Http.Api.Templates', function () {
         it('should return a list of templates', function () {
             templates.getAll.resolves([template]);
             return helper.request().get('/api/2.0/templates/metadata')
-            .expect('Content-Type', /^application\/json/)
-            .expect(200, [template])
-            .then(function () {
-                expect(templates.getAll).to.have.been.calledOnce;
-            });
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, [template])
+                .then(function () {
+                    expect(templates.getAll).to.have.been.calledOnce;
+                });
         });
     });
 
@@ -96,22 +97,22 @@ describe('Http.Api.Templates', function () {
         it('should return a single template', function () {
             templates.getName.resolves(template);
             return helper.request().get('/api/2.0/templates/metadata/123')
-            .expect('Content-Type', /^application\/json/)
-            .expect(200, template)
-            .then(function() {
-                expect(templates.getName).to.have.been.calledWith('123');
-            });
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, template)
+                .then(function() {
+                    expect(templates.getName).to.have.been.calledWith('123');
+                });
         });
 
         it('should return 404 for invalid templates name', function() {
             templates.getName.rejects(new Errors.NotFoundError('bad_template'));
             return helper.request().get('/api/2.0/templates/metadata/test')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404)
-            .then(function() {
-                expect(templates.getName).to.have.been.calledOnce;
-                expect(templates.getName).to.have.been.calledWith('test');
-            });
+                .expect('Content-Type', /^application\/json/)
+                .expect(404)
+                .then(function() {
+                    expect(templates.getName).to.have.been.calledOnce;
+                    expect(templates.getName).to.have.been.calledWith('test');
+                });
         });
 
     });
@@ -120,27 +121,27 @@ describe('Http.Api.Templates', function () {
         it('should return a single template', function () {
             templates.getName.resolves(template);
             return helper.request().get('/api/2.0/templates/metadata/123')
-            .expect('Content-Type', /^application\/json/)
-            .expect(200, template)
-            .then(function() {
-                expect(templates.getName).to.have.been.calledWith('123');
-            });
+                .expect('Content-Type', /^application\/json/)
+                .expect(200, template)
+                .then(function() {
+                    expect(templates.getName).to.have.been.calledWith('123');
+                });
         });
 
         it('should return 404 for invalid templates name', function() {
             templates.get.rejects(new Errors.NotFoundError('bad_template'));
             return helper.request().get('/api/2.0/templates/library/test')
-            .expect(404)
-            .then(function() {
-                expect(templates.get).to.have.been.calledOnce;
-                expect(templates.get).to.have.been.calledWith('test');
-            });
+                .expect(404)
+                .then(function() {
+                    expect(templates.get).to.have.been.calledOnce;
+                    expect(templates.get).to.have.been.calledWith('test');
+                });
         });
 
     });
 
     describe('2.0 PUT /templates/library/:name', function () {
-        beforeEach('should PUT new mockfile', function () {
+        it('should PUT new mockfile', function () {
             return helper.request().put('/api/2.0/templates/library/testTemplate')
                 .send('test\n')
                 .expect(200)
@@ -150,21 +151,12 @@ describe('Http.Api.Templates', function () {
                 });
         });
 
-        it('should get new templates', function () {
-            return helper.request().get('/api/2.0/templates/metadata/testTemplate')
-            .expect(200)
-            .then(function () {
-                expect(templates.getName).to.have.been.calledOnce;
-                expect(templates.getName).to.have.been.calledWith('testTemplate');
-            });
-        });
-
         it('should 400 error when templates.put() fails', function () {
             templates.put.rejects(new Error('dummy'));
             return helper.request().put('/api/2.0/templates/library/123')
-            .send('test_template_foo\n')
-            .expect('Content-Type', /^application\/json/)
-            .expect(400);
+                .send('test_template_foo\n')
+                .expect('Content-Type', /^application\/json/)
+                .expect(400);
         });
     });
 
@@ -182,43 +174,18 @@ describe('Http.Api.Templates', function () {
             this.sandbox.stub(swagger, 'makeRenderableOptions').resolves({});
             taskProtocol.requestProperties.resolves({});
             return helper.request().get('/api/2.0/templates/123')
-            .expect(200)
-            .then(function () {
-                expect(templates.render).to.have.been.calledOnce;
-                expect(templates.render).to.have.been.calledWith('123');
-            });
+                .expect(200)
+                .then(function () {
+                    expect(templates.render).to.have.been.calledOnce;
+                    expect(templates.render).to.have.been.calledWith('123');
+                });
         });
     });
 
-    describe('2.0 DELETE /templates/library/:name', function () {
-        beforeEach('should PUT new mockfile', function () {
-            return helper.request().put('/api/2.0/templates/library/test_foo')
-                .send('testFoo\n')
-                .expect(200)
-                .expect(function(){
-                    expect(templates.put).to.have.been.calledOnce;
-                    expect(templates.put).to.have.been.calledWith('test_foo');
-                });
-        });
-
-        it('should get new templates', function () {
-            return helper.request().get('/api/2.0/templates/metadata/test_foo')
-            .expect(200)
-            .then(function () {
-                expect(templates.getName).to.have.been.calledOnce;
-                expect(templates.getName).to.have.been.calledWith('test_foo');
-            });
-        });
-
-        it('should delete the new templates', function () {
+    describe('2.0 delete /templates/library/:name', function () {
+        it('should delete a template', function () {
             return helper.request().delete('/api/2.0/templates/library/test_foo')
-            .expect(200);
-        });
-
-        it('should return a  404 error when new template is requested', function () {
-            return helper.request().get('/api/2.0/templates/library/test_foo')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404);
+                .expect(200);
         });
     });
 

--- a/spec/lib/api/2.0/templates-spec.js
+++ b/spec/lib/api/2.0/templates-spec.js
@@ -1,0 +1,224 @@
+// Copyright 2015-2016, EMC, Inc.
+
+'use strict';
+
+describe('Http.Api.Templates', function () {
+    var workflowApiService;
+    var taskProtocol;
+    var lookupService;
+    var templates;
+    var Errors;
+    var waterline;
+    var swagger;
+    var tasksApiService;
+    var findActiveGraphForTarget;
+
+    before('start HTTP server', function () {
+        this.timeout(10000);
+        return helper.startServer([
+        ]);
+    });
+
+    beforeEach('set up mocks', function () {
+        taskProtocol = helper.injector.get('Protocol.Task');
+        lookupService = helper.injector.get('Services.Lookup');
+        Errors = helper.injector.get('Errors');
+        waterline = helper.injector.get('Services.Waterline');
+        swagger = helper.injector.get('Http.Services.Swagger');
+        this.sandbox = sinon.sandbox.create();
+
+        tasksApiService = helper.injector.get('Http.Services.Api.Tasks');
+        tasksApiService.getNode = sinon.stub().resolves({ id: '1234abcd5678effe9012dcba' });
+
+        lookupService.ipAddressToMacAddress = sinon.stub().resolves('00:11:22:33:44:55');
+        lookupService.reqIpAddressToMacAddress = sinon.stub().resolves();
+
+        sinon.stub(taskProtocol, 'activeTaskExists').resolves({});
+        sinon.stub(taskProtocol, 'requestCommands').resolves({ testcommands: 'cmd' });
+        sinon.stub(taskProtocol, 'requestProfile').resolves();
+        sinon.stub(taskProtocol, 'requestProperties').resolves();
+
+        workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
+        findActiveGraphForTarget = this.sandbox.stub(
+                workflowApiService, 'findActiveGraphForTarget');
+
+
+        sinon.stub(workflowApiService, 'createActiveGraph').resolves({ instanceId: 'test' });
+
+        templates = helper.injector.get('Templates');
+        sinon.stub(templates, 'getAll').resolves();
+        sinon.stub(templates, 'getName').resolves();
+        sinon.stub(templates, 'get').resolves();
+        sinon.stub(templates, 'put').resolves();
+        sinon.stub(templates, 'unlink').resolves();
+        sinon.stub(templates, 'render').resolves();
+
+        return helper.injector.get('Views').load();
+    });
+
+    afterEach('teardown mocks', function () {
+        function resetMocks(obj) {
+            _(obj).methods().forEach(function (method) {
+                if (typeof obj[method].restore === 'function') {
+                    obj[method].restore();
+                }
+            }).value();
+        }
+        resetMocks(lookupService);
+        resetMocks(taskProtocol);
+        resetMocks(workflowApiService);
+        resetMocks(templates);
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    var template = {
+        id: '1234abcd5678effe9012dcba',
+        name: '123',
+        contents: 'reboot\n'
+    };
+
+    describe('GET /templates/metadata', function () {
+        it('should return a list of templates', function () {
+            templates.getAll.resolves([template]);
+            return helper.request().get('/api/2.0/templates/metadata')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200, [template])
+            .then(function () {
+                expect(templates.getAll).to.have.been.calledOnce;
+            });
+        });
+    });
+
+    describe('GET /templates/metadata/:name', function () {
+        it('should return a single template', function () {
+            templates.getName.resolves(template);
+            return helper.request().get('/api/2.0/templates/metadata/123')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200, template)
+            .then(function() {
+                expect(templates.getName).to.have.been.calledWith('123');
+            });
+        });
+
+        it('should return 404 for invalid templates name', function() {
+            templates.getName.rejects(new Errors.NotFoundError('bad_template'));
+            return helper.request().get('/api/2.0/templates/metadata/test')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404)
+            .then(function() {
+                expect(templates.getName).to.have.been.calledOnce;
+                expect(templates.getName).to.have.been.calledWith('test');
+            });
+        });
+
+    });
+
+    describe('GET /templates/library/:name', function () {
+        it('should return a single template', function () {
+            templates.getName.resolves(template);
+            return helper.request().get('/api/2.0/templates/metadata/123')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200, template)
+            .then(function() {
+                expect(templates.getName).to.have.been.calledWith('123');
+            });
+        });
+
+        it('should return 404 for invalid templates name', function() {
+            templates.get.rejects(new Errors.NotFoundError('bad_template'));
+            return helper.request().get('/api/2.0/templates/library/test')
+            .expect(404)
+            .then(function() {
+                expect(templates.get).to.have.been.calledOnce;
+                expect(templates.get).to.have.been.calledWith('test');
+            });
+        });
+
+    });
+
+    describe('2.0 PUT /templates/library/:name', function () {
+        beforeEach('should PUT new mockfile', function () {
+            return helper.request().put('/api/2.0/templates/library/testTemplate')
+                .send('test\n')
+                .expect(200)
+                .expect(function(){
+                    expect(templates.put).to.have.been.calledOnce;
+                    expect(templates.put).to.have.been.calledWith('testTemplate');
+                });
+        });
+
+        it('should get new templates', function () {
+            return helper.request().get('/api/2.0/templates/metadata/testTemplate')
+            .expect(200)
+            .then(function () {
+                expect(templates.getName).to.have.been.calledOnce;
+                expect(templates.getName).to.have.been.calledWith('testTemplate');
+            });
+        });
+
+        it('should 400 error when templates.put() fails', function () {
+            templates.put.rejects(new Error('dummy'));
+            return helper.request().put('/api/2.0/templates/library/123')
+            .send('test_template_foo\n')
+            .expect('Content-Type', /^application\/json/)
+            .expect(400);
+        });
+    });
+
+    describe('GET SB /templates/:name', function () {
+        it('should return a template', function () {
+            var graph = {
+                instanceId: '0123'
+            };
+            waterline.nodes = {
+                needByIdentifier: sinon.stub().resolves({
+                    id: 'node id'
+                })
+            }
+            findActiveGraphForTarget.resolves(graph);
+            this.sandbox.stub(swagger, 'makeRenderableOptions').resolves({});
+            taskProtocol.requestProperties.resolves({})
+            return helper.request().get('/api/2.0/templates/123')
+            .expect(200)
+            .then(function () {
+                expect(templates.render).to.have.been.calledOnce;
+                expect(templates.render).to.have.been.calledWith('123');
+            });
+        });
+    });
+
+    describe('2.0 DELETE /templates/library/:name', function () {
+        beforeEach('should PUT new mockfile', function () {
+            return helper.request().put('/api/2.0/templates/library/test_foo')
+                .send('testFoo\n')
+                .expect(200)
+                .expect(function(){
+                    expect(templates.put).to.have.been.calledOnce;
+                    expect(templates.put).to.have.been.calledWith('test_foo');
+                });
+        });
+
+        it('should get new templates', function () {
+            return helper.request().get('/api/2.0/templates/metadata/test_foo')
+            .expect(200)
+            .then(function () {
+                expect(templates.getName).to.have.been.calledOnce;
+                expect(templates.getName).to.have.been.calledWith('test_foo');
+            });
+        });
+
+        it('should delete the new templates', function () {
+            return helper.request().delete('/api/2.0/templates/library/test_foo')
+            .expect(200)
+        });
+        it('should return a  404 error when new template is requested', function () {
+            return helper.request().get('/api/2.0/templates/library/test_foo')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404);
+        });
+    });
+
+});

--- a/spec/lib/api/2.0/templates-spec.js
+++ b/spec/lib/api/2.0/templates-spec.js
@@ -177,10 +177,10 @@ describe('Http.Api.Templates', function () {
                 needByIdentifier: sinon.stub().resolves({
                     id: 'node id'
                 })
-            }
+            };
             findActiveGraphForTarget.resolves(graph);
             this.sandbox.stub(swagger, 'makeRenderableOptions').resolves({});
-            taskProtocol.requestProperties.resolves({})
+            taskProtocol.requestProperties.resolves({});
             return helper.request().get('/api/2.0/templates/123')
             .expect(200)
             .then(function () {
@@ -212,8 +212,9 @@ describe('Http.Api.Templates', function () {
 
         it('should delete the new templates', function () {
             return helper.request().delete('/api/2.0/templates/library/test_foo')
-            .expect(200)
+            .expect(200);
         });
+
         it('should return a  404 error when new template is requested', function () {
             return helper.request().get('/api/2.0/templates/library/test_foo')
             .expect('Content-Type', /^application\/json/)

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -334,7 +334,7 @@ paths:
           type: string
         - name: scope
           in: query
-          description: | 
+          description: |
             template scope
           required: false
           type: string
@@ -373,7 +373,7 @@ paths:
           type: string
         - name: scope
           in: query
-          description: | 
+          description: |
             template scope
           required: false
           type: string
@@ -395,7 +395,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      operationId: templatesLibPut 
+      operationId: templatesLibPut
       x-privileges: [ 'Write' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
@@ -411,7 +411,7 @@ paths:
           type: string
         - name: scope
           in: query
-          description: | 
+          description: |
             template scope
           required: false
           type: string
@@ -452,7 +452,7 @@ paths:
           type: string
         - name: scope
           in: query
-          description: | 
+          description: |
             template scope
           required: false
           type: string
@@ -473,7 +473,7 @@ paths:
             $ref: '#/definitions/Error'
 
   /templates/{name}:
-    x-swagger-router-controller: templates 
+    x-swagger-router-controller: templates
     get:
       operationId: templatesGetByName
       x-privileges: [ 'Read' ]

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -294,16 +294,16 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /templates/library:
-    x-swagger-router-controller: unimplemented
+  /templates/metadata:
+    x-swagger-router-controller: templates
     get:
-      operationId: unimplemented
+      operationId: templatesMetaGet
       x-privileges: [ 'Read' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
-        get list of possible templates
+        get list of metadata for all templates
       description: |
-        get list of possible templates
+        get list of metadata for all templates
       tags: [ "/api/2.0" ]
       responses:
         200:
@@ -315,10 +315,49 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  /templates/library/{identifier}:
-    x-swagger-router-controller: unimplemented
+  /templates/metadata/{name}:
+    x-swagger-router-controller: templates
     get:
-      operationId: unimplemented
+      operationId: templatesMetaGetByName
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        get metadata for a specific template
+      description: |
+        get metadata for a specific template
+      parameters:
+        - name: name
+          in: path
+          description: |
+            template name
+          required: true
+          type: string
+        - name: scope
+          in: query
+          description: | 
+            template scope
+          required: false
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            single template metadata
+          schema:
+            type: object
+        404:
+          description: |
+            There is no template with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /templates/library/{name}:
+    x-swagger-router-controller: templates
+    get:
+      operationId: templatesLibGet
       x-privileges: [ 'Read' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
@@ -326,10 +365,128 @@ paths:
       description: |
         get a single template
       parameters:
-        - name: identifier
+        - name: name
           in: path
           description: |
-            template identifier
+            template name
+          required: true
+          type: string
+        - name: scope
+          in: query
+          description: | 
+            template scope
+          required: false
+          type: string
+          default: 'global'
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            single template
+          schema:
+            type: object
+        404:
+          description: |
+            There is no template with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      operationId: templatesLibPut 
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        put a single template
+      description: |
+        put a single template
+      parameters:
+        - name: name
+          in: path
+          description: |
+            objectid of template
+          required: true
+          type: string
+        - name: scope
+          in: query
+          description: | 
+            template scope
+          required: false
+          type: string
+          default: 'global'
+      consumes:
+        - text/plain
+        - application/x-www-form-urlencoded
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: |
+            return template
+          schema:
+            type: object
+        404:
+          description: |
+            There is no template with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      operationId: templatesLibDelete
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        delete a single template
+      description: |
+        delete a single template
+      parameters:
+        - name: name
+          in: path
+          description: |
+            objectid of template
+          required: true
+          type: string
+        - name: scope
+          in: query
+          description: | 
+            template scope
+          required: false
+          type: string
+          default: 'global'
+      tags: [ "/api/2.0" ]
+      responses:
+        204:
+          description: |
+            delete template
+        404:
+          description: |
+            There is no template with specified identifier.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /templates/{name}:
+    x-swagger-router-controller: templates 
+    get:
+      operationId: templatesGetByName
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        get a single template
+      description: |
+        get a single template
+      parameters:
+        - name: name
+          in: path
+          description: |
+            template name
           required: true
           type: string
       tags: [ "/api/2.0" ]
@@ -348,37 +505,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-    put:
-      operationId: unimplemented
-      x-privileges: [ 'Write' ]
-      x-authentication-type: [ 'jwt' ]
-      summary: |
-        put a single template
-      description: |
-        put a single template
-      parameters:
-        - name: identifier
-          in: path
-          description: |
-            objectid of template
-          required: true
-          type: string
-      tags: [ "/api/2.0" ]
-      responses:
-        200:
-          description: |
-            return template
-          schema:
-            type: object
-        404:
-          description: |
-            There is no template with specified identifier.
-          schema:
-            $ref: '#/definitions/Error'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
+
   /views:
     x-swagger-router-controller: views
     get:


### PR DESCRIPTION
GET /api/2.0/templates/metadata -> Get metadata for all templates
GET /api/2.0/templates/metadata/:name -> Get metadata for all templates with name.
GET /api/2.0/templates/metadata/:name?scope=:scope -> Get a single template with specified name in specified scope
GET/PUT /api/2.0/templates/library/:name -> Get/put raw template with specified name in global scope
GET/PUT /api/2.0/templates/library/:name?scope=:scope -> Get/put raw template with specified name in specified scope.
GET /api/2.0/templates/:name -> Southbound templates route. 