### PR TITLE
Fix POST /api/1.1/nodes/{identifier}/obm

### DIFF
--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -268,28 +268,24 @@ function nodesRouterFactory (
      */
 
     router.post('/nodes/:identifier/obm', rest(function (req) {
-        var storeNode;
-        return waterline.nodes.needByIdentifier(req.params.identifier)
-            .then(function (node){
-                return _renderNodeObmSettings(node)
-                .then(function (retNode){
-                    return ObmService.checkValidService(retNode, req.body)
-                        .then(function () {
-                            storeNode = retNode;
-                            return retNode;
-                        });
-                });
-            })
-            .then(function () {
-                var obmSettings = _.assign([], req.body.obmSettings);
-                return Promise.map(obmSettings, function(obmSetting) {
-                    return waterline.obms.upsertByNode(req.params.identifier, obmSetting);
-                });
-            })
-            .then(function (){
-                return storeNode;
-            });
+        var node;
 
+        return Promise.try(function() {
+            return waterline.nodes.needByIdentifier(req.params.identifier);
+        })
+        .then(function(queryNode) {
+            node = queryNode;
+            return ObmService.checkValidService(node, req.body);
+        })
+        .then(function() {
+            var obmSettings = _.isArray(req.body) ? req.body : [ req.body ];
+            return Promise.map(obmSettings, function(obmSetting) {
+                return waterline.obms.upsertByNode(req.params.identifier, obmSetting);
+            });
+        })
+        .then(function() {
+            return _renderNodeObmSettings(node);
+        });
     }));
 
     /**


### PR DESCRIPTION
* Allow posting OBM object or array of OBM objects
* Populate response body with obmSettings property

This problem was discovered by @uppalk1 
@RackHD/corecommitters @srinia6 @dalebremner @keedya @BillyAbildgaard 