### PR TITLE
Fix double npm install in HWIMO-BUILD

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -18,13 +18,7 @@ rsync -ar ../debianstatic/on-http/ debian
 rm -rf node_modules
 npm install --cache=`pwd`
 npm run apidoc
-
-# The following is a workaround for a bug in npm 1.3.10 where
-# prune --production removes the redfish-node module which is needed.
-# We are replacing "npm prune --production with a fresh
-# "npm install --production"
-rm -rf node_modules
-npm install --production --cache=`pwd`
+npm prune --production
 
 git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt
 


### PR DESCRIPTION
The redfish-node package dependency was removed from RackHD.
So the workaround should be cleared to avoid **double npm install** which takes **almost double** time to build deb package.

@RackHD/corecommitters @panpan0000 @jlongever @davidzuhn 