### PR TITLE
Support obm related node event

### DIFF
--- a/lib/api/2.0/obms.js
+++ b/lib/api/2.0/obms.js
@@ -9,6 +9,7 @@ var nameSpace = '/api/2.0/obms/definitions/';
 var waterline = injector.get('Services.Waterline');
 var Errors = injector.get('Errors');
 var nodes = injector.get('Http.Services.Api.Nodes');
+var obmsService = injector.get('Http.Services.Api.Obms');
 var _ = injector.get('_'); // jshint ignore:line
 
 // GET /obms/definitions
@@ -45,13 +46,14 @@ var obmsGetById = controller(function(req) {
 
 // PATCH /api/2.0/obms/identifier
 var obmsPatchById = controller( function(req) {
-    return waterline.obms.updateByIdentifier(
+    return obmsService.updateObmById(
         req.swagger.params.identifier.value, req.swagger.params.body.value);
+
 });
 
 // DELETE /api/2.0/obms/identifier
 var obmsDeleteById = controller(function(req) {
-    return waterline.obms.destroyByIdentifier(req.swagger.params.identifier.value);
+    return obmsService.removeObmById(req.swagger.params.identifier.value);
 });
 
 // POST /api/2.0/obms/led

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -221,12 +221,7 @@ function nodeApiServiceFactory(
             ]);
         })
         .then(function () {
-            var alertData = {
-                nodeId : node.id,
-                nodeType: node.type,
-                state: "removed"
-            };
-            return eventsProtocol.publishNodeAlert(node.id, alertData);
+            return eventsProtocol.publishNodeEvent(node, 'removed');
         })
         .then(function () {
             logger.debug('node deleted', {id: node.id, type: node.type});
@@ -291,7 +286,7 @@ function nodeApiServiceFactory(
     };
 
     NodeApiService.prototype.getNodeById = function(id) {
-        return waterline.nodes.findOne({id: id}).populate('obms')
+        return waterline.nodes.getNodeById(id)
         .then(function (node){
             if (!node) {
                 throw new Errors.NotFoundError(

--- a/lib/services/obm-api-service.js
+++ b/lib/services/obm-api-service.js
@@ -8,15 +8,22 @@ module.exports = obmApiServiceFactory;
 di.annotate(obmApiServiceFactory, new di.Provide('Http.Services.Api.Obms'));
 di.annotate(obmApiServiceFactory,
     new di.Inject(
+        'Services.Waterline',
+        'Logger',
+        'Protocol.Events',
         'Promise',
         '_'
     )
 );
 function obmApiServiceFactory(
+    waterline,
+    Logger,
+    eventsProtocol,
     Promise,
     _
 
 ) {
+    var logger = Logger.initialize(obmApiServiceFactory);
 
     function ObmApiService() {
     }
@@ -223,6 +230,74 @@ function obmApiServiceFactory(
      */
     ObmApiService.prototype.getObmLibById = function(id) {
         return _.detect(obms, { service: id });
+    };
+
+    /**
+     * Update obm by identifier
+     * @param obmId     Obm identifier 
+     * @param values    Values to be updated
+     * @return {Promise}
+     */
+    ObmApiService.prototype.updateObmById = function(obmId, values) {
+        return waterline.obms.needByIdentifier(obmId)
+        .then(function(oldObm) {
+            /* Get nodes that need to publish events */
+            if (oldObm.node && !values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(oldObm.node)]);
+            } else if (!oldObm.node && values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(values.node)]);
+            } else if (oldObm.node && values.nodeId && oldObm.node === values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(oldObm.node)]);
+            } else if (oldObm.node && values.nodeId && oldObm.node !== values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(oldObm.node),
+                        waterline.nodes.getNodeById(values.nodeId)]);
+            }
+        })
+        .then(function(oldNodes) {
+            return waterline.obms.updateByIdentifier(obmId, values)
+            .tap(function() {
+                /* Publish events of nodes got beofre update */
+                _.forEach(oldNodes, function(oldNode) {
+                    if (oldNode) {
+                        /* asynchronous, don't wait promise return for performance*/
+                        return waterline.nodes.getNodeById(oldNode.id)
+                        .then(function(newNode) {
+                            return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'obms');
+                        })
+                        .catch(function (error) {
+                            logger.error('Error occurs', error);
+                        });
+                    }
+                });
+            });
+        });
+    };
+
+    /**
+     * Delete obm by identifier
+     * @param obmId     Obm identifier 
+     * @return {Promise}
+     */
+    ObmApiService.prototype.removeObmById = function(obmId) {
+        return waterline.obms.needByIdentifier(obmId)
+        .then(function (obm) {
+            return waterline.nodes.getNodeById(obm.node);
+        })
+        .then(function (oldNode) {
+            return waterline.obms.destroyByIdentifier(obmId)
+            .tap(function () {
+                if (oldNode) {
+                    /* asynchronous, don't wait promise return for performance*/
+                    waterline.nodes.getNodeById(oldNode.id)
+                    .then(function (newNode) {
+                        return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'obms');
+                    })
+                    .catch(function (error) {
+                        logger.error('Error occurs', error);
+                    });
+                }
+            });
+        });
     };
 
     return new ObmApiService();

--- a/spec/lib/api/2.0/obms-spec.js
+++ b/spec/lib/api/2.0/obms-spec.js
@@ -4,7 +4,7 @@
 'use strict';
 
 describe('Http.Api.Obms', function () {
-    var waterline, stub, Errors, nodeApiService;
+    var waterline, stub, Errors, nodeApiService, obmsApiService;
 
     var goodData = [
         {
@@ -56,6 +56,7 @@ describe('Http.Api.Obms', function () {
             waterline = helper.injector.get('Services.Waterline');
             Errors = helper.injector.get('Errors');
             nodeApiService = helper.injector.get('Http.Services.Api.Nodes');
+            obmsApiService = helper.injector.get('Http.Services.Api.Obms');
         });
     });
 
@@ -184,7 +185,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should patch an OBM instance', function () {
-            stub = sinon.stub(waterline.obms, 'updateByIdentifier').resolves(goodData[0]);
+            stub = sinon.stub(obmsApiService, 'updateObmById').resolves(goodData[0]);
 
             return helper.request().patch('/api/2.0/obms/123')
                 .send(goodData[0])
@@ -196,7 +197,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should 400 when patching with bad data', function () {
-            stub = sinon.stub(waterline.obms, 'updateByIdentifier');
+            stub = sinon.stub(obmsApiService, 'updateObmById');
 
             return helper.request().patch('/api/2.0/obms/123')
                 .send(badData1)
@@ -209,7 +210,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should delete an OBM instance', function () {
-            stub = sinon.stub(waterline.obms, 'destroyByIdentifier');
+            stub = sinon.stub(obmsApiService, 'removeObmById');
 
             return helper.request().delete('/api/2.0/obms/123')
                 .expect(200)

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -80,7 +80,7 @@ describe("Http.Services.Api.Nodes", function () {
         updateByIdentifier = this.sandbox.stub(waterline.nodes, 'updateByIdentifier');
         findActiveGraphForTarget = this.sandbox.stub(
                 workflowApiService, 'findActiveGraphForTarget');
-        this.sandbox.stub(eventsProtocol, 'publishNodeAlert').resolves({});
+        this.sandbox.stub(eventsProtocol, 'publishNodeEvent').resolves({});
 
     });
 
@@ -543,11 +543,8 @@ describe("Http.Services.Api.Nodes", function () {
                 expect(waterline.nodes.destroy).to.have.been.calledOnce;
                 expect(waterline.nodes.destroy).to.have.been
                     .calledWith({id: computeNodeBefore.id});
-                expect(eventsProtocol.publishNodeAlert)
-                    .to.have.been.calledWith(computeNodeBefore.id, {
-                        nodeId : computeNodeBefore.id,
-                        nodeType: computeNodeBefore.type,
-                        state: "removed"})
+                expect(eventsProtocol.publishNodeEvent)
+                    .to.have.been.calledWith(computeNodeBefore, "removed")
                     .to.have.been.calledOnce;
             });
         });
@@ -561,11 +558,8 @@ describe("Http.Services.Api.Nodes", function () {
                 expect(node).to.equal(computeNode);
                 expect(updateByIdentifier).to.not.have.been.called;
                 expect(waterline.nodes.destroy).to.have.been.calledOnce;
-                expect(eventsProtocol.publishNodeAlert)
-                    .to.have.been.calledWith(computeNode.id, {
-                        nodeId : computeNode.id,
-                        nodeType: computeNode.type,
-                        state: "removed"})
+                expect(eventsProtocol.publishNodeEvent)
+                    .to.have.been.calledWith(computeNode, "removed")
                     .to.have.been.calledOnce;
             });
         });
@@ -587,11 +581,8 @@ describe("Http.Services.Api.Nodes", function () {
                 expect(node).to.equal(noopNode);
                 expect(updateByIdentifier).to.not.have.been.called;
                 expect(waterline.nodes.destroy).to.have.been.calledOnce;
-                expect(eventsProtocol.publishNodeAlert)
-                    .to.have.been.calledWith(noopNode.id, {
-                        nodeId : noopNode.id,
-                        nodeType: noopNode.type,
-                        state: "removed"})
+                expect(eventsProtocol.publishNodeEvent)
+                    .to.have.been.calledWith(noopNode, "removed")
                     .to.have.been.calledOnce;
             });
         });
@@ -624,11 +615,8 @@ describe("Http.Services.Api.Nodes", function () {
                 expect(node).to.equal(computeNode);
                 expect(waterline.nodes.destroy).to.have.been.calledOnce;
                 expect(waterline.nodes.destroy).to.have.been.calledWith({id: computeNode.id});
-                expect(eventsProtocol.publishNodeAlert)
-                    .to.have.been.calledWith(computeNode.id, {
-                        nodeId : computeNode.id,
-                        nodeType: computeNode.type,
-                        state: "removed"})
+                expect(eventsProtocol.publishNodeEvent)
+                    .to.have.been.calledWith(computeNode, "removed")
                     .to.have.been.calledOnce;
             });
         });
@@ -664,11 +652,8 @@ describe("Http.Services.Api.Nodes", function () {
                 expect(waterline.nodes.destroy).to.have.been.calledWith({id: computeNode.id});
                 expect(waterline.nodes.destroy).to.have.been.calledWith({id: computeNode2.id});
                 expect(waterline.nodes.destroy).to.have.been.calledWith({id: enclosureNode.id});
-                expect(eventsProtocol.publishNodeAlert)
-                    .to.have.been.calledWith(enclosureNode.id, {
-                        nodeId : enclosureNode.id,
-                        nodeType: enclosureNode.type,
-                        state: "removed"})
+                expect(eventsProtocol.publishNodeEvent)
+                    .to.have.been.calledWith(enclosureNode, "removed")
                     .to.have.callCount(3);
             });
         });
@@ -721,11 +706,8 @@ describe("Http.Services.Api.Nodes", function () {
                 expect(updateByIdentifier).to.have.been
                     .calledWith(pduNode.id,
                                 {relations: pduNodeAfter.relations});
-                expect(eventsProtocol.publishNodeAlert)
-                    .to.have.been.calledWith(enclosureNode.id, {
-                        nodeId : enclosureNode.id,
-                        nodeType: enclosureNode.type,
-                        state: "removed"})
+                expect(eventsProtocol.publishNodeEvent)
+                    .to.have.been.calledWith(enclosureNode, "removed")
                     .to.have.callCount(3);
             });
         });
@@ -765,7 +747,7 @@ describe("Http.Services.Api.Nodes", function () {
                         ', active workflow is running');
                     expect(waterline.nodes.destroy).to.not.have.been.called;
                     expect(updateByIdentifier).to.not.have.been.called;
-                    expect(eventsProtocol.publishNodeAlert).to.not.have.been.called;
+                    expect(eventsProtocol.publishNodeEvent).to.not.have.been.called;
                     done();
                 } catch (e) {
                     done(e);

--- a/spec/lib/services/obm-api-service-spec.js
+++ b/spec/lib/services/obm-api-service-spec.js
@@ -6,6 +6,9 @@
 describe("Http.Services.Api.Obms", function () {
     var obmService;
     var Promise;
+    var waterline;
+    var eventsProtocol;
+
     before("Http.Services.Api.Obms before", function() {
         helper.setupInjector([
             helper.require("/lib/services/obm-api-service.js")
@@ -13,8 +16,27 @@ describe("Http.Services.Api.Obms", function () {
 
         Promise = helper.injector.get('Promise');
         obmService = helper.injector.get("Http.Services.Api.Obms");
+        waterline = helper.injector.get('Services.Waterline');
+        eventsProtocol = helper.injector.get('Protocol.Events');
 
+        waterline.nodes = {
+            getNodeById: function() {}
+        };
+        waterline.obms = {
+            needByIdentifier: function() {},
+            updateByIdentifier: function() {},
+            destroyByIdentifier: function() {}
+        };
     });
+
+    beforeEach(function() {
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        this.sandbox.restore();
+    });
+
 
     var mockObms = [
     {
@@ -228,4 +250,180 @@ describe("Http.Services.Api.Obms", function () {
         });
     });
 
+    describe("updateObmById", function() {
+        it('should publish one event if new node is added when updating obm', function () {
+            var oldObm = { id: '123', node: '' };
+            var newObm =  {
+                nodeId: '12345678',
+                service: 'ipmi-obm-service',
+                config: {
+                    host: '1.1.1.1',
+                    user: 'user',
+                    password: 'passw'
+                }
+            };
+            var oldNode = { id: 'node123', obms: [ ] };
+            var newNode = { id: 'node123', obms: [ { id: '123'} ] };
+            this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(oldObm);
+            this.sandbox.stub(waterline.obms, 'updateByIdentifier').resolves(newObm);
+            this.sandbox.stub(waterline.nodes, 'getNodeById').resolves();
+            this.sandbox.stub(eventsProtocol, 'publishNodeAttrEvent').resolves();
+            waterline.nodes.getNodeById.onCall(0).resolves(oldNode);
+            waterline.nodes.getNodeById.onCall(1).resolves(newNode);
+
+            return obmService.updateObmById('123', newObm)
+                .then(function () {
+//                    expect(waterline.obms.updateByIdentifier).to.have.been.called.once;
+                    expect(eventsProtocol.publishNodeAttrEvent).to.have.been.calledOnce;
+//                    expect(eventsProtocol.publishNodeAttrEvent).to.have.been
+ //                   .calledWith(oldNode, newNode, 'obms');
+                });
+        });
+
+        it('should publish one event if node is removed when updating obm', function () {
+            var oldObm = { id: '123', node: 'node1234' };
+            var newObm =  {
+                nodeId: '',
+                service: 'ipmi-obm-service',
+                config: {
+                    host: '1.1.1.1',
+                    user: 'user',
+                    password: 'passw'
+                }
+            };
+            var oldNode = { id: 'node123', obms: [ ] };
+            var newNode = { id: 'node123', obms: [ { id: '123'} ] };
+            this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(oldObm);
+            this.sandbox.stub(waterline.obms, 'updateByIdentifier').resolves(newObm);
+            this.sandbox.stub(waterline.nodes, 'getNodeById').resolves();
+            this.sandbox.stub(eventsProtocol, 'publishNodeAttrEvent').resolves();
+            waterline.nodes.getNodeById.onCall(0).resolves(oldNode);
+            waterline.nodes.getNodeById.onCall(1).resolves(newNode);
+
+            return obmService.updateObmById('123', newObm)
+                .then(function () {
+                    expect(waterline.obms.updateByIdentifier).to.have.been.called.once;
+                    expect(eventsProtocol.publishNodeAttrEvent).to.have.been
+                    .calledWith(oldNode, newNode, 'obms');
+                });
+        });
+
+        it('should publish one event if the same node is updated when updating obm', function () {
+            var oldObm = { id: '123', node: 'abcd' };
+            var newObm =  {
+                nodeId: 'abcd',
+                service: 'ipmi-obm-service',
+                config: {
+                    host: '1.1.1.1',
+                    user: 'user',
+                    password: 'passw'
+                }
+            };
+            var oldNode = { id: 'node123', obms: [ ] };
+            var newNode = { id: 'node123', obms: [ { id: '123'} ] };
+            this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(oldObm);
+            this.sandbox.stub(waterline.obms, 'updateByIdentifier').resolves(newObm);
+            this.sandbox.stub(waterline.nodes, 'getNodeById').resolves();
+            this.sandbox.stub(eventsProtocol, 'publishNodeAttrEvent').resolves();
+            waterline.nodes.getNodeById.onCall(0).resolves(oldNode);
+            waterline.nodes.getNodeById.onCall(1).resolves(newNode);
+
+            return obmService.updateObmById('123', newObm)
+                .then(function () {
+                    expect(waterline.obms.updateByIdentifier).to.have.been.called.once;
+                    expect(eventsProtocol.publishNodeAttrEvent).to.have.been
+                    .calledWith(oldNode, newNode, 'obms');
+                });
+        });
+
+        it('should publish two events if new node is updated when updating obm', function () {
+            var oldObm = { id: '123', node: 'abcd' };
+            var newObm =  {
+                nodeId: '1234',
+                service: 'ipmi-obm-service',
+                config: {
+                    host: '1.1.1.1',
+                    user: 'user',
+                    password: 'passw'
+                }
+            };
+            var oldNode = { id: 'node123', obms: [ ] };
+            var newNode = { id: 'node123', obms: [ { id: '123'} ] };
+            this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(oldObm);
+            this.sandbox.stub(waterline.obms, 'updateByIdentifier').resolves(newObm);
+            this.sandbox.stub(waterline.nodes, 'getNodeById').resolves();
+            this.sandbox.stub(eventsProtocol, 'publishNodeAttrEvent').resolves();
+            waterline.nodes.getNodeById.onCall(0).resolves(oldNode);
+            waterline.nodes.getNodeById.onCall(1).resolves(newNode);
+
+            return obmService.updateObmById('123', newObm)
+                .then(function () {
+                    expect(waterline.obms.updateByIdentifier).to.have.been.called.once;
+                    expect(eventsProtocol.publishNodeAttrEvent).to.have.been.calledTwice;
+                });
+        });
+
+        it('should publish no event if node is empty before and after updating obm', function () {
+            var oldObm = { id: '123', node: '' };
+            var newObm =  {
+                nodeId: '',
+                service: 'ipmi-obm-service',
+                config: {
+                    host: '1.1.1.1',
+                    user: 'user',
+                    password: 'passw'
+                }
+            };
+            var oldNode = { id: 'node123', obms: [ ] };
+            var newNode = { id: 'node123', obms: [ { id: '123'} ] };
+            this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(oldObm);
+            this.sandbox.stub(waterline.obms, 'updateByIdentifier').resolves(newObm);
+            this.sandbox.stub(waterline.nodes, 'getNodeById').resolves();
+            this.sandbox.stub(eventsProtocol, 'publishNodeAttrEvent').resolves();
+            waterline.nodes.getNodeById.onCall(0).resolves(oldNode);
+            waterline.nodes.getNodeById.onCall(1).resolves(newNode);
+
+            return obmService.updateObmById('123', newObm)
+                .then(function () {
+                    expect(waterline.obms.updateByIdentifier).to.have.been.called.once;
+                    expect(eventsProtocol.publishNodeAttrEvent).to.have.not.been.called;
+                });
+        });
+    });
+
+    describe("removeObmById", function() {
+        it('should delete an OBM instance and publish no event if no node exists in obm', function () {
+            var obm = { node: ''};
+            var oldNode = undefined;
+            this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(obm);
+            this.sandbox.stub(waterline.nodes, 'getNodeById').resolves(oldNode);
+            this.sandbox.stub(waterline.obms, 'destroyByIdentifier').resolves(obm);
+            this.sandbox.stub(eventsProtocol, 'publishNodeAttrEvent').resolves();
+
+            return obmService.removeObmById('123')
+                .then(function () {
+                    expect(waterline.obms.destroyByIdentifier).to.have.been.called.once;
+                    expect(eventsProtocol.publishNodeAttrEvent).to.have.not.been.called;
+                });
+        });
+
+        it('should delete an OBM instance and publish one event if node exists in obm', function () {
+            var obm = { node: '123'};
+            var oldNode = { id: '123', obms: [ ] };
+            var newNode = { id: '123', obms: [ { id: 'abc'} ] };
+            this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(obm);
+            this.sandbox.stub(waterline.nodes, 'getNodeById').resolves();
+            this.sandbox.stub(waterline.obms, 'destroyByIdentifier').resolves(obm);
+            this.sandbox.stub(eventsProtocol, 'publishNodeAttrEvent').resolves();
+            waterline.nodes.getNodeById.onCall(0).resolves(oldNode);
+            waterline.nodes.getNodeById.onCall(1).resolves(newNode);
+
+            return obmService.removeObmById('123')
+                .then(function () {
+                    expect(waterline.obms.destroyByIdentifier).to.have.been.called.once;
+                    expect(eventsProtocol.publishNodeAttrEvent).to.have.been
+                    .calledWith(oldNode, newNode, 'obms');
+                });
+        });
+    });
 });


### PR DESCRIPTION
require https://github.com/RackHD/on-core/pull/178 asynchronous publish event when operating obm by API, the PUT and other obm update is handled in upsertByNode in on-core https://github.com/RackHD/on-core/pull/178    docs: https://github.com/RackHD/docs/pull/296

@RackHD/corecommitters @zyoung51 @WangWinson 