### PR TITLE
Create build script for task annotation generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p ./node_modules \
   && ln -s /RackHD/on-core ./node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && npm install --ignore-scripts --production \
-  && npm install apidoc && npm run apidoc \
+  && npm install apidoc && npm run apidoc && npm run taskdoc \
   && echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
   && apk add --update ipmitool@testing unzip \
   && /RackHD/on-http/install-web-ui.sh \

--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -18,6 +18,7 @@ rsync -ar ../debianstatic/on-http/ debian
 rm -rf node_modules
 npm install --cache=`pwd`
 npm run apidoc
+npm run taskdoc
 npm prune --production
 
 git log -n 1 --pretty=format:%h.%ai.%s > commitstring.txt

--- a/HWIMO-DOC
+++ b/HWIMO-DOC
@@ -8,4 +8,5 @@ set -x
 rm -rf node_modules
 npm install
 npm run apidoc
+npm run taskdoc
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ _Copyright 2015, EMC, Inc._
     rm -rf node_modules
     npm install
     npm run apidoc
+    npm run taskdoc
 
 ## Running
 

--- a/extra/make-docs.sh
+++ b/extra/make-docs.sh
@@ -5,3 +5,4 @@ SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 cd $SCRIPT_DIR/..
 
 npm run apidoc
+npm run taskdoc

--- a/install-task-doc.sh
+++ b/install-task-doc.sh
@@ -1,0 +1,18 @@
+# Copyright 2016, EMC, Inc.
+
+# Generate task doc from task schemas
+cd ./node_modules/on-tasks/
+node task-annotation-generator.js
+
+# Parse task doc data json to api_data.js so that it can be `require` by template
+echo 'define({"api":' > api_data.js
+cat task_doc_data.json | python -m json.tool >> api_data.js
+echo '});' >> api_data.js
+
+cd ../../
+# Copy templates from apidoc, taskdoc leverage apidoc templates for html rendering
+cp -rf ./node_modules/apidoc/template/* ./static/taskdoc/
+
+# Copy generated json file to ./static folder, override existing files
+mv -f ./node_modules/on-tasks/api_data.js ./static/taskdoc
+mv -f ./node_modules/on-tasks/task_doc_data.json ./static/taskdoc/api_data.json

--- a/install-task-doc.sh
+++ b/install-task-doc.sh
@@ -1,4 +1,10 @@
+#!/bin/bash
 # Copyright 2016, EMC, Inc.
+
+if [ ! -d './node_modules/on-tasks/' ]; then
+    echo 'on-tasks folder not found, please run npm install.'
+    exit 1
+fi
 
 # Generate task doc from task schemas
 cd ./node_modules/on-tasks/

--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -228,6 +228,9 @@ function httpServiceFactory(
         // UI Directory
         app.use('/ui', express.static('./static/web-ui'));
 
+        // Task-doc Directory
+        app.use('/taskdoc', express.static('./static/taskdoc/'));
+
         // Initialize authentication always
         app.use(authService.getPassportMidware());
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "./node_modules/.bin/jsdoc lib/api/1.1/northbound -r -d docs",
     "test": "./node_modules/.bin/mocha $(find spec -name '*-spec.js') -R spec --require spec/helper.js",
     "install": "./install-web-ui.sh && ./install-swagger-ui.sh",
-    "apidoc": "./node_modules/.bin/apidoc -i lib/api/1.1/northbound -f '.*\\.js$' -o build/apidoc"
+    "apidoc": "./node_modules/.bin/apidoc -i lib/api/1.1/northbound -f '.*\\.js$' -o build/apidoc",
+    "taskdoc": "./install-task-doc.sh"
   },
   "repository": {
     "type": "git",

--- a/static/taskdoc/api_project.js
+++ b/static/taskdoc/api_project.js
@@ -10,7 +10,5 @@ define({
   },
   "name": "RackHD Task Documentation",
   "title": "RackHD Task Documentation",
-  "url": "http://servername:8080",
-  "version": "0.0.0",
-  "sampleUrl": false
+  "version": "0.0.0"
 });

--- a/static/taskdoc/api_project.js
+++ b/static/taskdoc/api_project.js
@@ -1,0 +1,16 @@
+define({
+  "description": "RackHD Task Documentation",
+  "footer": {
+    "title": "Other Information",
+    "content": "<p>&copy;2016, EMC, Inc.</p>\n"
+  },
+  "header": {
+    "title": "About",
+    "content": "<p>For more information on how to use these tasks, please also see our development guide documentation at <a href=\"http://rackhd.readthedocs.org/en/latest/development_guide.html\">http://rackhd.readthedocs.org/en/latest/development_guide.html</a></p>\n<p>&copy;2016, EMC, Inc.</p>\n"
+  },
+  "name": "RackHD Task Documentation",
+  "title": "RackHD Task Documentation",
+  "url": "http://servername:8080",
+  "version": "0.0.0",
+  "sampleUrl": false
+});


### PR DESCRIPTION
This change is based on @cgx027 's updates.

- add static router `/taskdoc` to access the task doc
- create task doc build script `install-task-doc.sh`, leveraging tool script [task-annotation-generator](https://github.com/RackHD/on-tasks/blob/master/task-annotation-generator.js)
- add `npm run taskdoc` to existing build script

@RackHD/corecommitters @iceiilin @pengz1 