### PR TITLE
Update 2.0 api workflow operations to operate on instanceId attribute

### DIFF
--- a/lib/api/2.0/workflows.js
+++ b/lib/api/2.0/workflows.js
@@ -48,15 +48,15 @@ var workflowsPost = controller({success: 201}, function(req) {
 * @api {get} /api/2.0/workflows/:identifier GET /workflows/:identifier
 * @apiVersion 2.0.0
 * @apiDescription get a specific workflow
-* @apiName workflows-getById
+* @apiName workflows-getByInstanceId
 * @apiGroup workflows
 * @apiParam {String} instanceId of workflow
 * @apiSuccess {json} workflows of the particular identifier or if there are none an empty object.
 * @apiError NotFound There is no workflow with <code>instanceId</code>
 */
 
-var workflowsGetById = controller(function(req) {
-    return workflowApiService.getWorkflowById(req.swagger.params.identifier.value);
+var workflowsGetByInstanceId = controller(function(req) {
+    return workflowApiService.getWorkflowByInstanceId(req.swagger.params.identifier.value);
 });
 
 /**
@@ -71,7 +71,6 @@ var workflowsGetById = controller(function(req) {
 */
 var workflowsAction = controller(function(req) {
     var command = req.body.command;
-    var options = req.body.options || {};
 
     var actionFunctions = {
         cancel: function() {
@@ -91,21 +90,21 @@ var workflowsAction = controller(function(req) {
 * @api {delete} /api/2.0/workflows/:identifier DELETE /workflows/:identifier
 * @apiVersion 2.0.0
 * @apiDescription Cancel currently running workflows for specified node
-* @apiName workflows-DeleteById
+* @apiName workflows-DeleteByInstanceId
 * @apiGroup workflows
 * @apiParam {String} instanceId of workflow
 * @apiSuccess {json}  object.
 * @apiError NotFound The node with the identifier was not found <code>instanceId</code>
 */
 
-var workflowsDeleteById = controller(function(req) {
+var workflowsDeleteByInstanceId = controller(function(req) {
     return workflowApiService.deleteTaskGraph(req.swagger.params.identifier.value);
 });
 
 module.exports = {
     workflowsGet: workflowsGet,
     workflowsPost: workflowsPost,
-    workflowsGetById: workflowsGetById,
-    workflowsDeleteById: workflowsDeleteById,
+    workflowsGetByInstanceId: workflowsGetByInstanceId,
+    workflowsDeleteByInstanceId: workflowsDeleteByInstanceId,
     workflowsAction: workflowsAction
 };

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -472,7 +472,7 @@ function nodeApiServiceFactory(
                     'No active workflow graph found for node ' + id
                 );
             }
-            return [ graph, workflowApiService.cancelTaskGraph(graph.id) ];
+            return [graph, workflowApiService.cancelTaskGraph(graph.instanceId)];
         })
         .spread(function(graph, graphId) {
             if (!graphId) {

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -72,7 +72,7 @@ function workflowApiServiceFactory(
                     context = _.defaults(context, { target: node.id });
                     return lookupService.nodeIdToProxy(node.id)
                     .catch(function(error) {
-                        // allow the proxy lookup to fail since not all nodes 
+                        // allow the proxy lookup to fail since not all nodes
                         // wanting to run a workflow may have an entry
                         logger.error('nodeIdToProxy Lookup', {error:error});
                     });
@@ -145,50 +145,33 @@ function workflowApiServiceFactory(
     };
 
     WorkflowApiService.prototype.cancelTaskGraph = function(graphId) {
-        var instanceId;
-
-        return waterline.graphobjects.needByIdentifier(graphId)
+        return waterline.graphobjects.needOne({ instanceId: graphId })
         .then(function(workflow) {
-            instanceId = workflow.instanceId;
-
             if (!workflow.active()) {
                 throw new Errors.TaskCancellationError(
                     graphId + ' is not an active workflow'
                 );
             }
 
-            return taskGraphProtocol.cancelTaskGraph(instanceId);
+            return taskGraphProtocol.cancelTaskGraph(graphId);
         });
     };
 
     WorkflowApiService.prototype.deleteTaskGraph = function(graphId) {
-        var instanceId;
-
         // Taskgraph deletion sequence:
         // 1) Get the graph object by ID
         // 2) Check if the returned workflow is running.
         // 3) If it is running, throw an error. Otherwise go on to step 4.
         // 4) Delete the graph object from the task graph store.
-        return waterline.graphobjects.needByIdentifier(graphId)
+        return waterline.graphobjects.needOne({ instanceId: graphId })
         .then(function(workflow) {
-            // Since deleteGraph takes instanceId as an argument, save it
-            // here using a closure so we don't need to do another query later.
-            instanceId = workflow.instanceId;
             if (workflow.active()) {
-                throw new Errors.ForbiddenError('Forbidden to delete an active workflow ' +graphId);
+                throw new Errors.ForbiddenError(
+                    'Forbidden to delete an active workflow ' + graphId);
             }
-            return instanceId;
+            return taskGraphStore.deleteGraph(graphId);
         })
-        .then(function(cancelledGraphId) {
-            if (cancelledGraphId !== instanceId) {
-                // Cancelled graph ID doesn't match the requested ID.
-                throw new Errors.TaskCancellationError('Failed to cancel ' + graphId);
-            }
-            return taskGraphStore.deleteGraph(instanceId);
-        })
-        .then(function(deletedGraphs) {
-            return deletedGraphs[0];
-        });
+        .then(_.first);
     };
 
     WorkflowApiService.prototype.defineTaskGraph = function(definition) {
@@ -261,8 +244,8 @@ function workflowApiServiceFactory(
         return waterline.graphobjects.find(query);
     };
 
-    WorkflowApiService.prototype.getWorkflowById = function(id) {
-        return waterline.graphobjects.needByIdentifier(id);
+    WorkflowApiService.prototype.getWorkflowByInstanceId = function(instanceId) {
+        return waterline.graphobjects.needOne({ instanceId: instanceId });
     };
 
     WorkflowApiService.prototype.destroyGraphDefinition = function(injectableName) {

--- a/spec/lib/api/2.0/workflows-spec.js
+++ b/spec/lib/api/2.0/workflows-spec.js
@@ -6,7 +6,7 @@
 describe('Http.Api.Workflows.2.0', function () {
     var waterline;
     var workflowApiService;
-    var arpCache = { 
+    var arpCache = {
         getCurrent: sinon.stub().resolves([])
     };
 
@@ -32,7 +32,7 @@ describe('Http.Api.Workflows.2.0', function () {
             self.sandbox.stub(workflowApiService, 'defineTask').resolves();
             self.sandbox.stub(workflowApiService, 'getAllWorkflows').resolves();
             self.sandbox.stub(workflowApiService, 'createAndRunGraph').resolves();
-            self.sandbox.stub(workflowApiService, 'getWorkflowById').resolves();
+            self.sandbox.stub(workflowApiService, 'getWorkflowByInstanceId').resolves();
             self.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves();
             self.sandbox.stub(workflowApiService, 'deleteTaskGraph').resolves();
         });
@@ -115,20 +115,21 @@ describe('Http.Api.Workflows.2.0', function () {
     describe('workflowsGetById', function () {
         it('should return a single persisted graph', function () {
             var graph = { id: 'foobar' };
-            workflowApiService.getWorkflowById.resolves(graph);
+            workflowApiService.getWorkflowByInstanceId.resolves(graph);
 
             return helper.request().get('/api/2.0/workflows/foobar')
                 .expect('Content-Type', /^application\/json/)
                 .expect(200, graph)
                 .expect(function () {
-                    expect(workflowApiService.getWorkflowById).to.have.been.calledOnce;
-                    expect(workflowApiService.getWorkflowById).to.have.been.calledWith('foobar');
+                    expect(workflowApiService.getWorkflowByInstanceId).to.have.been.calledOnce;
+                    expect(workflowApiService.getWorkflowByInstanceId)
+                        .to.have.been.calledWith('foobar');
                 });
         });
 
         it('should return a 404 if not found', function () {
             var Errors = helper.injector.get('Errors');
-            workflowApiService.getWorkflowById.rejects(new Errors.NotFoundError('test'));
+            workflowApiService.getWorkflowByInstanceId.rejects(new Errors.NotFoundError('test'));
 
             return helper.request().get('/api/2.0/workflows/12345')
                 .expect('Content-Type', /^application\/json/)

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -278,11 +278,11 @@ describe("Http.Services.Api.Nodes", function () {
                 id: '123'
             };
             var graph = {
-                id: 'testgraphid'
+                instanceId: 'testgraphid'
             };
             waterline.nodes.needByIdentifier.resolves(node);
             findActiveGraphForTarget.resolves(graph);
-            this.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves(graph.id);
+            this.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves(graph.instanceId);
 
             return nodeApiService.delActiveWorkflowById('testnodeid')
             .then(function() {
@@ -291,7 +291,7 @@ describe("Http.Services.Api.Nodes", function () {
                     .to.have.been.calledWith(node.id);
                 expect(workflowApiService.cancelTaskGraph).to.have.been.calledOnce;
                 expect(workflowApiService.cancelTaskGraph)
-                    .to.have.been.calledWith(graph.id);
+                    .to.have.been.calledWith(graph.instanceId);
             });
         });
 

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -32,10 +32,10 @@ describe('Http.Services.Api.Workflows', function () {
             needByIdentifier: sinon.stub().resolves({ id: 'testnodeid' })
         };
         waterline.lookups = {
-           findOneByTerm: sinon.stub().resolves() 
+           findOneByTerm: sinon.stub().resolves()
         };
         waterline.graphobjects = {
-            needByIdentifier: sinon.stub().resolves({ id: 'testgraphid', _status: 'pending' }),
+            needOne: sinon.stub().resolves({ id: 'testgraphid', _status: 'pending' }),
             find: sinon.stub().resolves(),
             findOne: sinon.stub().resolves()
         };
@@ -155,9 +155,9 @@ describe('Http.Services.Api.Workflows', function () {
             expect(store.findActiveGraphForTarget).to.have.been.calledWith('testnodeid');
             expect(workflowApiService.createActiveGraph).to.have.been.calledOnce;
             expect(workflowApiService.createActiveGraph).to.have.been.calledWith(
-                graphDefinition, 
-                { test: 1 }, 
-                { target: 'testnodeid', test: 2, proxy: 'proxy' }, 
+                graphDefinition,
+                { test: 1 },
+                { target: 'testnodeid', test: 2, proxy: 'proxy' },
                 'test'
             );
             expect(workflowApiService.runTaskGraph).to.have.been.calledOnce;
@@ -352,7 +352,7 @@ describe('Http.Services.Api.Workflows', function () {
         var mockWorkflowError = new Errors.TaskCancellationError(
             "testid is not an active workflow"
         );
-        waterline.graphobjects.needByIdentifier.rejects(mockWorkflowError);
+        waterline.graphobjects.needOne.rejects(mockWorkflowError);
         return workflowApiService.cancelTaskGraph()
             .should.be.rejectedWith(mockWorkflowError);
     });
@@ -369,16 +369,16 @@ describe('Http.Services.Api.Workflows', function () {
         });
     });
 
-    it('should return workflow by id ', function() {
-        waterline.graphobjects.needByIdentifier.resolves(workflow);
-        return workflowApiService.getWorkflowById().then(function (workflows) {
+    it('should return workflow by instanceId ', function() {
+        waterline.graphobjects.needOne.resolves(workflow);
+        return workflowApiService.getWorkflowByInstanceId().then(function (workflows) {
             expect(workflows).to.deep.equal(workflow);
         });
     });
 
-    it('should return Not Found Error when invalid id is passed', function() {
-        waterline.graphobjects.needByIdentifier.rejects(new Errors.NotFoundError('Not Found'));
-        return expect(workflowApiService.getWorkflowById())
+    it('should return Not Found Error when invalid instanceId is passed', function() {
+        waterline.graphobjects.needOne.rejects(new Errors.NotFoundError('Not Found'));
+        return expect(workflowApiService.getWorkflowByInstanceId())
                .to.be.rejectedWith(Errors.NotFoundError);
     });
 
@@ -388,6 +388,6 @@ describe('Http.Services.Api.Workflows', function () {
                                _status : 'pending'
                              };
         waterline.graphobjects.find.resolves(activeWorkflow);
-        return expect(workflowApiService.getWorkflowById()).to.become(activeWorkflow);
+        return expect(workflowApiService.getWorkflowByInstanceId()).to.become(activeWorkflow);
     });
 });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -1539,7 +1539,7 @@ paths:
   /workflows/{identifier}:
     x-swagger-router-controller: workflows
     get:
-      operationId: workflowsGetById
+      operationId: workflowsGetByInstanceId
       x-privileges: [ 'Read' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
@@ -1565,7 +1565,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      operationId: workflowsDeleteById
+      operationId: workflowsDeleteByInstanceId
       x-privileges: [ 'Write' ]
       x-authentication-type: [ 'jwt' ]
       summary: |


### PR DESCRIPTION
We should not be using the mongo ID for anything, but rather passing around the uuid.v4() instanceId attribute. The API docs reference instanceId, but the code does not, so updating for accuracy.

@RackHD/corecommitters 

Requires an integration test change: https://github.com/RackHD/RackHD/pull/268 which is why Jenkins is failing.