### PR TITLE
set cache directory when run npm install

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -16,7 +16,7 @@ cp ../package.json .
 rsync -ar ../debianstatic/on-http/ debian
 
 rm -rf node_modules
-npm install
+npm install --cache=`pwd`
 npm run apidoc
 
 # The following is a workaround for a bug in npm 1.3.10 where
@@ -24,7 +24,7 @@ npm run apidoc
 # We are replacing "npm prune --production with a fresh
 # "npm install --production"
 rm -rf node_modules
-npm install --production
+npm install --production --cache=`pwd`
 
 git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
 


### PR DESCRIPTION
when tried to run the script  HWIMO-BUILD in five repositories parallelly: on-http, on-dhcp-proxy, on-syslog, on-taskgraph, on-tftp, there will be cache confilict because the five repositories use the same cache directory.
below is the error log:
npm install
03:54:37 npm ERR! git clone --template=/home/onrack/.npm/_git-remotes/_templates --mirror https://github.com/RackHD/di.js.git /home/onrack/.npm/_git-remotes/https-github-com-RackHD-di-js-git-c922a7fd: fatal: destination path '/home/onrack/.npm/_git-remotes/https-github-com-RackHD-di-js-git-c922a7fd' already exists and is not an empty directory.
03:54:37 npm ERR! git clone --template=/home/onrack/.npm/_git-remotes/_templates --mirror https://github.com/RackHD/on-tasks.git /home/onrack/.npm/_git-remotes/https-github-com-RackHD-on-tasks-git-37e86542: fatal: destination path '/home/onrack/.npm/_git-remotes/https-github-com-RackHD-on-tasks-git-37e86542' already exists and is not an empty directory.
03:54:37 npm ERR! git clone --template=/home/onrack/.npm/_git-remotes/_templates --mirror https://github.com/RackHD/on-core.git /home/onrack/.npm/_git-remotes/https-github-com-RackHD-on-core-git-594d7351: fatal: destination path '/home/onrack/.npm/_git-remotes/https-github-com-RackHD-on-core-git-594d7351' already exists and is not an empty directory.
03:54:37 npm ERR! Linux 4.2.0-27-generic
03:54:37 npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
03:54:37 npm ERR! node v0.10.45
03:54:37 npm ERR! npm  v2.15.1
03:54:37 npm ERR! code 128
03:54:37 
03:54:37 npm ERR! Command failed: fatal: destination path '/home/onrack/.npm/_git-remotes/https-github-com-RackHD-di-js-git-c922a7fd' already exists and is not an empty directory.
03:54:37 npm ERR! 
03:54:37 npm ERR! 
03:54:37 npm ERR! If you need help, you may report this error at:
03:54:37 npm ERR!     <https://github.com/npm/npm/issues>
03:54:37 
03:54:37 npm ERR! Please include the following file with any support request:
03:54:37 npm ERR!     /home/onrack/jenkins_slave/workspace/RackHD_CI/Templates/smoke-test-steps/build-deb/on-http/packagebuild/npm-debug.log

And I tried to set cache directory for every repository. 
The error doesn't occur again.