### PR TITLE
add NTP configuration in esx-ks

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -108,8 +108,11 @@ esxcli network firewall set --default-action false --enabled no
 cat > /etc/ntp.conf << __NTP_CONFIG__
 restrict default kod nomodify notrap noquerynopeer
 restrict 127.0.0.1 kkl,lkl
-server 0.vmware.pool.ntp.org
-server 1.vmware.pool.ntp.org
+<% if( typeof ntpServers !== 'undefined' ) { %>
+   <% ntpServers.forEach(function(ntp) { %>
+      server <%= ntp %>
+   <% }); %>
+<% } %>
 __NTP_CONFIG__
 /sbin/chkconfig ntpd on
 


### PR DESCRIPTION
**Fix ODR-750** NTP configuration in esx-ks

The solution is adding ntpSevers options to support NTP configuration, so that the users could use the private NTP servers if needed.

@RackHD/corecommitters @panpan0000 

rackhd/on-tasks#259