### PR TITLE
add vlan support for windows install

### DIFF
--- a/data/templates/post-windows-install.ps1
+++ b/data/templates/post-windows-install.ps1
@@ -1,0 +1,49 @@
+curl http://<%=server%>:<%=port%>/templates/unattend_server2012.xml -Outfile unattend_server2012.xml
+
+$vlanEntries = Get-Content -Path C:\temp\unattend_server2012.xml  | Where-Object {$_ -like "*VLan*"}
+$vlansArray = New-Object System.Collections.ArrayList
+
+#Removing the 'VLAN::ID" tag from the unattend_server2012.xml file
+foreach ($vlanEntry in $vlanEntries)
+	{
+		$line= $vlanEntry | out-String
+		$cleanedline= $line.split("::")
+		$vlanItem= $cleanedline[2]
+		$vlansArray.add($vlanItem)
+		$vlansArray
+
+	}
+$ethPort
+$tempArray
+
+foreach ($entry in $vlansArray)
+	{
+
+		$tempArray= $entry.split(",")#The first element of the tempArray is the name of the Ethernet port, the second element is the value of the VLAND ID to be assigned to the Ethernet port
+		$ethPort = $tempArray[0]
+		Get-NetAdapterAdvancedProperty $ethPort -RegistryKeyword "VlanID"
+		If($? -eq "0") #Make sure that VLAN is supported  on a the specified Ethernet port
+
+			{
+				Write-Host "Vlan is supported on" $ethPort "Ethernet port"
+				[string]$vlanValue = $tempArray[1]
+				$vlanValue =$vlanValue -replace "`t|`n|`r","" #remove the carriage returns
+				IF($vlanValue -le 4096)
+					{
+						Set-NetAdapterAdvancedProperty $ethPort -RegistryKeyword "VlanID" -DisplayValue $vlanValue
+					}
+				Else
+					{
+						Write-Host "Vlan value should with the 0-4096 range"
+					}
+			}
+		Else
+			{
+				Write-Host "Vlan is NOT supported on" $ethPort "Ethernet port"
+			}
+
+	}
+
+
+#crul the renasar-ansible.pub to indicate that windows install workflow has completed
+curl http://<%=server%>:<%=port%>/api/2.0/templates/renasar-ansible.pub -Outfile renasar-ansible.pub

--- a/data/templates/unattend_server2012.xml
+++ b/data/templates/unattend_server2012.xml
@@ -109,14 +109,14 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>2</Order>
-                    <CommandLine>powershell -Command "curl http://<%=server%>:<%=port%>/api/2.0/templates/post-windows-install.ps1" -Outfile post-windows-install.ps1 </CommandLine>
-                    <Description>flag the end of the setup</Description>
+                    <CommandLine>powershell -Command "curl http://<%=server%>:<%=port%>/api/1.1/templates/post-windows-install.ps1" -Outfile post-windows-install.ps1 </CommandLine>
+                    <Description>setup any the VLAN IDs and trigger the end of the install workflow</Description>
                     <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>3</Order>
                     <CommandLine>powershell -ExecutionPolicy ByPass -File post-windows-install.ps1</CommandLine>
-                    <Description>flag the end of the setup</Description>
+                    <Description>run the script</Description>
                     <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
@@ -164,13 +164,7 @@
             <% gateWay  =n.ipv4.gateway %>
             <% } %>
 
-            <% if( undefined != n.ipv4.vlanIds ) { %>
-            <!--
-            VLanID::<%=n.device%>,<%=n.ipv4.vlanIds%>
-             -->
-            <% } %>
-
-            <% } %>
+           <% } %>
 
 
             <% if( undefined != n.ipv6 ) { %>

--- a/data/templates/unattend_server2012.xml
+++ b/data/templates/unattend_server2012.xml
@@ -109,7 +109,13 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>2</Order>
-                    <CommandLine>powershell -Command "curl http://<%=server%>:<%=port%>/api/2.0/templates/renasar-ansible.pub"</CommandLine>
+                    <CommandLine>powershell -Command "curl http://<%=server%>:<%=port%>/api/2.0/templates/post-windows-install.ps1" -Outfile post-windows-install.ps1 </CommandLine>
+                    <Description>flag the end of the setup</Description>
+                    <RequiresUserInput>false</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <CommandLine>powershell -ExecutionPolicy ByPass -File post-windows-install.ps1</CommandLine>
                     <Description>flag the end of the setup</Description>
                     <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
@@ -156,6 +162,12 @@
 
             <% if( undefined != n.ipv4.gateway ) { %>
             <% gateWay  =n.ipv4.gateway %>
+            <% } %>
+
+            <% if( undefined != n.ipv4.vlanIds ) { %>
+            <!--
+            VLanID::<%=n.device%>,<%=n.ipv4.vlanIds%>
+             -->
             <% } %>
 
             <% } %>


### PR DESCRIPTION
The post-windows-install.ps1 script runs after Windows OS is installed.
The script would first curl unattend_server2012.xml and then look for the vlan values that are in the xml file in a form of comments. 


Below is and example of the vlan value 104 assigned to to port "Ethernet 1"
<!--
 VLanID::Ethernet 1,104,105
-->
