### PR TITLE
Add a wait time for the boilerplate ipxe to allow the links to come up

### DIFF
--- a/data/profiles/boilerplate.ipxe
+++ b/data/profiles/boilerplate.ipxe
@@ -32,6 +32,8 @@ iseq ${interface} ${net${ifIndex}/mac} && goto ifBoot || inc ifIndex && goto ifF
 :ifBoot
 iseq ${ifBootAttempt} ${ifBootAttemptMax} && goto ifBootFailure || goto ifBootContinue
 :ifBootContinue
+echo "sleeping to allow link up"
+sleep 10
 ifopen net${ifIndex}
 ifconf net${ifIndex} && goto ifConfigured || inc ifBootAttempt && goto ifBoot
 


### PR DESCRIPTION
This is a fix for ODR-786 "Onrack is failing to discover high node count"
For convenience i pasted the description of this ODR:
https://hwjiraprd01.corp.emc.com/browse/ODR-786

"When powering up 18 physical nodes only 5 of those nodes got discovered, 1 of those nodes got fully discovered but 4 of them were not and displayed the error message below. The problem seems to be around the discovery workflow, Onrack assigned an ID for the discovered node but it failed along the process causing major issues with the rest of the nodes trying to be discover. This is an intermittent issue as I can discover all the nodes too.
Below is the error message from one of the discovered nodes:
https://10.241.197.32/redfish/v1/Chassis/577bb2834f428e6e0b4b285f
Response Body
{ "status": 404, "message": "get not found (Could not find node with identifier 577bb2834f428e6e0b4b285f)" }
Debugging so far:
While having a clear database and checked that all onrack services are running, I have brought up each of the node up separately and make sure that it gets discovered properly prior to power up the next node. This has been succesfull.

While having a clear database and checked that all onrack services are running, brought up two to four nodes at a time and monitor the discovery process. sometime works.
While having a clear database and checked that all onrack services are running, brought up all the 18 nodes at a time. 3 out of 4 times it fails.
Same issue has been seen with a virtual environment.
Results URL: https://web.hwimo.lab.emc.com/qa/log/bug_logs/ODR-786"