### PR TITLE
Add southbound SSDP observer support

### DIFF
--- a/lib/services/upnp-service.js
+++ b/lib/services/upnp-service.js
@@ -6,6 +6,7 @@ var di = require('di'),
     ip = require('ip'),
     ejs = require('ejs'),
     Server = require('node-ssdp').Server,
+    Client = require('node-ssdp').Client,
     nodeVersion = process.version.substr(1);
     
 module.exports = UPnPServiceFactory;
@@ -22,7 +23,10 @@ di.annotate(UPnPServiceFactory,
         'Errors',
         'Services.Configuration',
         'SystemUuid',
-        'fs'
+        'fs',
+        'Rx',
+        'Services.Messenger',
+        'Result'
     )
 );
 function UPnPServiceFactory(
@@ -36,7 +40,10 @@ function UPnPServiceFactory(
     Errors,
     configuration,
     systemUuid,
-    nodeFs
+    nodeFs,
+    Rx,
+    messenger,
+    Result
 ) {
     var logger = Logger.initialize(UPnPServiceFactory);
     var fs = Promise.promisifyAll(nodeFs);
@@ -51,6 +58,7 @@ function UPnPServiceFactory(
                          _.matches({routers:'southbound-api-router'}));
         this.description = './static/upnp/upnp-device-description.xml';
         this.ssdpList = [];
+        this.clientPollIntervalMs = 15000;
         this.registry = [
             {
                 urn: 'upnp:rootdevice', 
@@ -80,6 +88,16 @@ function UPnPServiceFactory(
             {
                 urn: 'urn:schemas-upnp-org:service:api:2.0:southbound',
                 path: '/api/2.0/',
+                alive: false
+            },
+            {
+                urn: 'urn:schemas-upnp-org:service:api:1.1:southbound',
+                path: '/api/1.1/',
+                alive: false
+            },
+            {
+                urn: 'urn:dmtf-org:service:redfish-rest:1.0:southbound',
+                path: '/redfish/v1/',
                 alive: false
             }
         ];
@@ -119,6 +137,37 @@ function UPnPServiceFactory(
         return {};
     };
     
+    UPnPService.prototype.sendSSDPAlert = function(message) {
+        return messenger.publish(
+            Constants.Protocol.Exchanges.SSDP.Name,
+            'ssdp.alert.' + message.headers.USN, 
+            new Result({value: message})
+        );
+    };
+    
+    UPnPService.prototype.runClientObserver = function(address) {
+        var self = this;
+        self.client = new Client({unicastHost:address});
+        self.client.on('response', function inResponse(headers, code, info) {
+            self.sendSSDPAlert({ 
+                headers: headers,
+                info: info
+            });
+        });
+
+        self.subscription = Rx.Observable.interval(self.clientPollIntervalMs)
+        .subscribe(
+            function() {
+                self.client.search('ssdp:all');
+            },
+            function(error) {
+                if(error) {
+                    logger.error('SSDP Client Poller Error', {error:error});
+                }
+            }
+        );
+    };
+    
     UPnPService.prototype.start = function() {
         var self = this;
         var endpoint = _.first(self.northbound) || {
@@ -153,7 +202,7 @@ function UPnPServiceFactory(
                     location: (ep.httpsEnabled ? 'https':'http') + 
                         '://' + (ep.address !== '0.0.0.0' ? ep.address: ip.address()) + 
                         ':' + ep.port + r.path
-                }
+                };
                 var server = new Server(_.merge({}, self.options, loptions));
                 server.addUSN(r.urn);
                 server.on('advertise-alive', _alive.bind(self)); //jshint ignore: line
@@ -168,11 +217,19 @@ function UPnPServiceFactory(
                 });
                 self.ssdpList.push({urn:r.urn, server:server});
             });
+        })
+        .then(function() {
+            // periodically send m-search requests to the southbound network
+            // and publish any advertisements to the on.ssdp exchange
+            return self.runClientObserver(southPoint.address);
         });
     };
     
     UPnPService.prototype.stop = function() {
-        logger.info('Stopping SSDP/uPnP server(s)');
+        logger.info('Stopping SSDP/uPnP server(s) and client');
+        if(this.subscription) {
+            this.subscription.dispose();
+        }
         return _.forEach(this.ssdpList, function(ssdp) {
             ssdp.server.stop();
         });


### PR DESCRIPTION
- Send M-SEARCH requests on southbound network from UPnP/SSDP service and publish advertisements to AMQP `on.ssdp` exchange.
- Include 1.1 and Redfish API URNs on southbound membership.

@RackHD/corecommitters @uppalk1 @tannoa2 @zyoung51 @keedya 