### PR TITLE
Add UUID prefix to SSDP UDN

### DIFF
--- a/lib/services/upnp-service.js
+++ b/lib/services/upnp-service.js
@@ -195,6 +195,7 @@ function UPnPServiceFactory(
             return fs.writeFileAsync(self.description, content);
         })
         .then(function() {
+            self.options.udn = 'uuid:' + self.options.udn;
             return _.forEach(self.registry, function(r) {
                 logger.debug('Starting SSDP/uPnP server', {usn: r});
                 var ep = (_.includes(r.urn, 'southbound')) ? southPoint : endpoint;


### PR DESCRIPTION
This is per upnp/ssdp specification,  node-ssdp library doesn't construct the UDN as expected.

@RackHD/corecommitters @zyoung51 @uppalk1 @tannoa2 @keedya @king-jam 