### PR TITLE
Fix ODR787: defineTaskGraph only validate definition rather than creating whole graph instance

### DIFF
--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -129,6 +129,11 @@ function workflowApiServiceFactory(
             });
         })
         .catch(function(error) {
+            logger.error('createGraph fails', {
+                definition: definition,
+                options: options,
+                error: error
+            });
             if (!error.status) {
                 var badRequestError = new Errors.BadRequestError(error.message);
                 badRequestError.stack = error.stack;
@@ -181,12 +186,24 @@ function workflowApiServiceFactory(
 
     WorkflowApiService.prototype.defineTaskGraph = function(definition) {
         // Do validation before persisting a definition
-        return this.createGraph(definition)
+        return TaskGraph.validateDefinition(Constants.DefaultTaskDomain, { definition: definition })
         .then(function() {
             return taskGraphStore.persistGraphDefinition(definition);
         })
         .then(function(definition) {
             return definition.injectableName;
+        })
+        .catch(function(error) {
+            logger.error('defineTaskGraph fails', {
+                definition: definition,
+                error: error
+            });
+            if (!error.status) {
+                var badRequestError = new Errors.BadRequestError(error.message);
+                badRequestError.stack = error.stack;
+                throw badRequestError;
+            }
+            throw error;
         });
     };
 

--- a/spec/lib/services/workflow-api-service-spec.js
+++ b/spec/lib/services/workflow-api-service-spec.js
@@ -15,6 +15,7 @@ describe('Http.Services.Api.Workflows', function () {
     var workflowDefinition;
     var workflow;
     var Promise;
+    var TaskGraph;
 
     before('Http.Services.Api.Workflows before', function() {
         helper.setupInjector([
@@ -27,6 +28,7 @@ describe('Http.Services.Api.Workflows', function () {
         store = helper.injector.get('TaskGraph.Store');
         env = helper.injector.get('Services.Environment');
         Promise = helper.injector.get('Promise');
+        TaskGraph = helper.injector.get('TaskGraph.TaskGraph');
     });
 
     beforeEach(function() {
@@ -266,7 +268,8 @@ describe('Http.Services.Api.Workflows', function () {
                     context: { test: 2 },
                     domain: 'test'
                 }, 'testnodeid')
-            ).to.be.rejectedWith(Errors.BadRequestError, /Graph name is missing or in wrong format/);
+            ).to.be.rejectedWith(Errors.BadRequestError,
+                /Graph name is missing or in wrong format/);
         });
     });
 
@@ -310,13 +313,12 @@ describe('Http.Services.Api.Workflows', function () {
 
     it('should persist a graph definition', function () {
         store.persistGraphDefinition.resolves({ injectableName: 'test' });
-        this.sandbox.stub(workflowApiService, 'createGraph').resolves();
+        this.sandbox.stub(TaskGraph, 'validateDefinition').resolves();
         return workflowApiService.defineTaskGraph(graphDefinition)
         .then(function() {
             expect(store.persistGraphDefinition).to.have.been.calledOnce;
             expect(store.persistGraphDefinition).to.have.been.calledWith(graphDefinition);
-            expect(workflowApiService.createGraph).to.have.been.calledOnce;
-            expect(workflowApiService.createGraph).to.have.been.calledWith(graphDefinition);
+            expect(TaskGraph.validateDefinition).to.have.been.calledOnce;
         });
     });
 
@@ -330,8 +332,7 @@ describe('Http.Services.Api.Workflows', function () {
         };
 
         return expect(workflowApiService.defineTaskGraph(badDefinition))
-            .to.be.rejectedWith(Errors.BadRequestError,
-                /The task label \'duplicate\' is used more than once/);
+            .to.be.rejectedWith(Errors.BadRequestError, /duplicate/);
     });
 
     it('should throw a NotFoundError if a graph definition does not exist', function() {


### PR DESCRIPTION
This PR is to fix [ODR#787](https://hwjiraprd01.corp.emc.com/browse/ODR-787).

Previously the `defineTaskGraph` leverage creating graph instance to validate whether the graph definition is valid, but some required option may not be ready at  that time (for example when insert a SKU pack which contains some SKU specific graph). The change is to use the new API to validate the graph definition only, it will skip the task rendering and schema validation.

@RackHD/corecommitters @zyoung51 @iceiilin @pengz1 

Depends on: https://github.com/RackHD/on-tasks/pull/273