### PR TITLE
Add southbound API to pass notification to RackHD (refer to ODR682)

### DIFF
--- a/data/templates/install-photon/photon-os-ks
+++ b/data/templates/install-photon/photon-os-ks
@@ -50,12 +50,12 @@
                     "#!/bin/sh",
 
                     "# Set the configuration",
-                    "/bin/curl http://<%=server%>:<%=port%>/api/common/templates/post-install-photon.sh > /tmp/post-install-photon.sh",
+                    "/bin/curl http://<%=server%>:<%=port%>/api/current/templates/post-install-photon.sh > /tmp/post-install-photon.sh",
                     "chmod +x /tmp/post-install-photon.sh",
                     "./tmp/post-install-photon.sh 2>&1 > /root/post-install-photon.log",
 
                     "# Download the service to callback to RackHD after OS installation/reboot completion",
-                    "/bin/curl http://<%=server%>:<%=port%>/api/common/templates/<%=rackhdCallbackScript%> > /etc/<%=rackhdCallbackScript%>",
+                    "/bin/curl http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%> > /etc/<%=rackhdCallbackScript%>",
                     "chmod +x /etc/<%=rackhdCallbackScript%>",
 
                     "# Generate the service file",
@@ -73,6 +73,6 @@
                     "sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config",
 
                     "# Signify ORA the installation completed",
-                    "curl http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>"
+                    "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=identifier%>&type=osInstall&data=finished'"
                    ]
 }

--- a/data/templates/install-photon/photon-os-ks
+++ b/data/templates/install-photon/photon-os-ks
@@ -73,6 +73,6 @@
                     "sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config",
 
                     "# Signify ORA the installation completed",
-                    "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=identifier%>&type=osInstall&data=finished'"
+                    "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%>/api/current/notification?taskId=<%=taskid%>&data=finished'"
                    ]
 }

--- a/lib/api/1.1/southbound/notification.js
+++ b/lib/api/1.1/southbound/notification.js
@@ -11,7 +11,7 @@ di.annotate(notificationRouterFactory, new di.Provide('Http.Api.Internal.Notific
 di.annotate(notificationRouterFactory,
     new di.Inject(
         'Http.Services.RestApi',
-		'Http.Services.Api.Notification',
+        'Http.Services.Api.Notification',
         '_'
 	)
 );

--- a/lib/api/1.1/southbound/notification.js
+++ b/lib/api/1.1/southbound/notification.js
@@ -32,8 +32,8 @@ function notificationRouterFactory (
      */
 
     router.post('/notification/', rest(function (req) {
-        var configuration = _.defaults(req.query || {}, req.body || {});
-        return notificationApiService.postNotification(configuration);
+        var message = _.defaults(req.query || {}, req.body || {});
+        return notificationApiService.postNotification(message);
     }, {renderOptions: {success: 201}}));
 
     return router;

--- a/lib/api/1.1/southbound/notification.js
+++ b/lib/api/1.1/southbound/notification.js
@@ -1,0 +1,40 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di'),
+    express = require('express');
+
+module.exports = notificationRouterFactory;
+
+di.annotate(notificationRouterFactory, new di.Provide('Http.Api.Internal.Notification'));
+di.annotate(notificationRouterFactory,
+    new di.Inject(
+        'Http.Services.RestApi',
+		'Http.Services.Api.Notification',
+        '_'
+	)
+);
+
+function notificationRouterFactory (
+    rest,
+    notificationApiService,
+    _
+) {
+    var router = express.Router();
+
+    /**
+     * @api {post} /api/1.1/notification
+     * @apiVersion 1.1.0
+     * @apiDescription post a notification from node
+     * @apiName notification-post
+     * @apiGroup notification
+     */
+
+    router.post('/notification/', rest(function (req) {
+        var configuration = _.defaults(req.query || {}, req.body || {});
+        return notificationApiService.postNotification(configuration);
+    }, {renderOptions: {success: 201}}));
+
+    return router;
+}

--- a/lib/api/1.1/southbound/router.js
+++ b/lib/api/1.1/southbound/router.js
@@ -25,6 +25,7 @@ function internalApiFactory (injector) {
         router.use(injector.get(require('./files')));
         router.use(injector.get(require('./tasks')));
         router.use(injector.get(require('./templates')));
+        router.use(injector.get(require('./notification')));
         router.use(injector.get(require('../northbound/lookups')));
     };
 

--- a/lib/api/1.1/southbound/templates.js
+++ b/lib/api/1.1/southbound/templates.js
@@ -10,12 +10,12 @@ module.exports = templatesRouterFactory;
 di.annotate(templatesRouterFactory, new di.Provide('Http.Api.Internal.Templates'));
 di.annotate(templatesRouterFactory,
     new di.Inject(
-		'Services.Waterline',
-		'Http.Services.Api.Workflows',
-		'Protocol.Task',
-		'Services.Lookup',
-		'Promise',
-		'common-api-presenter',
+	    'Services.Waterline',
+	    'Http.Services.Api.Workflows',
+	    'Protocol.Task',
+	    'Services.Lookup',
+	    'Promise',
+	    'common-api-presenter',
         '_'
 	)
 );
@@ -43,7 +43,6 @@ function templatesRouterFactory (
     router.get('/templates/:identifier',
                lookupService.ipAddressToMacAddressMiddleware(),
                function (req, res) {
-        var nodeId = '';
         if (!req.macaddress) {
             return presenter(req, res)
                 .renderError(new Error("Unable to look up the relevant node from " +
@@ -51,7 +50,6 @@ function templatesRouterFactory (
         }
         waterline.nodes.findByIdentifier(req.macaddress).then(function (node) {
             if (node) {
-                nodeId = node.id;
                 return workflowApiService.findActiveGraphForTarget(node.id)
                     .then(function(taskGraphInstance) {
                         if (taskGraphInstance) {
@@ -74,7 +72,7 @@ function templatesRouterFactory (
             presenter(req, res)
                 .renderTemplate(
                     req.params.identifier,
-                    _.merge(properties.options, {identifier: nodeId}),
+                    properties.options,
                     200,
                     properties.context
                 );

--- a/lib/api/1.1/southbound/templates.js
+++ b/lib/api/1.1/southbound/templates.js
@@ -51,7 +51,6 @@ function templatesRouterFactory (
         }
         waterline.nodes.findByIdentifier(req.macaddress).then(function (node) {
             if (node) {
-                console.log("--------------------Ted:node", node);
                 nodeId = node.id;
                 return workflowApiService.findActiveGraphForTarget(node.id)
                     .then(function(taskGraphInstance) {

--- a/lib/api/1.1/southbound/templates.js
+++ b/lib/api/1.1/southbound/templates.js
@@ -15,8 +15,7 @@ di.annotate(templatesRouterFactory,
 	    'Protocol.Task',
 	    'Services.Lookup',
 	    'Promise',
-	    'common-api-presenter',
-        '_'
+	    'common-api-presenter'
 	)
 );
 
@@ -26,8 +25,7 @@ function templatesRouterFactory (
     taskProtocol,
     lookupService,
     Promise,
-    presenter,
-    _
+    presenter
 ) {
     var router = express.Router();
 

--- a/lib/api/1.1/southbound/templates.js
+++ b/lib/api/1.1/southbound/templates.js
@@ -15,7 +15,8 @@ di.annotate(templatesRouterFactory,
 		'Protocol.Task',
 		'Services.Lookup',
 		'Promise',
-		'common-api-presenter'
+		'common-api-presenter',
+        '_'
 	)
 );
 
@@ -25,7 +26,8 @@ function templatesRouterFactory (
     taskProtocol,
     lookupService,
     Promise,
-    presenter
+    presenter,
+    _
 ) {
     var router = express.Router();
 
@@ -41,6 +43,7 @@ function templatesRouterFactory (
     router.get('/templates/:identifier',
                lookupService.ipAddressToMacAddressMiddleware(),
                function (req, res) {
+        var nodeId = '';
         if (!req.macaddress) {
             return presenter(req, res)
                 .renderError(new Error("Unable to look up the relevant node from " +
@@ -48,6 +51,8 @@ function templatesRouterFactory (
         }
         waterline.nodes.findByIdentifier(req.macaddress).then(function (node) {
             if (node) {
+                console.log("--------------------Ted:node", node);
+                nodeId = node.id;
                 return workflowApiService.findActiveGraphForTarget(node.id)
                     .then(function(taskGraphInstance) {
                         if (taskGraphInstance) {
@@ -70,7 +75,7 @@ function templatesRouterFactory (
             presenter(req, res)
                 .renderTemplate(
                     req.params.identifier,
-                    properties.options,
+                    _.merge(properties.options, {identifier: nodeId}),
                     200,
                     properties.context
                 );

--- a/lib/api/2.0/notification.js
+++ b/lib/api/2.0/notification.js
@@ -1,0 +1,17 @@
+// Copyright 2016, EMC Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var notificationApiService = injector.get('Http.Services.Api.Notification');
+var _ = injector.get('_');    // jshint ignore:line
+
+var notificationPost = controller({success: 201}, function(req) {
+    var configuration = _.defaults(req.swagger.query || {}, req.body || {});
+    return notificationApiService.postNotification(configuration);
+});
+
+module.exports = {
+    notificationPost: notificationPost
+};

--- a/lib/api/2.0/notification.js
+++ b/lib/api/2.0/notification.js
@@ -8,8 +8,8 @@ var notificationApiService = injector.get('Http.Services.Api.Notification');
 var _ = injector.get('_');    // jshint ignore:line
 
 var notificationPost = controller({success: 201}, function(req) {
-    var configuration = _.defaults(req.swagger.query || {}, req.body || {});
-    return notificationApiService.postNotification(configuration);
+    var message = _.defaults(req.swagger.query || {}, req.body || {});
+    return notificationApiService.postNotification(message);
 });
 
 module.exports = {

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -20,7 +20,8 @@ di.annotate(CommonApiPresenterFactory,
         'Profiles',
         'Templates',
         '_',
-        'Services.Environment'
+        'Services.Environment',
+        'Protocol.Task'
     )
 );
 
@@ -41,7 +42,8 @@ function CommonApiPresenterFactory(
     profiles,
     templates,
     _,
-    Env
+    Env,
+    taskProtocol
 ) {
     var logger = Logger.initialize(CommonApiPresenterFactory);
 
@@ -264,8 +266,18 @@ function CommonApiPresenterFactory(
             context: graphContext,
             task: {
                 nodeId: graphContext.target
-            }
+            },
+            taskid: _getActiveTaskId(graphContext.target)
         });
+    };
+
+    function _getActiveTaskId(nodeId) {
+        if (nodeId) {
+            return taskProtocol.activeTaskExists(nodeId)
+                .then(function (activeTask) {
+                    return activeTask.taskId;
+                })
+        }
     };
 
     presenter.use = function serializer(name, func) {

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -1,0 +1,76 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = notificationApiServiceFactory;
+di.annotate(notificationApiServiceFactory, new di.Provide('Http.Services.Api.Notification'));
+di.annotate(notificationApiServiceFactory,
+    new di.Inject(
+        'Protocol.Events',
+        'Protocol.Task',
+        'TaskGraph.Store',
+        'Logger',
+        'Errors',
+        'Promise',
+        '_'
+    )
+);
+
+function notificationApiServiceFactory(
+    eventsProtocol,
+    taskProtocol,
+    taskGraphStore,
+    Logger,
+    Errors,
+    Promise,
+    _
+) {
+    var logger = Logger.initialize(notificationApiServiceFactory);
+
+    function notificationApiService() {
+    }
+
+    notificationApiService.prototype.postNotification = function(configuration) {
+        var self = this;
+        return Promise.try(function() {
+            if (!configuration.nodeId || !_.isString(configuration.nodeId)) {
+                throw new Errors.BadRequestError('Missing node ID in query');
+            };
+            if (!configuration.type || !_.isString(configuration.type)) {
+                throw new Errors.BadRequestError('Missing notification type in query');
+            };
+            if (!configuration.data || !_.isString(configuration.data)) {
+                throw new Errors.BadRequestError('Missing notification data in query');
+            }            
+        })
+        .then(function() {
+            var nodeId = configuration.nodeId;
+            return [
+                taskGraphStore.findActiveGraphForTarget(nodeId),
+                taskProtocol.activeTaskExists(nodeId)
+            ]
+        })
+        .spread(function (activeGraph, activeTask) {
+            if (!activeGraph) {
+                throw new Error("No active task graph.");
+            }
+            if (!activeTask) {
+                throw new Error("No active task.");
+            }
+            console.log("-------Ted: find active graph", activeGraph);
+            console.log("-------Ted: find active task", activeTask);
+
+            return eventsProtocol.publishTaskNotification(
+                configuration.nodeId,
+                activeTask.taskId,
+                activeGraph.instanceId,
+                configuration.type,
+                configuration.data
+                )
+        });
+    };
+
+    return new notificationApiService();
+}

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -41,7 +41,7 @@ function notificationApiServiceFactory(
             if (!message.taskId || !_.isString(message.taskId)) {
                 throw new Errors.BadRequestError('Missing task ID in query or body');
             };
-            if (!message.data || !_.isString(message.data)) {
+            if (!message.data || !(_.isString(message.data) || _.isObject(message.data))) {
                 throw new Errors.BadRequestError('Missing notification data in query or body');
             }            
         })

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -36,56 +36,24 @@ function notificationApiServiceFactory(
 
     notificationApiService.prototype.postNotification = function(message) {
         var self = this;
-        var activeTaskId, activeGraphId;
-        var nodeId;
 
         return Promise.try(function() {
-            if (!message.nodeId || !_.isString(message.nodeId)) {
-                throw new Errors.BadRequestError('Missing node ID in query or body');
-            };
-            if (!message.type || !_.isString(message.type)) {
-                throw new Errors.BadRequestError('Missing notification type in query or body');
+            if (!message.taskId || !_.isString(message.taskId)) {
+                throw new Errors.BadRequestError('Missing task ID in query or body');
             };
             if (!message.data || !_.isString(message.data)) {
                 throw new Errors.BadRequestError('Missing notification data in query or body');
             }            
         })
-        .then(function() {
-            nodeId = message.nodeId;
-            // Check if the node exists
-            return waterline.nodes.needByIdentifier(nodeId)
-        })
         .then(function () {
-            return [
-                taskGraphStore.findActiveGraphForTarget(nodeId),
-                taskProtocol.activeTaskExists(nodeId)
-            ]
-        })
-        .spread(function (activeGraph, activeTask) {
-            if (!activeGraph) {
-                throw new Error("No active task graph.");
-            }
-            if (!activeTask) {
-                throw new Error("No active task.");
-            }
-
-            activeTaskId = activeTask.taskId;
-            activeGraphId = activeGraph.instanceId;
-
             return eventsProtocol.publishTaskNotification(
-                nodeId,
-                activeTaskId,
-                activeGraphId,
-                message.type,
+                message.taskId,
                 message.data
-                )
+            );
         })
         .then(function () {
             return {
-                node: nodeId,
-                activeTask: activeTaskId,
-                activeGraph: activeGraphId,
-                type: message.type,
+                taskId: message.taskId,
                 data: message.data
             }
         });

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -34,24 +34,25 @@ function notificationApiServiceFactory(
     function notificationApiService() {
     }
 
-    notificationApiService.prototype.postNotification = function(configuration) {
+    notificationApiService.prototype.postNotification = function(message) {
         var self = this;
         var activeTaskId, activeGraphId;
         var nodeId;
 
         return Promise.try(function() {
-            if (!configuration.nodeId || !_.isString(configuration.nodeId)) {
+            if (!message.nodeId || !_.isString(message.nodeId)) {
                 throw new Errors.BadRequestError('Missing node ID in query or body');
             };
-            if (!configuration.type || !_.isString(configuration.type)) {
+            if (!message.type || !_.isString(message.type)) {
                 throw new Errors.BadRequestError('Missing notification type in query or body');
             };
-            if (!configuration.data || !_.isString(configuration.data)) {
+            if (!message.data || !_.isString(message.data)) {
                 throw new Errors.BadRequestError('Missing notification data in query or body');
             }            
         })
         .then(function() {
-            nodeId = configuration.nodeId;
+            nodeId = message.nodeId;
+            // Check if the node exists
             return waterline.nodes.needByIdentifier(nodeId)
         })
         .then(function () {
@@ -75,8 +76,8 @@ function notificationApiServiceFactory(
                 nodeId,
                 activeTaskId,
                 activeGraphId,
-                configuration.type,
-                configuration.data
+                message.type,
+                message.data
                 )
         })
         .then(function () {
@@ -84,8 +85,8 @@ function notificationApiServiceFactory(
                 node: nodeId,
                 activeTask: activeTaskId,
                 activeGraph: activeGraphId,
-                type: configuration.type,
-                data: configuration.data
+                type: message.type,
+                data: message.data
             }
         });
     };

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -12,6 +12,7 @@ di.annotate(notificationApiServiceFactory,
         'Protocol.Task',
         'TaskGraph.Store',
         'Logger',
+        'Services.Waterline',
         'Errors',
         'Promise',
         '_'
@@ -23,6 +24,7 @@ function notificationApiServiceFactory(
     taskProtocol,
     taskGraphStore,
     Logger,
+    waterline,
     Errors,
     Promise,
     _
@@ -34,19 +36,25 @@ function notificationApiServiceFactory(
 
     notificationApiService.prototype.postNotification = function(configuration) {
         var self = this;
+        var activeTaskId, activeGraphId;
+        var nodeId;
+
         return Promise.try(function() {
             if (!configuration.nodeId || !_.isString(configuration.nodeId)) {
-                throw new Errors.BadRequestError('Missing node ID in query');
+                throw new Errors.BadRequestError('Missing node ID in query or body');
             };
             if (!configuration.type || !_.isString(configuration.type)) {
-                throw new Errors.BadRequestError('Missing notification type in query');
+                throw new Errors.BadRequestError('Missing notification type in query or body');
             };
             if (!configuration.data || !_.isString(configuration.data)) {
-                throw new Errors.BadRequestError('Missing notification data in query');
+                throw new Errors.BadRequestError('Missing notification data in query or body');
             }            
         })
         .then(function() {
-            var nodeId = configuration.nodeId;
+            nodeId = configuration.nodeId;
+            return waterline.nodes.needByIdentifier(nodeId)
+        })
+        .then(function () {
             return [
                 taskGraphStore.findActiveGraphForTarget(nodeId),
                 taskProtocol.activeTaskExists(nodeId)
@@ -59,16 +67,26 @@ function notificationApiServiceFactory(
             if (!activeTask) {
                 throw new Error("No active task.");
             }
-            console.log("-------Ted: find active graph", activeGraph);
-            console.log("-------Ted: find active task", activeTask);
+
+            activeTaskId = activeTask.taskId;
+            activeGraphId = activeGraph.instanceId;
 
             return eventsProtocol.publishTaskNotification(
-                configuration.nodeId,
-                activeTask.taskId,
-                activeGraph.instanceId,
+                nodeId,
+                activeTaskId,
+                activeGraphId,
                 configuration.type,
                 configuration.data
                 )
+        })
+        .then(function () {
+            return {
+                node: nodeId,
+                activeTask: activeTaskId,
+                activeGraph: activeGraphId,
+                type: configuration.type,
+                data: configuration.data
+            }
         });
     };
 

--- a/spec/lib/api/1.1/notification-spec.js
+++ b/spec/lib/api/1.1/notification-spec.js
@@ -1,0 +1,55 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('Http.Api.Notification', function () {
+    var notificationApiService;
+
+    var notificationMessage = {
+        taskId: '1234abcd5678effe9012dcba',
+        data: 'dummy data'
+    };
+
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        return helper.startServer([]);
+    });
+
+    beforeEach('set up mocks', function () {
+        notificationApiService = helper.injector.get('Http.Services.Api.Notification');
+        sinon.stub(notificationApiService, 'postNotification').resolves(notificationMessage);
+    });
+
+    afterEach('teardown mocks', function () {
+        function resetMocks(obj) {
+            _(obj).methods().forEach(function (method) {
+                if (typeof obj[method].restore === 'function') {
+                    obj[method].restore();
+                }
+            }).value();
+        }
+        resetMocks(notificationApiService);
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    describe('POST /notification', function () {
+        it('should return notification detail', function () {
+            return helper.request()
+            .post(
+                '/api/1.1/notification?taskId='
+                + notificationMessage.taskId 
+                + '&data='
+                + notificationMessage.data)
+            .set('Content-Type', 'application/json')
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, notificationMessage)
+            .then(function () {
+                expect(notificationApiService.postNotification).to.have.been.calledOnce;
+                expect(notificationApiService.postNotification).to.have.been.calledWith(notificationMessage);
+            });
+        });
+    });
+});

--- a/spec/lib/api/2.0/notification-spec.js
+++ b/spec/lib/api/2.0/notification-spec.js
@@ -1,0 +1,55 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('Http.Api.Notification', function () {
+    var notificationApiService;
+
+    var notificationMessage = {
+        taskId: '1234abcd5678effe9012dcba',
+        data: 'dummy data'
+    };
+
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        return helper.startServer([]);
+    });
+
+    beforeEach('set up mocks', function () {
+        notificationApiService = helper.injector.get('Http.Services.Api.Notification');
+        sinon.stub(notificationApiService, 'postNotification').resolves(notificationMessage);
+    });
+
+    afterEach('teardown mocks', function () {
+        function resetMocks(obj) {
+            _(obj).methods().forEach(function (method) {
+                if (typeof obj[method].restore === 'function') {
+                    obj[method].restore();
+                }
+            }).value();
+        }
+        resetMocks(notificationApiService);
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    describe('POST /notification', function () {
+        it('should return notification detail', function () {
+            return helper.request()
+            .post(
+                '/api/2.0/notification?taskId='
+                + notificationMessage.taskId 
+                + '&data='
+                + notificationMessage.data)
+            .set('Content-Type', 'application/json')
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, notificationMessage)
+            .then(function () {
+                expect(notificationApiService.postNotification).to.have.been.calledOnce;
+                expect(notificationApiService.postNotification).to.have.been.calledWith(notificationMessage);
+            });
+        });
+    });
+});

--- a/spec/lib/services/notification-api-service-spec.js
+++ b/spec/lib/services/notification-api-service-spec.js
@@ -1,0 +1,121 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('Http.Api.Notification', function () {
+    var notificationApiService;
+    var taskProtocol;
+
+    var notificationMessage = {
+        taskId: "73b8ca01-735b-40d6-897a-7003ef2fa988",
+        data: 'dummy data'
+    };
+
+     var activeTask = {
+         taskId: notificationMessage.taskId,
+     }
+
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        return helper.startServer([]);
+    });
+
+    beforeEach('set up mocks', function () {
+        notificationApiService = helper.injector.get('Http.Services.Api.Notification');
+        taskProtocol = helper.injector.get('Protocol.Task');
+
+        sinon.stub(taskProtocol, 'activeTaskExists').resolves(activeTask);
+    });
+
+    afterEach('teardown mocks', function () {
+        function resetMocks(obj) {
+            _(obj).methods().forEach(function (method) {
+                if (typeof obj[method].restore === 'function') {
+                    obj[method].restore();
+                }
+            }).value();
+        }
+        resetMocks(taskProtocol);
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+
+    describe('POST /notification', function () {
+        it('should return notification detail', function () {
+            return helper.request()
+            .post(
+                '/api/current/notification?taskId='
+                + notificationMessage.taskId 
+                + '&data='
+                + notificationMessage.data)
+            .set('Content-Type', 'application/json')
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, notificationMessage)
+        });
+
+        it('should fail with no taskId in query parameter', function () {
+            return helper.request()
+            .post(
+                '/api/current/notification?'
+                + 'data='
+                + notificationMessage.data)
+            .set('Content-Type', 'application/json')
+            .expect('Content-Type', /^application\/json/)
+            .expect(400, { message: 'Missing task ID in query or body' })
+        });
+
+        it('should fail with no data in query parameter', function () {
+            return helper.request()
+            .post(
+                '/api/current/notification?taskId='
+                + notificationMessage.taskId)
+            .set('Content-Type', 'application/json')
+            .expect('Content-Type', /^application\/json/)
+            .expect(400, { message: 'Missing notification data in query or body' })
+        });
+
+        it('should fail with invalid task ID in query parameter', function () {
+            return helper.request()
+            .post(
+                '/api/current/notification?taskId='
+                + 'I_am_not_a_valid_task_id'
+                + '&data='
+                + notificationMessage.data)
+            .set('Content-Type', 'application/json')
+            .expect('Content-Type', /^application\/json/)
+            .expect(400, { message: 'Invalid taskId, uuid expected' })
+        });
+
+        it('should pass with taskId in query body', function () {
+            return helper.request()
+            .post('/api/current/notification?data=' + notificationMessage.data)
+            .send({taskId: notificationMessage.taskId})
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, notificationMessage)
+        });
+
+        it('should pass with data in query body', function () {
+            return helper.request()
+            .post('/api/current/notification?taskId=' + notificationMessage.taskId)
+            .send({data: notificationMessage.data})
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, notificationMessage)
+        });
+
+        it('should pass with data as an object in query body', function () {
+            var mockDataObj = {
+                taskId: notificationMessage.taskId,
+                data: { type: "I_am_the_type", data: "I_am_the_data"} 
+            }
+            return helper.request()
+            .post('/api/current/notification?taskId=' + notificationMessage.taskId)
+            .send(mockDataObj)
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, mockDataObj)
+        });
+
+    });
+
+});

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -127,16 +127,10 @@ paths:
       description: |
         post a notification
       parameters:
-        - name: nodeId
+        - name: taskId
           in: query
           description: |
             node identifier
-          required: false
-          type: string
-        - name: type
-          in: query
-          description: |
-            notification type
           required: false
           type: string
         - name: data

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -118,7 +118,54 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-
+  /notification:
+    x-swagger-router-controller: notification
+    post:
+      operationId: notificationPost
+      summary: |
+        post a notification
+      description: |
+        post a notification
+      parameters:
+        - name: nodeId
+          in: query
+          description: |
+            node identifier
+          required: false
+          type: string
+        - name: type
+          in: query
+          description: |
+            notification type
+          required: false
+          type: string
+        - name: data
+          in: query
+          description: |
+            node identifier
+          required: false
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        201:
+          description: |
+            Specifics of the notification
+          schema:
+            type: object
+        400:
+          description: |
+            bad request parameter passed or no active task or taskgraph.
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: |
+            Node not found.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
   /swagger:
     x-swagger-pipe: swagger_raw

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -130,14 +130,14 @@ paths:
         - name: taskId
           in: query
           description: |
-            node identifier
-          required: false
+            task instance identifier
+          required: true
           type: string
         - name: data
           in: query
           description: |
-            node identifier
-          required: false
+            notification data
+          required: true
           type: string
       tags: [ "/api/2.0" ]
       responses:
@@ -149,11 +149,6 @@ paths:
         400:
           description: |
             bad request parameter passed or no active task or taskgraph.
-          schema:
-            $ref: '#/definitions/Error'
-        404:
-          description: |
-            Node not found.
           schema:
             $ref: '#/definitions/Error'
         default:


### PR DESCRIPTION
/notification API defined to replace ```completionUri``` used by os installation, with benifit of not depending to lookup entry, refer to ODR682.

In this PR:
* POST /notification southbound API is defined, used by node to signaling os install finish. 
* Both API 1.1 and API 2.0 compatible.
* Photon OS kickstart file modified to make use of the new notification mechanism.
 

This PR depends on following PRs:
* https://github.com/RackHD/on-core/pull/184 
* https://github.com/RackHD/on-tasks/pull/284
