### PR TITLE
Increase completion uri retry time to wait network ready

### DIFF
--- a/data/templates/centos.rackhdcallback
+++ b/data/templates/centos.rackhdcallback
@@ -26,6 +26,6 @@
 # Nothing wrong with set -e here since we're not doing anything complex
 set -e
 echo "Attempting to call back to RackHD CentOS installer"
-wget --retry-connrefused --waitretry=1 -t 30 http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>
+wget --retry-connrefused --waitretry=1 -t 300 http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>
 # Only run this once to verify the OS was installed, then disable it forever
 chkconfig centos.rackhdcallback off


### PR DESCRIPTION
For ODR-737 https://hwjiraprd01.corp.emc.com/browse/ODR-737. Increase wget completion uri waiting time from 30s to 5 minutes. to cover worse cases that waiting more time for network ready. 5 minutes is just a long enough experience time tested.  C6320 and platfom-H platforms are tested.

@RackHD/corecommitters @RackHD/rackhd_dev 