### PR TITLE
Use MAC addresses to create vSwitch uplinks and networkDevices in esx-ks

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -8,24 +8,22 @@ accepteula
 <% } %>
 rootpw <%=rootPlainPassword%>
 
-# Search the networkDevices and set the first vmnic# (if defined) up.
-# If no vmnic# device is specified in the networkDevices, then we fallback
-# to setting vmnic0 up as dhcp
+# Search the networkDevices and set the first device (if defined) up.
+# If no device is specified in the networkDevices, then we fallback
+# to setting 'vmnic0' up as DHCP. The device can be specified with a
+# MAC address or device name ('vmnic0' for example)
 <% if( typeof networkDevices !== 'undefined' ) { %>
   <% need_default = networkDevices.every(function(n) { %>
-    <% if( n.device.substring(0,5) === 'vmnic' ) { %>
-      <% if(typeof n.ipv4 !== 'undefined') { %>
-        <% ipopts = '--ip=' + n.ipv4.ipAddr + ' --gateway=' + n.ipv4.gateway + ' --netmask=' + n.ipv4.netmask %>
-        <% if (typeof n.ipv4.vlanIds !== 'undefined' ) { %>
-          <% ipopts += ' --vlandid=' + n.ipv4.vlanIds[0] %>
-        <% } %>
-        network --bootproto=static --device=<%=n.device%> <%=ipopts%>
-      <% } else { %>
-        network --bootproto=dhcp --device=<%=n.device%>
+    <% if(typeof n.ipv4 !== 'undefined') { %>
+      <% ipopts = '--ip=' + n.ipv4.ipAddr + ' --gateway=' + n.ipv4.gateway + ' --netmask=' + n.ipv4.netmask %>
+      <% if (typeof n.ipv4.vlanIds !== 'undefined' ) { %>
+        <% ipopts += ' --vlandid=' + n.ipv4.vlanIds[0] %>
       <% } %>
-      <% return false; %>
+      network --bootproto=static --device=<%=n.device%> <%=ipopts%>
+    <% } else { %>
+      network --bootproto=dhcp --device=<%=n.device%>
     <% } %>
-    <% return true; %>
+    <% return false; %>
   <% }); %>
   <% if (need_default) { %>
     network --bootproto=dhcp --device=vmnic0
@@ -122,6 +120,8 @@ esxcli system maintenanceMode set -e true
 #copy the first boot logs
 cp /var/log/hostd.log "/vmfs/volumes/datastore1/firstboot-hostd.log"
 cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.log"
+
+#setup DNS
 <% if( typeof dnsServers !== 'undefined' ) { %>
   <% if ( typeof domain !== 'undefined' ) { %>
   esxcli network ip dns search add --domain=<%=domain%>
@@ -131,16 +131,22 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
   <% }); %>
 <% } %>
 
+#create vSwitches with uplinks. An uplink can be specifed with its MAC
+#address or device name
 <% if ( typeof switchDevices !== 'undefined' ) { %>
   <% switchDevices.forEach(function(n) { %>
     esxcli network vswitch standard add -v "<%=n.switchName%>"
     <% if( undefined !== n.uplinks ) { %>
       <% n.uplinks.forEach(function(s) { %>
-        currsw=`esxcli --debug --formatter=csv network vswitch standard list | grep <%=s%> | awk -F, '{print $9}'`
+        currdev = <%=s%>
+        <% if (s.substring(0,5) !== 'vmnic') { %>
+          currdev=`esxcli network nic list | grep <%=s%> | cut -d ' ' -f 1`
+        <% } %>
+        currsw=`esxcli --debug --formatter=csv network vswitch standard list | grep $currdev | awk -F, '{print $9}'`
         if [ "$currsw" != "" ]; then
-          esxcli network vswitch standard uplink remove -v $currsw -u <%=s%>
+          esxcli network vswitch standard uplink remove -v $currsw -u $currdev
         fi
-        esxcli network vswitch standard uplink add -v <%=n.switchName%> -u <%=s%>
+        esxcli network vswitch standard uplink add -v <%=n.switchName%> -u $currdev
       <% }); %>
     <% } %>
   <% }); %>
@@ -149,23 +155,27 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 <% vmkid = 0 %>
 <% if( typeof networkDevices !== 'undefined' ) { %>
   <% networkDevices.forEach(function(n) { %>
+    currdev = <%=n.device%>
+    <% if (n.device.substring(0,5) != 'vmnic') { %>
+       currdev=`esxcli network nic list | grep <%=n.device%> | cut -d ' ' -f 1`
+    <% } %>
     <% if( undefined !== n.ipv4 ) { %>
       <% if( undefined !== n.ipv4.vlanIds ) { %>
         <% n.ipv4.vlanIds.forEach(function(vid) { %>
           <% vmkname = 'vmk' + vmkid++ %>
-          esxcli network vswitch standard portgroup add -p <%=n.device%>.<%=vid%> -v "<%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>"
+          esxcli network vswitch standard portgroup add -p $currdev.<%=vid%> -v "<%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>"
           esxcli network ip interface remove -i <%=vmkname%>
-          esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>.<%=vid%>
+          esxcli network ip interface add -i <%=vmkname%> -p $currdev.<%=vid%>
           esxcli network ip interface ipv4 set -i <%=vmkname%> -I <%=n.ipv4.ipAddr%> -N <%=n.ipv4.netmask%> -t static
           esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%>
-          esxcli network vswitch standard portgroup set -p <%=n.device%>.<%=vid%> -v <%=vid %>
+          esxcli network vswitch standard portgroup set -p $currdev.<%=vid%> -v <%=vid %>
           postLookup <%=vmkname%> <%=n.ipv4.ipAddr%>
         <% }); %>
       <% } else { %>
         <% vmkname = 'vmk' + vmkid++ %>
-        esxcli network vswitch standard portgroup add -p <%=n.device%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
+        esxcli network vswitch standard portgroup add -p $currdev -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
         esxcli network ip interface remove -i <%=vmkname%>
-        esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>
+        esxcli network ip interface add -i <%=vmkname%> -p $currdev
         esxcli network ip interface ipv4 set -i <%=vmkname%> -I <%=n.ipv4.ipAddr%> -N <%=n.ipv4.netmask%> -t static
         esxcli network ip route ipv4 add -n default -g <%=n.ipv4.gateway%>
         postLookup <%=vmkname%> <%=n.ipv4.ipAddr%>
@@ -175,25 +185,25 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
       <% if( undefined !== n.ipv6.vlanIds ) { %>
         <% n.ipv6.vlanIds.forEach(function(vid) { %>
           <% vmkname = 'vmk' + vmkid++ %>
-          esxcli network vswitch standard portgroup add -p <%=n.device%>.<%=vid%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
+          esxcli network vswitch standard portgroup add -p $currdev.<%=vid%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
           esxcli network ip interface remove -i <%=vmkname%>
-          esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>.<%=vid%>
+          esxcli network ip interface add -i <%=vmkname%> -p $currdev.<%=vid%>
           esxcli network ip interface ipv6 address add -i <%=vmkname%> -I <%=n.ipv6.ipAddr%>
-          esxcli network vswitch standard portgroup set -p <%=n.device%>.<%=vid%> -v <%=vid %>
+          esxcli network vswitch standard portgroup set -p $currdev.<%=vid%> -v <%=vid %>
         <% }); %>
       <% } else { %>
         <% vmkname = 'vmk' + vmkid++ %>
-        esxcli network vswitch standard portgroup add -p <%=n.device%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
+        esxcli network vswitch standard portgroup add -p $currdev -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
         esxcli network ip interface remove -i <%=vmkname%>
-        esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>
+        esxcli network ip interface add -i <%=vmkname%> -p $currdev
         esxcli network ip interface ipv6 address add -i <%=vmkname%> -I <%=n.ipv6.ipAddr%>
       <% } %>
     <% } %>
     <% if( (undefined === n.ipv6) && (undefined === n.ipv4) ) { %>
       <% vmkname = 'vmk' + vmkid++ %>
-      esxcli network vswitch standard portgroup add -p <%=n.device%> -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
+      esxcli network vswitch standard portgroup add -p $currdev -v <%= typeof n.esxSwitchName!='undefined' ? n.esxSwitchName : 'vSwitch0' %>
       esxcli network ip interface remove -i <%=vmkname%>
-      esxcli network ip interface add -i <%=vmkname%> -p <%=n.device%>
+      esxcli network ip interface add -i <%=vmkname%> -p $currdev
       esxcli network ip interface ipv4 set -i <%=vmkname%> -t dhcp
     <% } %>
   <% }); %>


### PR DESCRIPTION
1. Fix ODR-749 Use MAC addresses to create vSwitch uplinks in esx-ks
2. Use MAC addresses to specify the device under networkDevices

@RackHD/corecommitters @panpan0000 