### PR TITLE
fix travisci error by refactor a Http.Api.Views test case

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "sinon": "1.16.1",
     "sinon-as-promised": "^2.0.3",
     "sinon-chai": "^2.7.0",
-    "supertest": "^0.15.0",
+    "supertest": "^1.2.0",
     "xunit-file": "0.0.6"
   },
   "apidoc": {

--- a/spec/lib/api/2.0/views-spec.js
+++ b/spec/lib/api/2.0/views-spec.js
@@ -97,17 +97,17 @@ describe('Http.Api.Views', function () {
 
         it('should create an application/octet-stream view', function() {
             var view = {name: 'foo', content: 'foo', scope: 'global'};
-            var req = helper.request().put('/api/2.0/views/foo');
-
             viewsProtocol.put.resolves(view);
-            req.set('Content-Type', 'application/octet-stream');
-            req.write(new Buffer('{ "message": "hello" }', 'ascii'));
-            req.end(function(err, res) {
-                expect(res.get('Content-Type')).to.match(/^application\/json/);
-                expect(res.status).to.equal(200);
-                expect(res.body).to.deep.equal(view);
-                expect(viewsProtocol.put).to.have.been.calledOnce;
-            });
+
+            return helper.request().put('/api/2.0/views/foo')
+                .set('Content-Type', 'application/octet-stream')
+                .send(new Buffer('{ "message": "hello" }', 'ascii'))
+                .expect(200)
+                .expect(function(res) {
+                    expect(res.get('Content-Type')).to.match(/^application\/json/);
+                    expect(res.body).to.deep.equal(view);
+                    expect(viewsProtocol.put).to.have.been.calledOnce;
+                });
         });
 
         it('should reject invalid data type', function() {


### PR DESCRIPTION
This is a fix to recent travis ci error on on-http repository.

I tested in my forked on-http by enable the travis ci, it passes.

The detail root cause is still unknown for me, at least there is error is that the `request` doesn't been returned.

@brianparry @RackHD/corecommitters @pengz1 @iceiilin @WangWinson 