### PR TITLE
Create linux diag profile

### DIFF
--- a/data/profiles/linux-generic.ipxe
+++ b/data/profiles/linux-generic.ipxe
@@ -1,0 +1,4 @@
+kernel <%=kernelUri%>
+initrd <%=initrdUri%>
+imgargs <%=kernelFile%> initrd=<%=initrdFile%> ip=<%=ipaddress%>:<%=server%>:<%=gateway%>:<%=netmask%> rsyslog=<%=server%> cb_url=http://<%=server%>:<%=port%><%=completionPath%> BOOTIF=01-<%=macaddress%> console=tty0 console=<%=comport%>,115200n8 <%=bootargs%>
+boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell


### PR DESCRIPTION
Added Linux diag boot profile for EMC diagnostic images.

@RackHD/corecommitters @uppalk1 @tannoa2 @zyoung51 @keedya 