### PR TITLE
Search environment key with 'config.' for graph definition.

### DIFF
--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -48,7 +48,8 @@ function workflowApiServiceFactory(
                 return waterline.nodes.needByIdentifier(nodeId)
                 .then(function(node) {
                     if(node.sku) {
-                        return [node, env.get(configuration.name, configuration.name, [node.sku])];
+                        return [node, env.get("config." + configuration.name, configuration.name, 
+                            [node.sku,  Constants.Scope.Global])];
                     }
                     return [node, configuration.name];
                 }).spread(function(node, name) {

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -173,7 +173,7 @@ describe('Http.Services.Api.Workflows', function () {
         workflowApiService.runTaskGraph.resolves();
         store.findActiveGraphForTarget.resolves();
         waterline.nodes.needByIdentifier.resolves({ id: 'testnodeid', sku: 'skuid' });
-        env.get.withArgs('Graph.Test').resolves('Graph.Test');
+        env.get.withArgs('config.Graph.Test').resolves('Graph.Test');
 
         return workflowApiService.createAndRunGraph({
             name: 'Graph.Test',
@@ -194,7 +194,8 @@ describe('Http.Services.Api.Workflows', function () {
             expect(workflowApiService.runTaskGraph).to.have.been.calledOnce;
             expect(workflowApiService.runTaskGraph)
                 .to.have.been.calledWith(graph.instanceId, 'test');
-            expect(env.get).to.have.been.calledWith('Graph.Test', 'Graph.Test', ['skuid']);
+            expect(env.get).to.have.been.calledWith('config.Graph.Test', 'Graph.Test', 
+                ['skuid', "global"]);
         });
     });
 
@@ -204,7 +205,7 @@ describe('Http.Services.Api.Workflows', function () {
         workflowApiService.runTaskGraph.resolves();
         store.findActiveGraphForTarget.resolves();
         waterline.nodes.needByIdentifier.resolves({ id: 'testnodeid', sku: 'skuid' });
-        env.get.withArgs('Graph.Test').resolves('Graph.Test.skuid');
+        env.get.withArgs('config.Graph.Test').resolves('Graph.Test.skuid');
 
         return workflowApiService.createAndRunGraph({
             name: 'Graph.Test',
@@ -225,7 +226,8 @@ describe('Http.Services.Api.Workflows', function () {
             expect(workflowApiService.runTaskGraph).to.have.been.calledOnce;
             expect(workflowApiService.runTaskGraph)
                 .to.have.been.calledWith(graph.instanceId, 'test');
-            expect(env.get).to.have.been.calledWith('Graph.Test', 'Graph.Test', ['skuid']);
+            expect(env.get).to.have.been.calledWith('config.Graph.Test', 'Graph.Test', 
+                ['skuid', "global"]);
         });
     });
 


### PR DESCRIPTION
Search environment key with 'config.' for graph definition.

This is a similar change as done in https://github.com/RackHD/on-tasks/blob/master/lib/utils/job-utils/workflow-tool.js#L66 