### PR TITLE
install-os: fix template defect when a value is not existing; change hostname/domain to be optional

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -26,18 +26,20 @@ authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 rootpw --iscrypted <%=rootEncryptedPassword%>
 
 #create all users
+<% if (typeof users !== 'undefined') { %>
 <% users.forEach(function(user) { %>
 <%_  if( typeof user.uid !== 'undefined' ) { _%>
         user --name=<%=user.name%> --uid=<%=user.uid%> --iscrypted --password <%=user.encryptedPassword%>
 <%_  } else { _%>
         user --name=<%=user.name%>  --iscrypted --password <%=user.encryptedPassword%>
 <%_ }}) _%>
+<% } %>
 
 # Disk Partitioning
 zerombr
 clearpart --all --drives=<%=installDisk%>
 
-<% if(installPartitions !== undefined && installPartitions.length > 0) { %>
+<% if (typeof installPartitions !== 'undefined' && installPartitions.length > 0) { %>
     <% installPartitions.forEach(function(partition) { %>
         # mountPoint and size is required
         <% if(partition.mountPoint !== undefined && partition.size !== undefined) { %>
@@ -80,7 +82,7 @@ sudo
 perl
 libselinux-python
 net-tools
-<% if( typeof kvm !== 'undefined' ) { %>
+<% if( typeof kvm !== 'undefined' && kvm ) { %>
     <% if (version === "6.5") { %>
         kvm
         virt-manager
@@ -111,6 +113,7 @@ export PATH
     echo <%=rootSshKey%> > /root/.ssh/authorized_keys
     chown -R root:root /root/.ssh
 <% } %>
+<% if (typeof users !== 'undefined') { %>
 <% users.forEach(function(user) { %>
     <% if (typeof user.sshKey !== 'undefined') { %>
         mkdir /home/<%=user.name%>/.ssh
@@ -118,13 +121,18 @@ export PATH
         chown -R <%=user.name%>:<%=user.name%> /home/<%=user.name%>/.ssh
     <% } %>
 <% }) %>
+<% } %>
 
 #set hostname
-echo <%=hostname%> > /etc/hostname
-echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/network
+<% if (typeof hostname !== 'undefined') { %>
+    echo <%=hostname%> > /etc/hostname
+    <% if (typeof domain !== 'undefined') { %>
+        echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/network
+    <% } %>
+<% } %>
 
 # Setup static network configuration
-<% if( undefined !== networkDevices ) { %>
+<% if (typeof networkDevices !== 'undefined') { %>
   <% ipv6 = 0 %>
   <% networkDevices.forEach(function(n) { %>
     <% if( undefined != n.ipv4 ) { %>
@@ -188,8 +196,10 @@ echo -e "NETWORKING=yes\nHOSTNAME=<%=hostname%>.<%=domain%>" > /etc/sysconfig/ne
 <% } %>
 
 # Setup DNS servers
-<% if( undefined !== dnsServers ) { %>
-  echo "search <%=domain%>" > /etc/resolv.conf
+<% if (typeof dnsServers !== 'undefined') { %>
+  <% if (typeof domain !== 'undefined') { %>
+    echo "search <%=domain%>" > /etc/resolv.conf
+  <% } %>
   <% dnsServers.forEach(function(dns) { %>
     echo "nameserver <%=dns%>" >> /etc/resolv.conf
   <% }) %>

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -11,7 +11,7 @@ rootpw <%=rootPlainPassword%>
 # Search the networkDevices and set the first vmnic# (if defined) up.
 # If no vmnic# device is specified in the networkDevices, then we fallback
 # to setting vmnic0 up as dhcp
-<% if( undefined !== networkDevices ) { %>
+<% if( typeof networkDevices !== 'undefined' ) { %>
   <% need_default = networkDevices.every(function(n) { %>
     <% if( n.device.substring(0,5) === 'vmnic' ) { %>
       <% if(typeof n.ipv4 !== 'undefined') { %>
@@ -79,11 +79,12 @@ esxcli system settings advanced set -o /UserVars/ESXiShellInteractiveTimeout -i 
 esxcli network firewall set --default-action false --enabled no
 
 # set hostname and domain
-# if hostname is 'localhost', domain cannot be set.
-<% if ( typeof domain !== 'undefined' ) { %>
-esxcli system hostname set --host <%=hostname%> --domain <%=domain%>
-<% } else { %>
-esxcli system hostname set --host <%=hostname%>
+<% var hostnameCmdStr=''; %>
+<% if (typeof domain === 'string') hostnameCmdStr += (' --domain ' + domain) %>
+<% if (typeof hostname === 'string') hostnameCmdStr += (' --host ' + hostname) %>
+<% if (typeof fqdn === 'string') hostnameCmdStr += (' --fqdn ' + fqdn) %>
+<% if (hostnameCmdStr.length > 0) { %>
+    esxcli system hostname set <%=hostnameCmdStr%>
 <% } %>
 
 #config root account
@@ -92,6 +93,7 @@ esxcli system hostname set --host <%=hostname%>
 <%} %>
 
 #create users
+<% if( typeof users !== 'undefined' ) { %>
 <% users.forEach(function(user) { %>
     /usr/lib/vmware/auth/bin/adduser -s /bin/sh -G root -h / -D <%=user.name%>
     echo <%=user.plainPassword%> | passwd <%=user.name%> --stdin
@@ -100,6 +102,7 @@ esxcli system hostname set --host <%=hostname%>
         echo <%=user.sshKey%> > /etc/ssh/keys-<%=user.name%>/authorized_keys
     <%} %>
 <%}) %>
+<%} %>
 
 #setup ntp
 cat > /etc/ntp.conf << __NTP_CONFIG__
@@ -116,7 +119,7 @@ esxcli system maintenanceMode set -e true
 #copy the first boot logs
 cp /var/log/hostd.log "/vmfs/volumes/datastore1/firstboot-hostd.log"
 cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.log"
-<% if( undefined !== dnsServers ) { %>
+<% if( typeof dnsServers !== 'undefined' ) { %>
   <% if ( typeof domain !== 'undefined' ) { %>
   esxcli network ip dns search add --domain=<%=domain%>
   <% } %>
@@ -141,7 +144,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 <% } %>
 
 <% vmkid = 0 %>
-<% if( undefined !== networkDevices ) { %>
+<% if( typeof networkDevices !== 'undefined' ) { %>
   <% networkDevices.forEach(function(n) { %>
     <% if( undefined !== n.ipv4 ) { %>
       <% if( undefined !== n.ipv4.vlanIds ) { %>
@@ -151,7 +154,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
           esxcli network ip interface remove -i <%=vmkname%>
           esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>.<%=vid%>
           esxcli network ip interface ipv4 set -i <%=vmkname%> -I <%=n.ipv4.ipAddr%> -N <%=n.ipv4.netmask%> -t static
-          esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%> 
+          esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%>
           esxcli network vswitch standard portgroup set -p <%=n.device%>.<%=vid%> -v <%=vid %>
           postLookup <%=vmkname%> <%=n.ipv4.ipAddr%>
         <% }); %>
@@ -161,7 +164,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
         esxcli network ip interface remove -i <%=vmkname%>
         esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>
         esxcli network ip interface ipv4 set -i <%=vmkname%> -I <%=n.ipv4.ipAddr%> -N <%=n.ipv4.netmask%> -t static
-        esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%> 
+        esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%>
         postLookup <%=vmkname%> <%=n.ipv4.ipAddr%>
       <% } %>
     <% } %>
@@ -208,7 +211,7 @@ sleep 60
 # %firstboot ends with a reboot, this script will run afterwards to signify completion
 # of the installer and all reboot steps.
 #
-# The approved method for adding startup commands is to write to /etc/rc.local.d/local.sh, 
+# The approved method for adding startup commands is to write to /etc/rc.local.d/local.sh,
 # which is a pre-existing file with a sticky bit set by VisorFS. You can't just create new
 # files and expect them to stick around, even if you set a sticky bit yourself.
 # The /sbin/auto-backup.sh script will ensure the changes are persisted across reboots and

--- a/data/templates/install-ubuntu/post-install-ubuntu.sh
+++ b/data/templates/install-ubuntu/post-install-ubuntu.sh
@@ -8,6 +8,7 @@ chown -R root:root /root/.ssh
 <% } -%>
 
 # create users and SSH key for users
+<% if (typeof users !== 'undefined') { -%>
 <% users.forEach(function(user) { -%>
     <%_ if (undefined !== user.uid) { _%>
         useradd -u <%=user.uid%> -m -p <%=user.encryptedPassword%> <%=user.name%>
@@ -20,3 +21,4 @@ echo <%=user.sshKey%> > /home/<%=user.name%>/.ssh/authorized_keys
 chown -R <%=user.name%>:<%=user.name%> /home/<%=user.name%>/.ssh
     <%_ } _%>
 <% }); -%>
+<% } -%>

--- a/data/templates/install-ubuntu/ubuntu-interfaces
+++ b/data/templates/install-ubuntu/ubuntu-interfaces
@@ -1,3 +1,4 @@
+<%_ if (typeof networkDevices !== 'undefined' && networkDevices.length > 0) { _%>
 <%_ networkDevices.forEach(function(n) { _%>
     <%_ for (p in n) { _%>
         <%_ ip = n[p]; _%>
@@ -21,7 +22,8 @@ gateway <%=ip.gateway%>
         <%_ } _%>
     <%_ } _%>
 <%_ }); _%>
+<%_ } _%>
 
-<% if (undefined !== dnsServers && dnsServers.length > 0) { -%>
+<% if (typeof dnsServers !== 'undefined' && dnsServers.length > 0) { -%>
 dns-nameservers <%=dnsServers.join(' ')%>
 <% } -%>

--- a/data/templates/install-ubuntu/ubuntu-preseed
+++ b/data/templates/install-ubuntu/ubuntu-preseed
@@ -15,8 +15,12 @@ d-i keyboard-configuration/layoutcode string us
 # netcfg will choose an interface that has link if possible. This makes it
 # skip displaying a list if there is more than one interface.
 d-i netcfg/choose_interface select auto
+<% if (typeof hostname !== 'undefined') { %>
 d-i netcfg/get_hostname string <%=hostname%>
+<% } %>
+<% if (typeof domain !== 'undefined') { %>
 d-i netcfg/get_domain string <%=domain%>
+<%} %>
 
 
 # Disable that annoying WEP key dialog.
@@ -132,7 +136,7 @@ d-i passwd/root-password-crypted password <%=rootEncryptedPassword%>
 tasksel tasksel/first multiselect ubuntu-server
 
 # Individual additional packages to install
-<% var pkgs = (typeof kvm === 'undefined' ? '' : 'qemu-kvm virt-manager libvirt0 python-libvirt bridge-utils') -%>
+<% var pkgs = ((typeof kvm === 'undefined' || !kvm) ? '' : 'qemu-kvm virt-manager libvirt0 python-libvirt bridge-utils') -%>
 d-i pkgsel/include string openssh-server curl <%=pkgs%>
 
 # Policy for applying updates. May be "none" (no automatic updates),
@@ -179,7 +183,7 @@ xserver-xorg xserver-xorg/autodetect_monitor boolean true
 #d-i pretemplate/late_command string apt-install zsh; in-target chsh -s /bin/zsh
 
 d-i preseed/late_command string \
-<%_ if (undefined !== networkDevices && networkDevices.length > 0) { _%>
+<%_ if (typeof networkDevices !== 'undefined' && networkDevices.length > 0) { _%>
 wget http://<%=server%>:<%=port%>/api/common/templates/ubuntu-interfaces -O /etc/network/interfaces; \
 <%_ } _%>
 in-target wget http://<%=server%>:<%=port%>/api/common/templates/post-install-ubuntu.sh -O ./post-install.sh; \

--- a/data/templates/suse-autoinst.xml
+++ b/data/templates/suse-autoinst.xml
@@ -26,6 +26,8 @@
       <user_password><%=rootEncryptedPassword%></user_password>
       <username>root</username>
     </user>
+
+<% if( typeof users !== 'undefined' ) { %>
 <% users.forEach(function(user) { %>
     <user>
       <encrypted config:type="boolean">true</encrypted>
@@ -37,6 +39,7 @@
       <username><%=user.name%></username>
     </user>
 <% }) %>
+<% } %>
   </users>
 
   <networking>
@@ -44,10 +47,14 @@
     <dns>
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <dhcp_resolv config:type="boolean">true</dhcp_resolv>
+      <% if( typeof domain !== 'undefined') { %>
       <domain><%=domain%></domain>
+      <% } %>
+      <% if( typeof hostname !== 'undefined') { %>
       <hostname><%=hostname%></hostname>
+      <% } %>
       <write_hostname config:type="boolean">true</write_hostname>
-<% if( undefined !== dnsServers ) { %>
+<% if( typeof dnsServers !== 'undefined' ) { %>
       <nameservers config:type="list">
   <% dnsServers.forEach(function(dns) { %>
         <nameserver><%=dns%></nameserver>
@@ -57,8 +64,8 @@
     </dns>
 
   <interfaces config:type="list">
-<% if( undefined !== networkDevices ) { %>
   <% ipv6 = 0 %>
+<% if( typeof networkDevices !== 'undefined') { %>
   <% networkDevices.forEach(function(n) { %>
     <% if( undefined != n.ipv4 ) { %>
       <% if( undefined != n.ipv4.vlanIds ) { %>
@@ -124,7 +131,7 @@
   <software>
     <packages config:type="list">
       <package>openssh</package>
-<% if( typeof kvm !== 'undefined' ) { %>
+<% if( typeof kvm !== 'undefined' && kvm ) { %>
   <% if (version === "11") { %>
       <package>kvm</package>
   <% } else { %>
@@ -147,7 +154,7 @@
   </services-manager>
 
   <scripts>
-    <chroot-scripts config:type="list"> 
+    <chroot-scripts config:type="list">
       <script>
         <chrooted config:type="boolean">true</chrooted>
         <interpreter>shell</interpreter>
@@ -160,7 +167,7 @@
       </script>
     </chroot-scripts>
 
-    <post-scripts config:type="list"> 
+    <post-scripts config:type="list">
       <script>
         <interpreter>shell</interpreter>
         <chrooted config:type="boolean">true</chrooted>
@@ -177,13 +184,15 @@
           <% } %>
 
           # Set users ssh key
+          <% if (typeof users !== 'undefined') { %>
           <% users.forEach(function(user) { %>
             <% if (typeof user.sshKey !== 'undefined') { %>
-                mkdir /home/<%=user.name%>/.ssh 
+                mkdir /home/<%=user.name%>/.ssh
                 echo <%=user.sshKey%> > /home/<%=user.name%>/.ssh/authorized_keys
                 chown -R <%=user.name%>:users /home/<%=user.name%>/.ssh
             <% } %>
           <% }) %>
+          <% } %>
           ]]>
         </source>
       </script>

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -232,14 +232,14 @@ function CommonApiPresenterFactory(
         var scope = self.res.locals.scope;
         var config = CommonApiPresenter.configCache;
         var apiServerAddress = self.req.get(constants.HttpHeaders.ApiProxyIp) ||
-                                                      config.apiServerAddress || 
+                                                      config.apiServerAddress ||
                                                       '10.1.1.1';
-        var apiServerPort = self.req.get(constants.HttpHeaders.ApiProxyPort) || 
-                                                        config.apiServerPort || 
+        var apiServerPort = self.req.get(constants.HttpHeaders.ApiProxyPort) ||
+                                                        config.apiServerPort ||
                                                         80;
         var serverUri = 'http://' + apiServerAddress + ':' + apiServerPort;
         var baseUri = serverUri + '/api/current';
-        
+
         graphContext = graphContext || {};
 
         return Promise.props({


### PR DESCRIPTION
When task-schema is enabled, if an parameter is optional it will not existing in the rendering context, (previously the optional value will be set to null or []). But current template rendering will throw error if the parameter is missing, currently ,we use following syntax to check a parameter is not missing:
```
if (param !== undefined) {
 ...
}
```
This will cause the ejs error with failing to find the `param`.
The correct syntax should be:
```
if (typeof param !== 'undefined') {
 ...
}
```

Meanwhile, I have updated all install-os template to let the `domain`/`hostname` to be optional. This is a requirement from this PR (https://github.com/RackHD/on-http/pull/342), that PR only change on ESXi, my PR changes all install-os's template.

Depends on: https://github.com/RackHD/on-tasks/pull/257

**NOTE**: merge together with https://github.com/RackHD/on-tasks/pull/257, otherwise various OS installation may be broken down (when some optional parameters are missing).

@RackHD/corecommitters @WangWinson @iceiilin @cgx027 @pengz1 