### PR TITLE
Change swagger yaml file for processing by swagger-ui

### DIFF
--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -2035,6 +2035,7 @@ paths:
       operationId: nodesGetSshById
       x-privileges: [ 'Read' ]
       x-authentication-type: [ 'jwt' ]
+      tags: [ "/api/2.0" ]
       summary: |
         get the ssh settings associated with a node.
       description: |

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -901,8 +901,8 @@ paths:
         - name: body
           in: body
           required: false
-          schema: 
-            type: object
+          schema:
+            $ref: "#/definitions/testEvent"
       responses:
         200:
           description: Success
@@ -5913,3 +5913,6 @@ definitions:
     properties:
       message:
         type: string
+  testEvent:
+    type: object
+


### PR DESCRIPTION
- The swagger-ui code throws an exception while parsing the schema
  object if it is not a reference.  Change to reference to make
  swagger-ui happy.
- Added the missing api/2.0 tag to the node ssh GET