### PR TITLE
Os install params

### DIFF
--- a/data/profiles/install-centos.ipxe
+++ b/data/profiles/install-centos.ipxe
@@ -1,6 +1,6 @@
 echo Starting CentOS/RHEL <%=version%> installer for ${hostidentifier}
 set base-url <%=repo%>/images/pxeboot
-set params initrd=initrd.img ks=http://<%=server%>:<%=port%>/api/common/templates/centos-ks hostname=<%=hostname%> ksdevice=bootif BOOTIF=01-${netX/mac} console=<%=comport%>,115200n8 console=tty0 
+set params initrd=initrd.img ks=<%=installScriptUri%> hostname=<%=hostname%> ksdevice=bootif BOOTIF=01-${netX/mac} console=<%=comport%>,115200n8 console=tty0
 kernel ${base-url}/vmlinuz repo=<%=repo%> ${params}
 initrd ${base-url}/initrd.img
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/profiles/install-coreos.ipxe
+++ b/data/profiles/install-coreos.ipxe
@@ -5,6 +5,6 @@ set base-url <%=repo%>
 # JUST BOOT AND RUN COREOS
 # kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/pxe-cloud-config.yml
 #
-kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/common/templates/install-coreos.sh
+kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=<%=installScriptUri%>
 initrd ${base-url}/<%=version%>/coreos_production_pxe_image.cpio.gz
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -1,10 +1,10 @@
 iseq ${platform} efi && goto is_efi || goto not_efi
 
 :not_efi
-kernel <%=mbootFile%> -c http://<%=server%>:<%=port%>/api/common/templates/<%=esxBootConfigTemplate%> BOOTIF=01-${netX/mac}
+kernel <%=mbootFile%> -c <%=installScriptUri%> BOOTIF=01-${netX/mac}
 boot
 
 :is_efi
-kernel <%=repo%>/efi/boot/bootx64.efi -c http://<%=server%>:<%=port%>/api/common/templates/<%=esxBootConfigTemplate%>
+kernel <%=repo%>/efi/boot/bootx64.efi -c <%=installScriptUri%>
 boot
 

--- a/data/profiles/install-suse.ipxe
+++ b/data/profiles/install-suse.ipxe
@@ -1,6 +1,6 @@
 echo Starting SUSE <%=version%> installer >
 set base-url <%=repo%>
-set params linux install=${base-url} autoyast=http://<%=server%>:<%=port%>/api/common/templates/suse-autoinst.xml
+set params linux install=${base-url} autoyast=<%=installScriptUri%>
 kernel ${base-url}/boot/x86_64/loader/linux
 initrd ${base-url}/boot/x86_64/loader/initrd
 imgargs linux ${params}

--- a/data/profiles/install-ubuntu.ipxe
+++ b/data/profiles/install-ubuntu.ipxe
@@ -2,5 +2,5 @@ echo Starting Ubuntu x64 installer for ${hostidentifier}
 set base-url <%=repo%>/dists/<%=version%>/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64
 kernel ${base-url}/linux
 initrd ${base-url}/initrd.gz
-imgargs linux auto=true url=http://<%=server%>:<%=port%>/api/common/templates/ubuntu-preseed hostname=<%=hostname%> log_host=<%=server%> BOOTIF=01-<%=macaddress%> interface=auto console=<%=comport%>,115200n8 console=tty0
+imgargs linux auto=true url=<%=installScriptUri%> hostname=<%=hostname%> log_host=<%=server%> BOOTIF=01-<%=macaddress%> interface=auto console=<%=comport%>,115200n8 console=tty0
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/templates/esx-boot-cfg
+++ b/data/templates/esx-boot-cfg
@@ -1,7 +1,7 @@
 bootstate=0
 title=Loading ESXi installer
 kernel=<%=tbootFile%>
-kernelopt=runweasel formatwithmbr com1_baud=115200 com1_Port=<%=comportaddress%> tty2Port=<%=comport%> debugLogToSerial=1 logPort=<%=comport%> ks=http://<%=server%>:<%=port%>/api/common/templates/esx-ks
+kernelopt=runweasel formatwithmbr com1_baud=115200 com1_Port=<%=comportaddress%> tty2Port=<%=comport%> debugLogToSerial=1 logPort=<%=comport%> ks=<%=installScriptUri%>
 modules=<%=moduleFiles%>
 build=
 updated=0

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -247,6 +247,9 @@ function CommonApiPresenterFactory(
             api: {
                 server: 'http://' + config.apiServerAddress + ':' + config.apiServerPort,
                 base: baseUri,
+                templates: baseUri + '/templates',
+                profiles: baseUri + '/profiles',
+                lookups: baseUri + '/lookups',
                 files: baseUri + '/files',
                 nodes: baseUri + '/nodes'
             },


### PR DESCRIPTION
This will make it easier to point our OS installer workflows toward custom kickstart/preseed files, and in general make changes in this location.

I'm inclined to not add documentation as I consider these more system specific options, since the kickstart files contain special callback scripts for our workflows. However, It's better that they're not hardcoded in the templates themselves (It is much, much harder to trace what files link to what files with OS installers, and will be easier to just look at a task definition and see all the files that will be downloaded).

Requires https://github.com/RackHD/on-tasks/pull/218
Docs: https://github.com/RackHD/docs/pull/283

@RackHD/corecommitters @heckj 

@zyoung51 I also updated the common-api-presenter rendering to add `<%=api.lookups|templates|profiles%>` support (same for task rendering in the linked PR).