### PR TITLE
Add redfish-obm-service schema and fix node view

### DIFF
--- a/data/views/node.2.0.json
+++ b/data/views/node.2.0.json
@@ -32,10 +32,12 @@
         <% } else { %>
         "info": <%- JSON.stringify(value.info) %>,
         <% } %>
+        "targets": [
         <% value.targets.forEach(function ( item, i, arr){ %>
-            "targets": "<%=basepath %>/nodes/<%=item %>"
+            "<%=item %>" 
         <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
         <% }); %>
+        ]
     }
     <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
     <% }); %>

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -83,7 +83,7 @@ describe('2.0 Http.Api.Nodes', function () {
 
     var relations =[{
         relationType: "enclosedBy",
-        targets: ["5678abcd5678abcd5678abcd"]
+        targets: [ "5678abcd5678abcd5678abcd" ]
     }];
 
     var node = {
@@ -97,7 +97,7 @@ describe('2.0 Http.Api.Nodes', function () {
         relations:[{
             relationType: 'enclosedBy',
             info: null,
-            targets: '/api/2.0/nodes/5678abcd5678abcd5678abcd'
+            targets: [ '5678abcd5678abcd5678abcd' ]
         }],
         obms: [{
             service: 'noop-obm-service',

--- a/static/schemas/obms/redfish-obm-service.json
+++ b/static/schemas/obms/redfish-obm-service.json
@@ -1,0 +1,57 @@
+{
+    "title": "redfish-obm-service",
+    "definitions": {
+        "Obm": {
+            "description": "Redfish OBM settings",
+            "type": "object",
+            "properties": {
+                "nodeId": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "description": "Redfish address",
+                            "type": "string"
+                        },
+                        "user": {
+                            "description": "Redfish username",
+                            "type": "string"
+                        },
+                        "password": {
+                            "description": "Redfish password",
+                            "type": "string"
+                        },
+                        "verfiySSL": {
+                            "description": "Validate SSL/TLS certs on client request",
+                            "type": "boolean"
+                        },
+                        "protocol": {
+                            "description": "Request protocol",
+                            "type": "string",
+                            "enum": ["http", "https"]
+                        },
+                        "port": {
+                            "description": "Optional http(s) host port, default 80/443",
+                            "type": "string"
+                        },
+                        "root": {
+                            "description": "The Redfish resources target path",
+                            "type": "string"
+                        },
+                        "uri": {
+                            "description": "The Redfish endpoint address",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["host", "user", "password", "root", "uri", "protocol"]
+                }
+            },
+            "required": ["nodeId", "service", "config"]
+        }
+    }
+}


### PR DESCRIPTION
- Create Redfish OBM service schema file.
- Fix nodes view template to handle a target list type.

@RackHD/corecommitters @zyoung51 @tannoa2 @uppalk1 @keedya @BillyAbildgaard @srinia6 @dalebremner @geoff-reid

@brianparry @srinia6: One of the changes below changes the relation target value.  Not all relationship values could be a reference to another resource,  for example Redfish endpoint relations:
```
       "targets": [
          "ComputeElement0",
          "StorageElement1"
        ],
        "relationType": "elementEndpoints"
      }
``` 

Was the intention to make all properties a reference link?