### PR TITLE
Update workflow service unit-tests to mock ARP cache in lookup service

### DIFF
--- a/spec/lib/api/1.1/workflows-spec.js
+++ b/spec/lib/api/1.1/workflows-spec.js
@@ -6,6 +6,9 @@
 describe('Http.Api.Workflows', function () {
     var waterline;
     var workflowApiService;
+    var arpCache = { 
+        getCurrent: sinon.stub().resolves([])
+    };
 
     before('start HTTP server', function () {
         var self = this;
@@ -22,6 +25,7 @@ describe('Http.Api.Workflows', function () {
 
         return helper.startServer([
             dihelper.simpleWrapper(waterline, 'Services.Waterline'),
+            dihelper.simpleWrapper(arpCache, 'ARPCache')
         ])
         .then(function() {
             workflowApiService = helper.injector.get('Http.Services.Api.Workflows');

--- a/spec/lib/api/2.0/workflowGraphs-spec.js
+++ b/spec/lib/api/2.0/workflowGraphs-spec.js
@@ -5,6 +5,9 @@
 
 describe('Http.Api.Workflows.2.0', function () {
     var workflowApiService;
+    var arpCache = { 
+        getCurrent: sinon.stub().resolves([])
+    };
 
     before('start HTTP server', function () {
         this.timeout(5000);
@@ -17,6 +20,7 @@ describe('Http.Api.Workflows.2.0', function () {
 
         return helper.startServer([
             dihelper.simpleWrapper(workflowApiService, 'Http.Services.Api.Workflows'),
+            dihelper.simpleWrapper(arpCache, 'ARPCache')
         ]);
     });
 

--- a/spec/lib/api/2.0/workflowTasks-spec.js
+++ b/spec/lib/api/2.0/workflowTasks-spec.js
@@ -6,7 +6,10 @@
 describe('Http.Api.workflowTasks.2.0', function () {
     var waterline;
     var workflowApiService;
-
+    var arpCache = { 
+        getCurrent: sinon.stub().resolves([])
+    };
+    
     before('start HTTP server', function () {
         var self = this;
         this.timeout(5000);
@@ -22,6 +25,7 @@ describe('Http.Api.workflowTasks.2.0', function () {
 
         return helper.startServer([
             dihelper.simpleWrapper(waterline, 'Services.Waterline'),
+            dihelper.simpleWrapper(arpCache, 'ARPCache')
         ])
         .then(function() {
             workflowApiService = helper.injector.get('Http.Services.Api.Workflows');

--- a/spec/lib/api/2.0/workflows-spec.js
+++ b/spec/lib/api/2.0/workflows-spec.js
@@ -6,6 +6,9 @@
 describe('Http.Api.Workflows.2.0', function () {
     var waterline;
     var workflowApiService;
+    var arpCache = { 
+        getCurrent: sinon.stub().resolves([])
+    };
 
     before('start HTTP server', function () {
         var self = this;
@@ -21,7 +24,8 @@ describe('Http.Api.Workflows.2.0', function () {
         this.sandbox = sinon.sandbox.create();
 
         return helper.startServer([
-            dihelper.simpleWrapper(waterline, 'Services.Waterline')
+            dihelper.simpleWrapper(waterline, 'Services.Waterline'),
+            dihelper.simpleWrapper(arpCache, 'ARPCache')
         ])
         .then(function() {
             workflowApiService = helper.injector.get('Http.Services.Api.Workflows');


### PR DESCRIPTION
@RackHD/corecommitters @zyoung51 @uppalk1 @tannoa2 @keedya 

Resolves unit-test failures for dependent PR: https://github.com/RackHD/on-core/pull/145 