### PR TITLE
Fix for Issue #235

### DIFF
--- a/lib/api/1.1/northbound/profiles.js
+++ b/lib/api/1.1/northbound/profiles.js
@@ -11,12 +11,14 @@ module.exports = profilesRouterFactory;
 di.annotate(profilesRouterFactory, new di.Provide('Http.Api.Profiles'));
 di.annotate(profilesRouterFactory,
     new di.Inject(
+        'Promise',
         'Profiles',
         'common-api-presenter'
     )
 );
 
 function profilesRouterFactory (
+    Promise,
     profiles,
     presenter
 ) {
@@ -32,7 +34,9 @@ function profilesRouterFactory (
      */
 
     router.get('/profiles/library', presenter.middleware(function () {
-        return profiles.getAll();
+        return Promise.map(profiles.getAll(), function(p) {
+            return profiles.get(p.name);
+        });
     }));
 
 

--- a/lib/api/1.1/northbound/templates.js
+++ b/lib/api/1.1/northbound/templates.js
@@ -12,13 +12,15 @@ di.annotate(templatesRouterFactory, new di.Provide('Http.Api.Templates'));
 di.annotate(templatesRouterFactory,
     new di.Inject(
 		'Templates',
-		'common-api-presenter'
+		'common-api-presenter',
+        'Promise'
 	)
 );
 
 function templatesRouterFactory (
     templates,
-    presenter
+    presenter,
+    Promise
 ) {
     var router = express.Router();
 
@@ -32,8 +34,12 @@ function templatesRouterFactory (
      */
 
     router.get('/templates/library', function (req, res) {
-        presenter(req, res)
-            .render(templates.getAll());
+        Promise.map(templates.getAll(), function(t) {
+            return templates.get(t.name);
+        })
+        .then(function(t) {
+            presenter(req, res).render(t);
+        });
     });
 
 

--- a/spec/lib/api/1.1/profiles-spec.js
+++ b/spec/lib/api/1.1/profiles-spec.js
@@ -75,6 +75,7 @@ describe('Http.Api.Profiles', function () {
     describe('GET /profiles/library', function () {
         it('should return a list of profiles', function () {
             profiles.getAll.resolves([profile]);
+            profiles.get.resolves(profile);
             return helper.request().get('/api/1.1/profiles/library')
             .expect('Content-Type', /^application\/json/)
             .expect(200, [profile])

--- a/spec/lib/api/1.1/templates-spec.js
+++ b/spec/lib/api/1.1/templates-spec.js
@@ -71,6 +71,7 @@ describe('Http.Api.Templates', function () {
     describe('GET /templates/library', function () {
         it('should return a list of templates', function () {
             templates.getAll.resolves([template]);
+            templates.get.resolves(template);
             return helper.request().get('/api/1.1/templates/library')
             .expect('Content-Type', /^application\/json/)
             .expect(200, [template])


### PR DESCRIPTION
* Add contents field to 1.1 API templates/profiles library routes.

Resolves https://github.com/RackHD/RackHD/issues/235