### PR TITLE
judge the status of processor at list system processors (redfish api)

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -246,6 +246,16 @@ var listSystemProcessors = controller(function(req, res)  {
     var options = redfish.makeOptions(req, res, identifier);
     return dataFactory(identifier, 'dmi').then(function(dmi) {
         options.dmi = dmi;
+        options.dmi.data['Processor Information'].forEach(function(element,index){
+            if(element.Status.indexOf('Unpopulated') !== -1){
+                options.dmi.data['Processor Information'].splice(index,1);
+            }
+            console.log(options.dmi.data['Processor Information']);
+
+        });
+        if(options.dmi.data['Processor Information'].length === 0){
+            throw new Errors.NotFoundError('no valid processor found');
+        }
         return redfish.render('redfish.1.0.0.processorcollection.json',
                         'ProcessorCollection.json#/definitions/ProcessorCollection',
                         options);

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -177,9 +177,57 @@ describe('Redfish Systems Root', function () {
                 'Thread Count': '20',
                 Version: 'Intel(R) Xeon(R) CPU E5-2650 v3 @ 2.30GHz',
                 ID: 'test',
+                'Status': 'Populated, Enabled',
                 Family: 'test'
+            },
+            {
+                "Asset Tag": "Not Specified",
+                "Characteristics": "None",
+                "Current Speed": "Unknown",
+                "External Clock": "Unknown",
+                Family: "<OUT OF SPEC>",
+                ID: "test2",
+                "L1 Cache Handle": "Not Provided",
+                "L2 Cache Handle": "Not Provided",
+                "L3 Cache Handle": "Not Provided",
+                Manufacturer: "Not Specified",
+                "Max Speed": "Unknown",
+                "Part Number": "Not Specified",
+                "Serial Number": "Not Specified",
+                "Socket Designation": "SOCKET 1",
+                "Status": "Unpopulated",
+                "Type": "<OUT OF SPEC>",
+                "Upgrade": "<OUT OF SPEC>",
+                Version: "Not Specified",
+                "Voltage": "Unknown"
             }
         ],
+    };
+
+    var catalogDataWithBadProcessor = {
+        'Processor Information' : [
+            {
+                "Asset Tag": "Not Specified",
+                "Characteristics": "None",
+                "Current Speed": "Unknown",
+                "External Clock": "Unknown",
+                Family: "<OUT OF SPEC>",
+                ID: "test2",
+                "L1 Cache Handle": "Not Provided",
+                "L2 Cache Handle": "Not Provided",
+                "L3 Cache Handle": "Not Provided",
+                Manufacturer: "Not Specified",
+                "Max Speed": "Unknown",
+                "Part Number": "Not Specified",
+                "Serial Number": "Not Specified",
+                "Socket Designation": "SOCKET 1",
+                "Status": "Unpopulated",
+                "Type": "<OUT OF SPEC>",
+                "Upgrade": "<OUT OF SPEC>",
+                Version: "Not Specified",
+                "Voltage": "Unknown"
+            }
+          ]
     };
 
     var smartCatalog = [
@@ -293,6 +341,20 @@ describe('Redfish Systems Root', function () {
             .expect('Content-Type', /^application\/json/)
             .expect(404);
     });
+
+    it('should 404 an invalid processor list', function() {
+        waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
+            node: '1234abcd1234abcd1234abcd',
+            source: 'dummysource',
+            data: catalogDataWithBadProcessor
+        }));
+
+        return helper.request().get('/redfish/v1/Systems/' + node.id + '/Processors')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404);
+    });
+ 
+    
 
     it('should return a valid processor', function() {
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({


### PR DESCRIPTION
Fix the issue: 
failed to get processor information with redfish api:/Systems/{identifier}/Processors/{socket} 
https://github.com/RackHD/RackHD/issues/269

The redfish api "/Systems/{identifier}/Processors" always list all the processors including unpopulated processors.
However, when try to get the information of unpopulated processors, the api "/Systems/{identifier}/Processors/{socket} " just response error.

Unpopulated processors should be filtered.
