### PR TITLE
Allow proxy lookup to fail in workflow service 

### DIFF
--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -70,7 +70,12 @@ function workflowApiServiceFactory(
             return Promise.resolve().then(function() {
                 if(node) {
                     context = _.defaults(context, { target: node.id });
-                    return lookupService.nodeIdToProxy(node.id);
+                    return lookupService.nodeIdToProxy(node.id)
+                    .catch(function(error) {
+                        // allow the proxy lookup to fail since not all nodes 
+                        // wanting to run a workflow may have an entry
+                        logger.error('nodeIdToProxy Lookup', {error:error});
+                    });
                 } else {
                     return undefined;
                 }

--- a/spec/lib/services/upnp-service-spec.js
+++ b/spec/lib/services/upnp-service-spec.js
@@ -80,6 +80,12 @@ describe("UPnP Service", function() {
         sandbox.reset();
     });
 
+    afterEach(function() {
+        emitter.removeAllListeners('advertise-bye');
+        emitter.removeAllListeners('advertise-alive');
+        emitter.removeAllListeners('response');
+    });
+
     helper.after(function () {
         sandbox.restore();
     });
@@ -148,7 +154,7 @@ describe("UPnP Service", function() {
                 });
             });
         });
-        
+
         it('should run client poller event', function(done) {
             SSDPClient.prototype.on = function(event, callback) {
                 emitter.on(event, function(headers, code, info) {
@@ -168,7 +174,6 @@ describe("UPnP Service", function() {
                 });
             });
         });
-        
     });
 });
 


### PR DESCRIPTION
- Some targets may not have a lookup entry (e.g. Redfish enclosure node only has OBM settings).
- Remove all listeners in upnp service spec.

@RackHD/corecommitters @zyoung51 @uppalk1 @tannoa2 @keedya @shanemsully 