### PR TITLE
incrementing debian version based on git commit

### DIFF
--- a/extra/make-deb.sh
+++ b/extra/make-deb.sh
@@ -13,11 +13,19 @@ else
    BRANCH=${TRAVIS_BRANCH}
 fi
 
+# this appends a datestring formatting specifically to be increasing
+# based on the last date of the commit in this branch to provide increasing
+# DCH version numbers for building debian packages for bintray.
+GITCOMMITDATE=$(git show -s --pretty="format:%ci")
+DATESTRING=$(date -d "$GITCOMMITDATE" -u +"%Y%m%d%H%M%SZ")
+
+BRANCH="${BRANCH}-${DATESTRING}"
+
 npm prune --production
 git clone --branch v2.1.5 https://github.com/swagger-api/swagger-codegen.git
 pushd ./swagger-codegen && mvn package && popd
 java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail.yml -o on-http-api1.1 -l python --additional-properties packageName=on_http_api1_1
-java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail-2.0.yaml -o on-http-api2.0 -l python --additional-properties packageName=on_http_api2_0 
+java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/monorail-2.0.yaml -o on-http-api2.0 -l python --additional-properties packageName=on_http_api2_0
 java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate -i static/redfish.yaml -o on-http-redfish-1.0 -l python --additional-properties packageName=on_http_redfish_1_0
 
 


### PR DESCRIPTION
partial resolution for RackHD/RackHD#310

Basically pulling the same scenario we used in https://github.com/RackHD/on-taskgraph/blob/master/HWIMO-BUILD to include an increasing version as we made additional builds on a branch. Date string is formatted to be increasing over time, and mapped (pretty closely) to the last commit merged into the branch.