### PR TITLE
Fix sata disk identifier SN

### DIFF
--- a/data/templates/get_driveid.js
+++ b/data/templates/get_driveid.js
@@ -15,11 +15,30 @@ var options = {
 
 /**
  * Get SATA drive's SN string.
- * @param {String} SATA drive's name, eg. 'sda'
+ * @param {String} sataDrive SATA drive's name, eg. 'sda'
  * @return {String} SATA drive's SN string with 20 characters like 'QM00007_____________'
  */
 function getSataSnStr(sataDrive) {
     var output = execSync(cmdSataRawInfo + ' /dev/' + sataDrive);
+    /*  output data like below:
+     *  $ sudo hdparm --Istdout /dev/sda
+     *  dev/sda:
+     *
+     *  0040 3fff 0000 0010 7e00 0200 003f 0000
+     *  0000 0000 514d 3030 3030 3520 2020 2020
+     *  2020 2020 2020 2020 0003 0200 0004 322e
+     *  322e 3120 2020 5145 4d55 2048 4152 4444
+     *  4953 4b20 2020 2020 2020 2020 2020 2020
+     *  2020 2020 2020 2020 2020 2020 2020 8010
+     *  .....
+     *
+     *  snHexStr is from 21 to 40 bytes, total 20 bytes, shown as below
+     *
+     *  .....
+     *            514d 3030 3030 3520 2020 2020
+     *  2020 2020 2020 2020
+     *  .....
+     */
     var lines = output.toString().split('\n');
     var snHexStr = lines.reduce(function (result,line) {
         if(line.length === 39) {

--- a/data/templates/get_driveid.js
+++ b/data/templates/get_driveid.js
@@ -40,8 +40,9 @@ function getSataSnStr(sataDrive) {
      *  .....
      */
     var lines = output.toString().split('\n');
+    var hexLineMatch = /^([0-9A-Fa-f]{4}\s+){7}[0-9A-Fa-f]{4}$/;
     var snHexStr = lines.reduce(function (result,line) {
-        if(line.length === 39) {
+        if(hexLineMatch.test(line)) {
             result.push(line);
         }
         return result;

--- a/spec/data/templates/get_driveid-spec.js
+++ b/spec/data/templates/get_driveid-spec.js
@@ -41,8 +41,8 @@ describe('get_driveid script', function() {
         'total 0\n' +
         'drwxr-xr-x 2 root root 360 Dec 22 10:02 ./\n' +
         'drwxr-xr-x 5 root root 100 Dec 22 10:02 ../\n' +
-        'lrwxrwxrwx 1 root root   9 Dec 22 10:03 ata-32GB_SATA-Flash_Drive_B0714226900900000016 -> ../../sdb\n' +
-        'lrwxrwxrwx 1 root root  10 Dec 22 10:03 ata-32GB_SATA-Flash_Drive_B0714226900900000016-part1 -> ../../sdb1\n' +
+        'lrwxrwxrwx 1 root root   9 Dec 22 10:03 ata-32GB_SATA-Flash_Drive_QM00001 -> ../../sdb\n' +
+        'lrwxrwxrwx 1 root root  10 Dec 22 10:03 ata-32GB_SATA-Flash_Drive_QM00001-part1 -> ../../sdb1\n' +
         'lrwxrwxrwx 1 root root   9 Dec 22 10:03 ata-HUS724040ALA640_PBJY9ZJX -> ../../sda\n' +
         'lrwxrwxrwx 1 root root   9 Dec 24 11:05 scsi-3600163600196c0401e0c0e6511cec3c0 -> ../../sdc\n' +
         'lrwxrwxrwx 1 root root   9 Dec 24 11:05 scsi-3600163600196c0401e0c0e6511dec3c0 -> ../../sdg\n' +
@@ -51,10 +51,28 @@ describe('get_driveid script', function() {
         'lrwxrwxrwx 1 root root  9 May 15 08:45 usb-SMART_eUSB_SPG143500HQ-0:0 -> ../../sdd';
     //jshint ignore: end
 
+    var mockSataRawInfoStd =
+    //jshint ignore: start
+        'dev/sda:\n' +
+        '0040 3fff 0000 0010 7e00 0200 003f 0000\n' +
+        '0000 0000 514d 3030 3030 3120 2020 2020\n' +
+        '2020 2020 2020 2020 0003 0200 0004 322e\n' +
+        '322e 3120 2020 5145 4d55 2048 4152 4444\n' +
+        '4953 4b20 2020 2020 2020 2020 2020 2020\n' +
+        '2020 2020 2020 2020 2020 2020 2020 8010\n'
+    //jshint ignore: end
+
+
     describe('parser', function() {
         var buildDriveMap = getDriveId.__get__('buildDriveMap');
 
+        var mockExec = function(cmd) {
+            return mockSataRawInfoStd;
+        };
+        getDriveId.__set__('execSync', mockExec);
+
         it('should discard DVD info', function() {
+
             var result = buildDriveMap(mockWwidDvd, mockVdInfoDvd, mockScsiDvd);
             expect(result).to.deep.equal(JSON.stringify(
                 //jshint ignore: start
@@ -62,7 +80,7 @@ describe('get_driveid script', function() {
                     {
                         "scsiId":"0:0:0:0",
                         "virtualDisk":"",
-                        "esxiWwid":"t10.ATA_____QEMU_HARDDISK________________________________________QM00001",
+                        "esxiWwid":"t10.ATA_____QEMU_HARDDISK___________________________QM00001_____________",
                         "devName":"sda",
                         "identifier":0,
                         "linuxWwid":"/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001"
@@ -80,10 +98,10 @@ describe('get_driveid script', function() {
                     {
                         "scsiId":"6:0:0:0",
                         "virtualDisk":"",
-                        "esxiWwid":"t10.ATA_____32GB_SATA2DFlash_Drive___________________B0714226900900000016",
+                        "esxiWwid":"t10.ATA_____32GB_SATA2DFlash_Drive___________________QM00001_____________",
                         "devName":"sdb",
                         "identifier":0,
-                        "linuxWwid":"/dev/disk/by-id/ata-32GB_SATA-Flash_Drive_B0714226900900000016"
+                        "linuxWwid":"/dev/disk/by-id/ata-32GB_SATA-Flash_Drive_QM00001"
                     },
                     {
                         "scsiId":"5:0:0:0",


### PR DESCRIPTION
when install ESXi,  lodash ‘_’  may be before or after disk SN,  like 'XXXXXX_____________' or '_____________YYYYYY' so the esxiWwid may be 
"esxiWwid":"t10.ATA_____QEMU_HARDDISK_XXXXXX_____________" or
"esxiWwid":"t10.ATA_____QEMU_HARDDISK______________YYYYYY"  it's decided by the raw data read by 'hdparm', previously, lodash ’_‘ is fixed before 'SN' in codes. 
this issue is found when installing ESXi6.0 in InfraSIM. with this fix, ESX6.0 could be installed with InfraSIM.

depends on: https://github.com/RackHD/on-imagebuilder/pull/45

@RackHD/corecommitters @RackHD/rackhd_dev 

