### PR TITLE
Enable snmpSettings for switch nodes

### DIFF
--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -50,7 +50,7 @@ function profilesRouterFactory (
                     type: 'compute',
                 };
 
-                return profileApiService.getNode(macAddresses, options)
+                return profileApiService.getNode(macAddresses, req.ip, options)
                 .then(function (node) {
                     if (node.newRecord) {
                         presenter(req, res).renderProfile('redirect.ipxe');
@@ -86,7 +86,7 @@ function profilesRouterFactory (
             switchVendor: req.params.vendor
         };
 
-        profileApiService.getNode(macAddresses, options)
+        profileApiService.getNode(macAddresses, req.ip, options)
         .then(function(node) {
             return profileApiService.renderProfileFromTaskOrNode(node, 'switch');
         })

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -99,7 +99,7 @@ function profileApiServiceFactory(
         return Promise.resolve();
     };
 
-    ProfileApiService.prototype.getNode = function(macAddresses, options) {
+    ProfileApiService.prototype.getNode = function(macAddresses, ip, options) {
         var self = this;
         return waterline.nodes.findByIdentifier(macAddresses)
         .then(function (node) {
@@ -123,7 +123,7 @@ function profileApiServiceFactory(
 
                 });
             } else {
-                return self.createNodeAndRunDiscovery(macAddresses, options);
+                return self.createNodeAndRunDiscovery(macAddresses, ip, options);
             }
         });
     };
@@ -197,13 +197,15 @@ function profileApiServiceFactory(
         return configuration;
     };
 
-    ProfileApiService.prototype.createNodeAndRunDiscovery = function(macAddresses, options) {
+    ProfileApiService.prototype.createNodeAndRunDiscovery = function(macAddresses, ip, options) {
         var self = this;
         var node;
+        var community = "rackhd";
         return waterline.nodes.create({
             name: macAddresses.join(','),
             identifiers: macAddresses,
-            type: options.type
+            type: options.type,
+            autoDiscover: true
         })
         .then(function (_node) {
             node = _node;
@@ -211,6 +213,14 @@ function profileApiServiceFactory(
             return Promise.resolve(macAddresses).each(function (macAddress) {
                 return waterline.lookups.upsertNodeToMacAddress(node.id, macAddress);
             });
+        })
+        .then(function () {
+            if (options.type === 'switch') {
+                return waterline.nodes.updateByIdentifier(
+                    node.id,
+                    { snmpSettings: { host: ip, community: community} }
+                );
+            }
         })
         .then(function () {
             // Setting newRecord to true allows us to


### PR DESCRIPTION
Adding in support for snmpSettings for switch nodes to enable snmp pollers. I put community setting straight in the code - there may be a better place for it, but not sure.

@RackHD/corecommitters @benbp @heckj 