### PR TITLE
updating on-http README w/ link to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 __`on-http` is the HTTP server for RackHD__
 
-_Copyright 2015, EMC, Inc._
+_Copyright 2015-2016, EMC, Inc._
 
 ## Installation
 
@@ -20,6 +20,14 @@ Note: requires MongoDB and RabbitMQ to be running to start correctly.
  * http://127.0.0.1/ui -- RackHD Web UI
  * http://127.0.0.1/docs -- RackHD Docs
  * http://127.0.0.1/taskdoc -- RackHD Task Annotation
+
+## API Reference
+
+ *http://rackhd.readthedocs.io/en/latest/rackhd/index.html
+
+The readthedocs shows API usage for 1.1 by default. Unless otherwise specified
+you can use `/api/2.0/` in place of `/api/1.1/` to leverage the 2.0 API. Any functional
+differences will be listed below the 1.1 API examples.
 
 ## Config
 


### PR DESCRIPTION
added link to readthedocs and explanation showing you can substitute api/1.1 for api/2.0 unless otherwise specified.

@RackHD/corecommitters @keedya @srinia6 