### PR TITLE
Fix adding DNS search domain not working in esx-ks template and set domain optional

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -79,7 +79,12 @@ esxcli system settings advanced set -o /UserVars/ESXiShellInteractiveTimeout -i 
 esxcli network firewall set --default-action false --enabled no
 
 # set hostname and domain
-esxcli system hostname set --domain <%=domain%> --host <%=hostname%>
+# if hostname is 'localhost', domain cannot be set.
+<% if (domain) { %>
+esxcli system hostname set --host <%=hostname%> --domain <%=domain%>
+<% } else { %>
+esxcli system hostname set --host <%=hostname%>
+<% } %>
 
 #config root account
 <% if (typeof rootSshKey !== 'undefined') { %>
@@ -112,7 +117,9 @@ esxcli system maintenanceMode set -e true
 cp /var/log/hostd.log "/vmfs/volumes/datastore1/firstboot-hostd.log"
 cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.log"
 <% if( undefined !== dnsServers ) { %>
-  esxcli network ip dns search add <%=domain%>
+  <% if (domain) { %>
+  esxcli network ip dns search add --domain=<%=domain%>
+  <% } %>
   <% dnsServers.forEach(function(dns) { %>
     esxcli network ip dns server add --server=<%= dns %>
   <% }); %>

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -80,7 +80,7 @@ esxcli network firewall set --default-action false --enabled no
 
 # set hostname and domain
 # if hostname is 'localhost', domain cannot be set.
-<% if (domain) { %>
+<% if ( typeof domain !== 'undefined' ) { %>
 esxcli system hostname set --host <%=hostname%> --domain <%=domain%>
 <% } else { %>
 esxcli system hostname set --host <%=hostname%>
@@ -117,7 +117,7 @@ esxcli system maintenanceMode set -e true
 cp /var/log/hostd.log "/vmfs/volumes/datastore1/firstboot-hostd.log"
 cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.log"
 <% if( undefined !== dnsServers ) { %>
-  <% if (domain) { %>
+  <% if ( typeof domain !== 'undefined' ) { %>
   esxcli network ip dns search add --domain=<%=domain%>
   <% } %>
   <% dnsServers.forEach(function(dns) { %>


### PR DESCRIPTION
**Fix ODR-748** Adding DNS search domain not working in esx-ks template
**solution:**
In the section that processes 'dnsServers,' this
esxcli network ip dns search add <%=domain%>
needs to be changed to this
esxcli network ip dns search add --domain=<%=domain%>

**Fix ODR-751** Setting 'domain' option is effectively required in esx-ks
**solution:**
According to RackHD docs, the default value of 'domain' is 'rackhd', and now it's changed to null. rackhd/on-tasks#250

@RackHD/corecommitters @panpan0000 