### PR TITLE
Update readme with taskdoc url and unify the task annotation naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Note: requires MongoDB and RabbitMQ to be running to start correctly.
 
  * http://127.0.0.1/ui -- RackHD Web UI
  * http://127.0.0.1/docs -- RackHD Docs
+ * http://127.0.0.1/taskdoc -- RackHD Task Annotation
 
 ## Config
 

--- a/static/taskdoc/api_project.js
+++ b/static/taskdoc/api_project.js
@@ -1,5 +1,5 @@
 define({
-  "description": "RackHD Task Documentation",
+  "description": "RackHD Task Annotation",
   "footer": {
     "title": "Other Information",
     "content": "<p>&copy;2016, EMC, Inc.</p>\n"
@@ -8,7 +8,7 @@ define({
     "title": "About",
     "content": "<p>For more information on how to use these tasks, please also see our development guide documentation at <a href=\"http://rackhd.readthedocs.org/en/latest/development_guide.html\">http://rackhd.readthedocs.org/en/latest/development_guide.html</a></p>\n<p>&copy;2016, EMC, Inc.</p>\n"
   },
-  "name": "RackHD Task Documentation",
-  "title": "RackHD Task Documentation",
+  "name": "RackHD Task Annotation",
+  "title": "RackHD Task Annotation",
   "version": "0.0.0"
 });


### PR DESCRIPTION
- Add /taskdoc url to readme
- Unify naming 'RackHD Task Annotation'

@RackHD/corecommitters @cgx027 @iceiilin @pengz1 