### PR TITLE
YAML return code corrections

### DIFF
--- a/lib/api/2.0/files.js
+++ b/lib/api/2.0/files.js
@@ -11,7 +11,7 @@ var filesGet = controller(function(req, res) {
     return fileService.getFile(req, res, req.swagger.params.fileidentifier.value);
 });
 
-var filesPut = controller(function(req) {
+var filesPut = controller({success: 201}, function(req) {
     return fileService.putFile(req, req.swagger.params.fileidentifier.value);
 });
 

--- a/lib/api/2.0/lookups.js
+++ b/lib/api/2.0/lookups.js
@@ -88,7 +88,7 @@ var lookupsPatchById = controller(function(req) {
  *       "error": "Not Found"
  *      }
  */
-var lookupsDelById = controller(function (req) {
+var lookupsDelById = controller({success: 204}, function (req) {
     return waterline.lookups.destroyOneById(req.swagger.params.id.value);
 });
 

--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -26,7 +26,7 @@ var nodesPatchById = controller(function(req) {
     return nodes.patchNodeById(req.swagger.params.identifier.value, req.body);
 });
 
-var nodesDelById = controller(function(req) {
+var nodesDelById = controller({success: 204}, function(req) {
     return nodes.delNodeById(req.swagger.params.identifier.value);
 });
 
@@ -106,7 +106,7 @@ var nodesGetTagsById = controller(function(req) {
     return nodes.getTagsById(req.swagger.params.identifier.value);
 });
 
-var nodesDelTagById = controller(function(req) {
+var nodesDelTagById = controller({success: 204}, function(req) {
     return nodes.removeTagsById(req.swagger.params.identifier.value,
                                 req.swagger.params.tagName.value);
 });
@@ -116,7 +116,7 @@ var nodesPatchTagById = controller(function(req) {
                              req.body.tags);
 });
 
-var nodesMasterDelTagById = controller(function(req) {
+var nodesMasterDelTagById = controller({success: 204}, function(req) {
     return nodes.masterDelTagById(req.swagger.params.tagName.value);
 });
 

--- a/lib/api/2.0/obms.js
+++ b/lib/api/2.0/obms.js
@@ -52,12 +52,12 @@ var obmsPatchById = controller( function(req) {
 });
 
 // DELETE /api/2.0/obms/identifier
-var obmsDeleteById = controller(function(req) {
+var obmsDeleteById = controller({success: 204}, function(req) {
     return obmsService.removeObmById(req.swagger.params.identifier.value);
 });
 
 // POST /api/2.0/obms/led
-var obmsPostLed = controller(function(req) {
+var obmsPostLed = controller({success: 201}, function(req) {
     if (_.has(req, 'swagger.params.body.value.nodeId')) {
         var nodeId = req.swagger.params.body.value.nodeId;
         delete req.swagger.params.body.value.nodeId;

--- a/lib/api/2.0/profiles.js
+++ b/lib/api/2.0/profiles.js
@@ -26,7 +26,7 @@ var profilesGetLibByName  = controller(function(req) {
 });
 
 // PUT /api/2.0/profiles/library/:name
-var profilesPutLibByName  = controller({success: 201},function(req) {
+var profilesPutLibByName  = controller({success: 201}, function(req) {
     return profiles.put(req.swagger.params.name.value, req, req.swagger.query.scope);
 });
 
@@ -48,7 +48,7 @@ var profilesGetSwitchVendor = controller(function(req, res) {
 });
 
 // POST /api/2.0/profiles/switch/error/
-var profilesPostSwitchError = controller(function(req) {
+var profilesPostSwitchError = controller({success: 201}, function(req) {
     return profilesApiService.postProfilesSwitchError(req.body);
 });
 

--- a/lib/api/2.0/skus.js
+++ b/lib/api/2.0/skus.js
@@ -74,7 +74,7 @@ var skusPost = controller({success: 201}, function(req) {
  * @apiGroup skus
  * @apiError E_VALIDATION attributes are invalid.
  */
-var skusPut = controller(function(req) {
+var skusPut = controller({success: 201}, function(req) {
     return   skuPack.upsertSku(req.swagger.params.body.value);
 });
 
@@ -122,7 +122,7 @@ var skusPatch = controller( function (req) {
  *       "error": "error message"
  *     }
  */
-var skusIdPutPack = controller(function (req,res) {
+var skusIdPutPack = controller({success: 201}, function (req,res) {
     return   skuPack.putPackBySkuId(req,res);
 });
 
@@ -140,7 +140,7 @@ var skusIdPutPack = controller(function (req,res) {
  *       "error": "Not Found"
  *     }
  */
-var skusIdDeletePack = controller(function (req) {
+var skusIdDeletePack = controller({success: 204}, function (req) {
     return  skuPack.deleteSkuPackById(req.swagger.params.identifier.value);
 });
 
@@ -158,7 +158,7 @@ var skusIdDeletePack = controller(function (req) {
  *       "error": "Not Found"
  *     }
  */
-var skusIdDelete = controller({success: 200}, function (req) {
+var skusIdDelete = controller({success: 204}, function (req) {
     return   skuPack.deleteSkuById(req.swagger.params.identifier.value);
 });
 

--- a/lib/api/2.0/templates.js
+++ b/lib/api/2.0/templates.js
@@ -67,7 +67,7 @@ var templatesLibGet = controller(function(req) {
 });
 
 // PUT /templates/library/:name
-var templatesLibPut = controller(function(req) {
+var templatesLibPut = controller({success: 201}, function(req) {
     return templates.put(req.swagger.params.name.value,
                          req,
                          req.swagger.query.scope);

--- a/lib/api/2.0/users.js
+++ b/lib/api/2.0/users.js
@@ -81,7 +81,7 @@ var getUser = controller(function(req) {
     return accountService.getUserByName(name);
 });
 
-var removeUser = controller(function(req) {
+var removeUser = controller({success: 204}, function(req) {
     var name = req.swagger.params.name.value;
     return accountService.removeUserByName(name);
 });

--- a/lib/api/2.0/views.js
+++ b/lib/api/2.0/views.js
@@ -54,7 +54,7 @@ var viewsGetById = controller(function(req) {
 * @apiSuccess {json} created or updated view.
 * @apiError Error was encountered, view is unchanged.
 */
-var viewsPut = controller(function(req, res) {
+var viewsPut = controller({success: 201}, function(req, res) {
     return views.put(req.swagger.params.identifier.value, req);
 });
 

--- a/lib/api/2.0/workflowGraphs.js
+++ b/lib/api/2.0/workflowGraphs.js
@@ -55,7 +55,7 @@ var workflowsPutGraphs = controller({success: 201},function(req) {
 * @apiSuccess Graph deleted
 * @apiGroup workflowGraphs
 */
-var workflowsDeleteGraphsByName = controller(function(req) {
+var workflowsDeleteGraphsByName = controller({success: 204}, function(req) {
     return workflowApiService.destroyGraphDefinition(req.swagger.params.injectableName.value); 
 });
 

--- a/lib/api/2.0/workflowTasks.js
+++ b/lib/api/2.0/workflowTasks.js
@@ -59,7 +59,7 @@ var workflowsGetTasksByName = controller(function(req) {
 * @apiSuccess {string} Task deleted
 */
 
-var workflowsDeleteTasksByName = controller({success: 200}, function(req) {
+var workflowsDeleteTasksByName = controller({success: 204}, function(req) {
     return workflowApiService.deleteWorkflowsTasksByName(req.swagger.params.injectableName.value);
 });
 

--- a/lib/api/2.0/workflows.js
+++ b/lib/api/2.0/workflows.js
@@ -69,7 +69,7 @@ var workflowsGetByInstanceId = controller(function(req) {
 * @apiSuccess {json}  object.
 * @apiError NotFound There is no workflow with <code>instanceId</code>
 */
-var workflowsAction = controller(function(req) {
+var workflowsAction = controller({success: 202}, function(req) {
     var command = req.body.command;
 
     var actionFunctions = {
@@ -97,7 +97,7 @@ var workflowsAction = controller(function(req) {
 * @apiError NotFound The node with the identifier was not found <code>instanceId</code>
 */
 
-var workflowsDeleteByInstanceId = controller(function(req) {
+var workflowsDeleteByInstanceId = controller({success: 204}, function(req) {
     return workflowApiService.deleteTaskGraph(req.swagger.params.identifier.value);
 });
 

--- a/spec/lib/api/2.0/files-spec.js
+++ b/spec/lib/api/2.0/files-spec.js
@@ -22,7 +22,7 @@ describe('Http.Api.Internal.Files', function () {
             return helper.request().put('/api/2.0/files/mockfile')
                 .set('Content-Type', 'application/octet-stream')
                 .send('hello')
-                .expect(200)
+                .expect(201)
                 .expect(function (res) {
                     uuid = res.body.uuid;
                 });
@@ -68,7 +68,7 @@ describe('Http.Api.Internal.Files', function () {
             return helper.request().put('/api/2.0/files/mockfile')
                 .set('Content-Type', 'application/octet-stream')
                 .send('PUT /files works!')
-                .expect(200)
+                .expect(201)
                 .expect(function (res) {
                     newUuid = res.body.uuid;
                     expect(newUuid).to.equal(uuid);

--- a/spec/lib/api/2.0/lookups-spec.js
+++ b/spec/lib/api/2.0/lookups-spec.js
@@ -163,8 +163,7 @@ describe('Http.Api.Lookup 2.0', function () {
         describe('DELETE', function () {
             it('should call waterline.lookups.destroyOneById with 123', function() {
                 return helper.request().delete('/api/2.0/lookups/123')
-                    .expect('Content-Type', /^application\/json/)
-                    .expect(200)
+                    .expect(204)
                     .expect(function () {
                         expect(destroyOneById).to.have.been.calledWith('123');
                     });

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -220,8 +220,7 @@ describe('2.0 Http.Api.Nodes', function () {
             nodeApiService.removeNode.resolves(node);
 
             return helper.request().delete('/api/2.0/nodes/1234')
-                .expect('Content-Type', /^application\/json/)
-                .expect(200, node)
+                .expect(204)
                 .expect(function () {
                     expect(nodeApiService.removeNode).to.have.been.calledOnce;
                 });
@@ -696,8 +695,7 @@ describe('2.0 Http.Api.Nodes', function () {
 
         it('should call removeTagsById', function() {
             return helper.request().delete('/api/2.0/nodes/123/tags/name')
-                .expect('Content-Type', /^application\/json/)
-                .expect(200)
+                .expect(204)
                 .expect(function() {
                     expect(nodesApi.removeTagsById).to.have.been.calledWith('123', 'name');
                 });
@@ -705,12 +703,9 @@ describe('2.0 Http.Api.Nodes', function () {
 
         it('should call masterDelTagById', function() {
             return helper.request().delete('/api/2.0/nodes/tags/name')
-                .expect('Content-Type', /^application\/json/)
-                .expect(200)
+                .expect(204)
                 .expect(function(res) {
                     expect(nodesApi.masterDelTagById).to.have.been.calledWith('name');
-                    expect(res.body).to.deep.equal
-                    (['1234abcd1234abcd1234abcd','5678efgh5678efgh5678efgh']);
                 });
         });
     });

--- a/spec/lib/api/2.0/obms-spec.js
+++ b/spec/lib/api/2.0/obms-spec.js
@@ -239,7 +239,7 @@ describe('Http.Api.Obms', function () {
             stub = sinon.stub(obmsApiService, 'removeObmById');
 
             return helper.request().delete('/api/2.0/obms/123')
-                .expect(200)
+                .expect(204)
                 .expect(function () {
                     expect(stub).to.have.been.called.once;
                 });
@@ -252,7 +252,7 @@ describe('Http.Api.Obms', function () {
 
             return helper.request().post('/api/2.0/obms/led')
                 .send(goodLedData)
-                .expect(200)
+                .expect(201)
                 .expect(function () {
                     expect(stub).to.have.been.called.once;
                 });

--- a/spec/lib/api/2.0/skus-spec.js
+++ b/spec/lib/api/2.0/skus-spec.js
@@ -154,11 +154,11 @@ describe('Http.Api.Skus.2.0', function() {
                 });
         });
 
-        it('should 200 reputting the same sku', function() {
+        it('should 201 reputting the same sku', function() {
             skuApiService.upsertSku.resolves(input);
             return helper.request().put('/api/2.0/skus')
                 .send(input)
-                .expect(200)
+                .expect(201)
                 .then(function () {
                     expect(skuApiService.upsertSku).to.have.been.called;
                 });
@@ -222,7 +222,7 @@ describe('Http.Api.Skus.2.0', function() {
             beforeEach('DELETE /skus/:id', function () {
                 skuApiService.deleteSkuById.resolves();
                 return helper.request().delete('/api/2.0/skus/' + sku.id)
-                    .expect(200)
+                    .expect(204)
                     .then(function () {
                         expect(skuApiService.deleteSkuById).to.have.been.called;
                     });

--- a/spec/lib/api/2.0/templates-spec.js
+++ b/spec/lib/api/2.0/templates-spec.js
@@ -156,7 +156,7 @@ describe('Http.Api.Templates', function () {
         it('should PUT new mockfile', function () {
             return helper.request().put('/api/2.0/templates/library/testTemplate')
                 .send('test\n')
-                .expect(200)
+                .expect(201)
                 .expect(function(){
                     expect(templates.put).to.have.been.calledOnce;
                     expect(templates.put).to.have.been.calledWith('testTemplate');

--- a/spec/lib/api/2.0/users-spec.js
+++ b/spec/lib/api/2.0/users-spec.js
@@ -246,7 +246,7 @@ describe('Http.Api.Users', function () {
             });
     });
 
-    it('should 200 a user delete with auth tokens', function() {
+    it('should 204 a user delete with auth tokens', function() {
         accountService.removeUserByName.resolves({username: 'admin'});
         return helper.request().post('/login')
             .send({username: "admin", password: "admin123"})
@@ -256,8 +256,7 @@ describe('Http.Api.Users', function () {
             }).then(function(token) {
                 return helper.request().delete('/api/2.0/users/admin')
                     .set("authorization", 'JWT ' + token)
-                    .expect('Content-Type', /^application\/json/)
-                    .expect(200)
+                    .expect(204)
                     .then(function() {
                         expect(accountService.removeUserByName).to.have.been.calledWith('admin');
                     });

--- a/spec/lib/api/2.0/views-spec.js
+++ b/spec/lib/api/2.0/views-spec.js
@@ -130,7 +130,7 @@ describe('Http.Api.Views', function () {
                 .set('Content-Type', 'text/plain')
                 .send('{ "message": "hello" }')
                 .expect('Content-Type', /^application\/json/)
-                .expect(200)
+                .expect(201)
                 .expect(function(res) {
                     expect(res.body).to.deep.equal(view);
                     expect(viewsProtocol.put).to.have.been.calledOnce;
@@ -144,7 +144,7 @@ describe('Http.Api.Views', function () {
             return helper.request().put('/api/2.0/views/foo')
                 .set('Content-Type', 'application/octet-stream')
                 .send('{ "message": "hello" }')
-                .expect(200)
+                .expect(201)
                 .expect(function(res) {
                     expect(res.get('Content-Type')).to.match(/^application\/json/);
                     expect(res.body).to.deep.equal(view);

--- a/spec/lib/api/2.0/workflowGraphs-spec.js
+++ b/spec/lib/api/2.0/workflowGraphs-spec.js
@@ -80,8 +80,7 @@ describe('Http.Api.Workflows.2.0', function () {
             workflowApiService.destroyGraphDefinition.resolves(graph);
 
             return helper.request().delete('/api/2.0/workflows/graphs/' + graph.name)
-            .expect('Content-Type', /^application\/json/)
-            .expect(200, graph)
+            .expect(204)
             .expect(function() {
                 expect(workflowApiService.destroyGraphDefinition).to.have.been.calledOnce;
                 expect(workflowApiService.destroyGraphDefinition)

--- a/spec/lib/api/2.0/workflowTasks-spec.js
+++ b/spec/lib/api/2.0/workflowTasks-spec.js
@@ -176,7 +176,7 @@ describe('Http.Api.workflowTasks.2.0', function () {
 
         it('should delete the Task with DELETE /workflows/tasks/injectableName', function () {
             return helper.request().delete('/api/2.0/workflows/tasks/'+ workflowTask.injectableName)
-                .expect(200);
+                .expect(204);
         });
     });
 });

--- a/spec/lib/api/2.0/workflows-spec.js
+++ b/spec/lib/api/2.0/workflows-spec.js
@@ -152,7 +152,7 @@ describe('Http.Api.Workflows.2.0', function () {
             return helper.request().put('/api/2.0/workflows/56e6ef601c3a31638be765fc/action')
                 .set('Content-Type', 'application/json')
                 .send(action)
-                .expect(200)
+                .expect(202)
                 .expect(function() {
                     expect(workflowApiService.cancelTaskGraph).to.have.been.calledOnce;
                     expect(workflowApiService.cancelTaskGraph)
@@ -175,7 +175,7 @@ describe('Http.Api.Workflows.2.0', function () {
 
         it('should delete the Task with DELETE /workflows/id', function () {
             return helper.request().delete('/api/2.0/workflows/'+ workflow.id)
-                .expect(200)
+                .expect(204)
                 .expect(function() {
                     expect(workflowApiService.deleteTaskGraph).to.have.been.calledOnce;
                     expect(workflowApiService.deleteTaskGraph)

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -121,7 +121,7 @@ paths:
          $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Poller created successfully
           schema:
@@ -261,6 +261,11 @@ paths:
             Successfully retrieved poller data
           schema:
             type: object
+        204:
+          description: |
+            Successfully processed the request and did not return any data
+          schema:
+            type: object
         404:
           description: |
             Poller with specified identifier was not found
@@ -293,6 +298,11 @@ paths:
         200:
           description: |
             Successfully retrieved poller data
+          schema:
+            type: object
+        204:
+          description: |
+            Successfully processed the request and did not return any data
           schema:
             type: object
         404:
@@ -437,7 +447,7 @@ paths:
         - application/x-www-form-urlencoded
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully created the template
           schema:
@@ -600,9 +610,9 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
-            Successfully retrieved the specified template
+            Successfully created the specified template
           schema:
             type: object
     delete:
@@ -652,7 +662,7 @@ paths:
         set of files to a node during provisioning.
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
              Successfully created the SKU Pack
           schema:
@@ -709,7 +719,7 @@ paths:
                   $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully created the SKU
           schema:
@@ -742,7 +752,7 @@ paths:
             $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully created or updated SKU definition
           schema:
@@ -917,7 +927,7 @@ paths:
       consumes:
         - application/x-www-form-urlencoded
       responses:
-        200:
+        201:
           description: |
             Successfully created the SKU Pack
           schema:
@@ -950,7 +960,7 @@ paths:
       consumes:
         - application/x-www-form-urlencoded
       responses:
-        200:
+        204:
           description: |
             Successfully deleted the specified SKU Pack
           schema:
@@ -1029,7 +1039,7 @@ paths:
                   $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully posted the switch error
           schema:
@@ -1201,7 +1211,7 @@ paths:
         - application/x-www-form-urlencoded
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully put the specified profile
           schema:
@@ -1268,7 +1278,7 @@ paths:
             $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully put the OBM service
           schema:
@@ -1450,7 +1460,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: |
             Successfully deleted the specified OBM settings
           schema:
@@ -1503,7 +1513,7 @@ paths:
             $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully updated workflow task
           schema:
@@ -1563,7 +1573,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: |
             Successfully deleted the specified task
           schema:
@@ -1616,7 +1626,7 @@ paths:
             $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully updated workflow graph
           schema:
@@ -1676,7 +1686,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: |
             Successfully deleted the specified workflow graph
           schema:
@@ -1804,7 +1814,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: |
             Successfully deleted the specified workflow
           schema:
@@ -1846,7 +1856,7 @@ paths:
             $ref: '#/definitions/action'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        202:
           description: |
             Successfully performed the action on the specified workflow
           schema:
@@ -1889,7 +1899,7 @@ paths:
             $ref: '#/definitions/action'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        202:
           description: |
             Successfully performed the action on the specified workflow
           schema:
@@ -1981,7 +1991,7 @@ paths:
 
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully started the specified workflow
           schema:
@@ -2194,7 +2204,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: Successfully deleted tags
         404:
           description: The tag name identifier was not found
@@ -2250,7 +2260,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: Successfully deleted the node
         404:
           description: The specified node was not found
@@ -2505,7 +2515,7 @@ paths:
          $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: Successfully created new lookup
           schema:
             type: object
@@ -2558,7 +2568,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: Successfully deleted lookup
         404:
           description: The specified lookup was not found
@@ -2672,7 +2682,7 @@ paths:
         - application/octet-stream
         - application/x-www-form-urlencoded
       responses:
-        200:
+        201:
           description: Successfully stored file
           schema:
             type: string
@@ -3267,7 +3277,7 @@ paths:
           type: string
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        204:
           description: |
             Successfully deleted the specified user
         401:
@@ -3416,7 +3426,7 @@ paths:
             $ref: '#/definitions/generic_obj'
       tags: [ "/api/2.0" ]
       responses:
-        200:
+        201:
           description: |
             Successfully posted the specified task
           schema:


### PR DESCRIPTION
Update YAML to reflect correct return codes. Also, make the return code consistent across the API's as follows:
GETs/PATCH - 200
PUT/POST - 201
DELETE - 204 [No content]
With an exception of PUT - /workflows/{identifier}/action, /nodes/{identifier}/workflows/action and POST /tags/{tagName}/nodes/workflows that returns a 202.

 ALL unit-tests pass locally as this PR has unit-test updates as well.

@benbp @keedya @BillyAbildgaard @brianparry @dalebremner @RackHD/corecommitters @zyoung51 @jlongever 