### PR TITLE
Pass boot config template instead of install script template to esx i…

### DIFF
--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -1,10 +1,10 @@
 iseq ${platform} efi && goto is_efi || goto not_efi
 
 :not_efi
-kernel <%=mbootFile%> -c <%=installScriptUri%> BOOTIF=01-${netX/mac}
+kernel <%=mbootFile%> -c <%=esxBootConfigTemplateUri%> BOOTIF=01-${netX/mac}
 boot
 
 :is_efi
-kernel <%=repo%>/efi/boot/bootx64.efi -c <%=installScriptUri%>
+kernel <%=repo%>/efi/boot/bootx64.efi -c <%=esxBootConfigTemplateUri%>
 boot
 


### PR DESCRIPTION
…nstaller

Unfortunately I missed this in testing to my latest update to https://github.com/RackHD/on-http/pull/302

We are passing in the wrong variable for the boot config template (passing in the kickstart instead of the boot script which has the kernel options, and points to the kickstart). This will fix the early installation error:

```
kernel=<FILEPATH> must be set in http://172.31.128.1:9080/api/current/templates/esx-ks
Fatal error: 32 (Syntax)
```

Just ran a dry run of ESX with these options and things work now.

@RackHD/corecommitters @jlongever @WangWinson 