### PR TITLE
[1.2] add PUT /lookups API to fix esx-ks installation timeout issue

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -47,7 +47,7 @@ postLookup () {
   BODY=$BODY"}"
   BODYLEN=$(echo -n ${BODY} | wc -c )
   echo ${BODY} >> /vmfs/volumes/datastore1/firstboot.log
-  echo -ne "POST /api/1.1/lookups HTTP/1.0\r\nHost: $2\r\nContent-Type: application/json\r\nContent-Length: ${BODYLEN}\r\n\r\n${BODY}" | nc -i 3 <%=server%> <%=port%>
+  echo -ne "PUT /api/1.1/lookups HTTP/1.0\r\nHost: $2\r\nContent-Type: application/json\r\nContent-Length: ${BODYLEN}\r\n\r\n${BODY}" | nc -i 3 <%=server%> <%=port%>
 }
 
 # enable VHV (Virtual Hardware Virtualization to run nested 64bit Guests + Hyper-V VM)

--- a/lib/api/1.1/northbound/lookups.js
+++ b/lib/api/1.1/northbound/lookups.js
@@ -53,6 +53,38 @@ function lookupsRouterFactory (waterline, rest) {
     }));
 
     /**
+     * @api {put} /api/1.1/lookups POST /
+     * @apiVersion 1.1.0
+     * @apiDescription create or replace a lookup
+     * @apiName lookups-post
+     * @apiParam {String} macAddress MAC Address for the Lookup Record
+     * @apiParam {String} ipAddress IP Address associated with the MAC Address
+     * @apiParam {String} node Node associated with the Lookup Record
+     * @apiGroup lookups
+     * @apiSuccess {json} lookup the lookup that was created
+    */
+    router.put('/lookups', rest(function (req) {
+        var query = {
+            or: [
+                { ipAddress: req.body.ipAddress },
+                { macAddress: req.body.macAddress }
+            ]
+        };
+        return waterline.lookups.findOne(query)
+        .then(function(record) {
+            if (record) { //replace existing one
+                return waterline.lookups.updateOneById(record.id, req.body);
+            }
+            else { //create a brand new
+                return waterline.lookups.create(req.body);
+            }
+        });
+    }, {
+        serializer: 'Serializables.V1.Lookup',
+        deserializer: 'Serializables.V1.Lookup'
+    }));
+
+    /**
      * @api {get} /api/1.1/lookups/:id GET /:id
      * @apiVersion 1.1.0
      * @apiDescription get specific lookup details
@@ -61,8 +93,8 @@ function lookupsRouterFactory (waterline, rest) {
      * @apiParam {String} id lookup id
      * @apiSuccess {json} lookup the lookups that have the <code>id</code>
      * @apiError NotFound The lookup with the <code>id</code> was not found.
-     * @apiErrorExample {json} Error-Response:
      *     HTTP/1.1 404 Not Found
+     * @apiErrorExample {json} Error-Response:
      *     {
      *       "error": "Not Found"
      *      }

--- a/spec/lib/api/1.1/lookups-spec.js
+++ b/spec/lib/api/1.1/lookups-spec.js
@@ -4,7 +4,7 @@
 'use strict';
 
 describe('Http.Api.Lookup', function () {
-    var waterline, stub;
+    var waterline, sandbox;
 
     var data = [
         {
@@ -27,6 +27,7 @@ describe('Http.Api.Lookup', function () {
 
     before('start HTTP server', function () {
         this.timeout(5000);
+        sandbox = sinon.sandbox.create();
         return helper.startServer();
     });
 
@@ -35,10 +36,7 @@ describe('Http.Api.Lookup', function () {
     });
 
     afterEach(function () {
-        if (stub) {
-            stub.restore();
-            stub = undefined;
-        }
+        sandbox.restore();
     });
 
     after('stop HTTP server', function () {
@@ -48,38 +46,180 @@ describe('Http.Api.Lookup', function () {
     describe('/api/1.1/lookups', function () {
         describe('GET', function () {
             it('should should call waterline.lookups.findByTerm', function() {
-                stub = sinon.stub(waterline.lookups, 'findByTerm').resolves(data);
+                sandbox.stub(waterline.lookups, 'findByTerm').resolves(data);
 
                 return helper.request().get('/api/1.1/lookups')
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(stub).to.have.been.calledWith(undefined);
+                        expect(waterline.lookups.findByTerm).to.have.been.calledWith(undefined);
                     });
             });
 
             it('should call waterline.lookups.findByterm with 123', function() {
-                stub = sinon.stub(waterline.lookups, 'findByTerm').resolves(data);
+                sandbox.stub(waterline.lookups, 'findByTerm').resolves(data);
 
                 return helper.request().get('/api/1.1/lookups?q=123')
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(stub).to.have.been.calledWith('123');
+                        expect(waterline.lookups.findByTerm).to.have.been.calledWith('123');
                     });
             });
         });
 
         describe('POST', function () {
             it('should call waterline.lookups.create', function() {
-                stub = sinon.stub(waterline.lookups, 'create').resolves(data[0]);
+                sandbox.stub(waterline.lookups, 'create').resolves(data[0]);
 
                 return helper.request().post('/api/1.1/lookups')
                     .send(data[0])
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(stub).to.have.been.calledWith(sinon.match(data[0]));
+                        expect(waterline.lookups.create).to.been.calledWith(sinon.match(data[0]));
+                    });
+            });
+        });
+
+        describe('PUT', function () {
+            it('should create a new lookup entry', function() {
+                var entry = data[0];
+                sandbox.stub(waterline.lookups, 'findOne').resolves();
+                sandbox.stub(waterline.lookups, 'create',
+                    function(data) {
+                        var result = _.cloneDeep(data);
+                        result.id = '112233445566';
+                        return Promise.resolve(result);
+                    }
+                );
+                sandbox.spy(waterline.lookups, 'updateOneById');
+
+                return helper.request().put('/api/1.1/lookups')
+                    .send(entry)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(200)
+                    .expect(function (data) {
+                        expect(waterline.lookups.findOne).to.have.been.called;
+                        expect(waterline.lookups.updateOneById).to.not.have.been.called;
+                        expect(waterline.lookups.create).to.have.callCount(1)
+                            .and.been.calledWith(entry);
+                        expect(data.body).to.have.property('ipAddress')
+                            .to.equal(entry.ipAddress);
+                        expect(data.body).to.have.property('macAddress')
+                            .to.equal(entry.macAddress);
+                        expect(data.body).to.have.property('node')
+                            .to.equal(entry.node);
+                        expect(data.body).to.have.property('id')
+                            .to.equal('112233445566');
+                    });
+            });
+
+            it('should replace the record if there is duplicated macAddress', function() {
+                var origData = data[0];
+                var newData = {
+                    ipAddress: '172.31.128.98',
+                    macAddress: origData.macAddress,
+                    node: origData.node
+                };
+                sandbox.stub(waterline.lookups, 'findOne').resolves(origData);
+                sandbox.stub(waterline.lookups, 'updateOneById',
+                    function(id, data) {
+                        var result = _.cloneDeep(data);
+                        result.id = id;
+                        return Promise.resolve(result);
+                    }
+                );
+                sandbox.spy(waterline.lookups, 'create');
+                return helper.request().put('/api/1.1/lookups')
+                    .send(newData)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(200)
+                    .expect(function(data) {
+                        expect(waterline.lookups.findOne).to.have.been.called;
+                        expect(waterline.lookups.updateOneById).to.have.callCount(1)
+                            .and.been.calledWith(origData.id, newData);
+                        expect(waterline.lookups.create).to.not.have.been.called;
+                        expect(data.body).to.have.property('ipAddress')
+                            .to.equal(newData.ipAddress);
+                        expect(data.body).to.have.property('macAddress')
+                            .to.equal(newData.macAddress);
+                        expect(data.body).to.have.property('node')
+                            .to.equal(newData.node);
+                        expect(data.body).to.have.property('id')
+                            .to.equal(origData.id);
+                    });
+            });
+
+            it('should replace the record if there is duplicated ipAddress', function() {
+                var origData = data[0];
+                var newData = {
+                    ipAddress: origData.ipAddress,
+                    macAddress: '00:22:12:cc:bb:17',
+                    node: origData.node
+                };
+                sandbox.stub(waterline.lookups, 'findOne').resolves(origData);
+                sandbox.stub(waterline.lookups, 'updateOneById',
+                    function(id, data) {
+                        var result = _.cloneDeep(data);
+                        result.id = id;
+                        return Promise.resolve(result);
+                    }
+                );
+                sandbox.spy(waterline.lookups, 'create');
+                return helper.request().put('/api/1.1/lookups')
+                    .send(newData)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(200)
+                    .expect(function(data) {
+                        expect(waterline.lookups.findOne).to.have.been.called;
+                        expect(waterline.lookups.updateOneById).to.have.callCount(1)
+                            .and.been.calledWith(origData.id, newData);
+                        expect(waterline.lookups.create).to.not.have.been.called;
+                        expect(data.body).to.have.property('ipAddress')
+                            .to.equal(newData.ipAddress);
+                        expect(data.body).to.have.property('macAddress')
+                            .to.equal(newData.macAddress);
+                        expect(data.body).to.have.property('node')
+                            .to.equal(newData.node);
+                        expect(data.body).to.have.property('id')
+                            .to.equal(origData.id);
+                    });
+            });
+
+            it('should still create new record if there is duplicated node', function() {
+                var origData = data[0];
+                var newData = {
+                    ipAddress: '172.31.188.99',
+                    macAddress: '99:82:cd:76:89:12',
+                    node: origData.node
+                };
+                sandbox.stub(waterline.lookups, 'findOne').resolves();
+                sandbox.stub(waterline.lookups, 'create',
+                    function(data) {
+                        var result = _.cloneDeep(data);
+                        result.id = '112233445566';
+                        return Promise.resolve(result);
+                    }
+                );
+                sandbox.spy(waterline.lookups, 'updateOneById');
+                return helper.request().put('/api/1.1/lookups')
+                    .send(newData)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(200)
+                    .expect(function(data) {
+                        expect(waterline.lookups.findOne).to.have.been.called;
+                        expect(waterline.lookups.updateOneById).to.have.callCount(0);
+                        expect(waterline.lookups.create).to.have.callCount(1)
+                            .and.been.calledWith(newData);
+                        expect(data.body).to.have.property('ipAddress')
+                            .to.equal(newData.ipAddress);
+                        expect(data.body).to.have.property('macAddress')
+                            .to.equal(newData.macAddress);
+                        expect(data.body).to.have.property('node')
+                            .to.equal(newData.node);
+                        expect(data.body).to.have.property('id')
+                            .to.equal('112233445566');
                     });
             });
         });
@@ -88,40 +228,40 @@ describe('Http.Api.Lookup', function () {
     describe('/api/1.1/lookups/:id', function () {
         describe('GET', function () {
             it('should call waterline.lookups.needOneById with 123', function() {
-                stub = sinon.stub(waterline.lookups, 'needOneById').resolves(data[0]);
+                sandbox.stub(waterline.lookups, 'needOneById').resolves(data[0]);
 
                 return helper.request().get('/api/1.1/lookups/123')
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(stub).to.have.been.calledWith('123');
+                        expect(waterline.lookups.needOneById).to.have.been.calledWith('123');
                     });
             });
         });
 
         describe('PATCH', function () {
             it('should call waterline.lookups.updateOneById with 123', function() {
-                stub = sinon.stub(waterline.lookups, 'updateOneById').resolves(data[0]);
+                sandbox.stub(waterline.lookups, 'updateOneById').resolves(data[0]);
 
                 return helper.request().patch('/api/1.1/lookups/123')
                     .send(data[0])
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(stub).to.have.been.calledWith('123', sinon.match(data[0]));
+                        expect(waterline.lookups.updateOneById).to.have.been.calledWith('123', sinon.match(data[0]));
                     });
             });
         });
 
         describe('DELETE', function () {
             it('should call waterline.lookups.destroyOneById with 123', function() {
-                stub = sinon.stub(waterline.lookups, 'destroyOneById').resolves(data[0]);
+                sandbox.stub(waterline.lookups, 'destroyOneById').resolves(data[0]);
 
                 return helper.request().delete('/api/1.1/lookups/123')
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(stub).to.have.been.calledWith('123');
+                        expect(waterline.lookups.destroyOneById).to.have.been.calledWith('123');
                     });
             });
         });

--- a/spec/lib/api/1.1/lookups-spec.js
+++ b/spec/lib/api/1.1/lookups-spec.js
@@ -248,7 +248,8 @@ describe('Http.Api.Lookup', function () {
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(waterline.lookups.updateOneById).to.have.been.calledWith('123', sinon.match(data[0]));
+                        expect(waterline.lookups.updateOneById)
+                            .to.have.been.calledWith('123', sinon.match(data[0]));
                     });
             });
         });


### PR DESCRIPTION
This is a hot fix for recent esx-ks installation timeout issue [ODR-728](https://hwjiraprd01.corp.emc.com/browse/ODR-728).

Unlike @benbp 's proposal to remove the duplicated lookup entry before installation, my solution is to add a new API "PUT /lookups",this API is to create or replace lookup entry. So if a duplicated lookup is sent, the lookup table will be updated.

I have tested this for ESXi installation with Quanta, all success. But the CentOS/RHEL installation will still fail as (unlike esxi) they don't try to PUT the lookup entry to RackHD, so node will fail to complete the wait-completion-uri. So another PR will be created to fix CentOS/RHEL.

@RackHD/corecommitters @benbp @richav1 @zyoung51 @jlongever @johren 