### PR TITLE
[1.2] Set bmc ip only when ip source is static when flashing quanta bmc

### DIFF
--- a/data/templates/flash_quanta_bmc.sh
+++ b/data/templates/flash_quanta_bmc.sh
@@ -60,50 +60,56 @@ until [ $counter -le 0 ]; do
            echo "Check didn't pass, ip source wasn't set properly"
            exit 1;
         fi;
-        sleep 2
 
-        #IPMI tool command to set IP address
-        ipmitool lan set 1 ipaddr $ipaddrInfo
-        sleep 8
-        ipaddrCheck=$(ipmitool lan print)
-        ipaddrCheck=(${ipaddrCheck//$'\n'/ })
-        ipaddrCheck=${ipaddrCheck[59]}
-        echo "$ipaddrCheck"
-        if [ $ipaddrCheck != $ipaddrInfo ]; then
-           echo "Check didn't pass, ip address wasn't set properly"
-           exit 1;
-        fi;
-        sleep 2
+        if [ $ipsrcCheck != 'DHCP' ]; then
+            sleep 2
 
-        #IPMI tool command to set net mask
-        ipmitool lan set 1 netmask $netMaskInfo
-        sleep 8
-        netmaskCheck=$(ipmitool lan print)
-        netmaskCheck=(${netmaskCheck//$'\n'/ })
-        netmaskCheck=${netmaskCheck[63]}
-        echo "$netmaskCheck"
-        if [ ${netmaskCheck} != ${netMaskInfo} ]; then
-           echo "Check didn't pass, netmask wasn't set properly"
-           exit 1;
+            #IPMI tool command to set IP address
+            ipmitool lan set 1 ipaddr $ipaddrInfo
+            sleep 8
+            ipaddrCheck=$(ipmitool lan print)
+            ipaddrCheck=(${ipaddrCheck//$'\n'/ })
+            ipaddrCheck=${ipaddrCheck[59]}
+            echo "$ipaddrCheck"
+            if [ $ipaddrCheck != $ipaddrInfo ]; then
+               echo "Check didn't pass, ip address wasn't set properly"
+               exit 1;
+            fi;
+            sleep 2
+
+            #IPMI tool command to set net mask
+            ipmitool lan set 1 netmask $netMaskInfo
+            sleep 8
+            netmaskCheck=$(ipmitool lan print)
+            netmaskCheck=(${netmaskCheck//$'\n'/ })
+            netmaskCheck=${netmaskCheck[63]}
+            echo "$netmaskCheck"
+            if [ ${netmaskCheck} != ${netMaskInfo} ]; then
+               echo "Check didn't pass, netmask wasn't set properly"
+               exit 1;
+            fi;
+
+            #IPMI tool command to set default gateway address
+            ipmitool lan set 1 defgw ipaddr $defGatewayInfo
+            sleep 8
+            defgwCheck=$(ipmitool lan print)
+            defgwCheck=(${defgwCheck//$'\n'/ })
+            defgwCheck=${defgwCheck[100]}
+            echo "$defgwCheck"
+            if [ ${defgwCheck} != ${defGatewayInfo} ]; then
+               echo "Check didn't pass, default gateway wasn't set properly"
+               exit 1;
+            fi;
         fi;
 
-        #IPMI tool command to set default gateway address
-        ipmitool lan set 1 defgw ipaddr $defGatewayInfo
-        sleep 8
-        defgwCheck=$(ipmitool lan print)
-        defgwCheck=(${defgwCheck//$'\n'/ })
-        defgwCheck=${defgwCheck[100]}
-        echo "$defgwCheck"
-        if [ ${defgwCheck} != ${defGatewayInfo} ]; then
-           echo "Check didn't pass, default gateway wasn't set properly"
-           exit 1;
-        fi;
 
         #Reboot BMC so that webUI can take effect
+        #Wait for a total of 90s at maximum,
+        #the same value as suggested by vendor's sample code after flashing BMC
         ipmitool mc reset cold
         sleep 30
         set +e
-        retry=30
+        retry=60
         until [ $retry -le 0 ]; do
             ipmitool mc info
             if [ $? == 0 ]; then


### PR DESCRIPTION
Fix ODR 771 in flashing quanta BMC scripts, about error to set BMC IP after flashing Quanta BMC, if ip source is DHCP. 

It happened in MN lab, where BMC IP source is DHCP. Though the "sudo ipmitool lan set 1 ipaddr xxx" after flashing returns the same message as in static IP source, the exit code is 1 rather than 0. Modify the script to skip these network setting steps if the source is DHCP.

Add retry count after mc reset so that total wait time (maximum) is 90s, the same as suggested by vendor after flashing BMC. The original value is 60s, which is not sufficient for stack 13 node 1 at a certain ratio.

@uppalk1 @zyoung51 