### PR TITLE
Add  profile and templates for the dockerized discovery task

### DIFF
--- a/data/profiles/rancherOS.ipxe
+++ b/data/profiles/rancherOS.ipxe
@@ -1,0 +1,4 @@
+kernel <%=kernelUri%>
+initrd <%=initrdUri%>
+imgargs <%=kernelFile%> initrd=<%=initrdFile%> console=tty0 rancher.password=root rancher.cloud_init.datasources=['url:http://<%=server%>:<%=port%>/api/common/templates/cloud-config.yaml']
+boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/templates/cloud-config.yaml
+++ b/data/templates/cloud-config.yaml
@@ -1,0 +1,35 @@
+#cloud-config
+write_files:
+  - path: /etc/rc.local
+    permissions: "0755"
+    owner: root
+    content: |
+      #!/bin/bash
+      modprobe ipmi_devintf
+      wget -O /tmp/micro.tar.xz <%= api.server %>/common/discovery.docker.tar.xz
+      while [ $(docker images | grep -c micro) == "0" ]; do
+         xz -cd /tmp/micro.tar.xz | docker load
+      done
+      docker run -it -d \
+          -e SERVER='<%= server %>' \
+          -e PORT='<%= port %>' \
+          -e MAC='<%= macaddress %>' \
+          --privileged --net=host rackhd/micro
+
+      mapfile -t containerlist < <(docker ps)
+      container=(${containerlist[1]//$'\n'/ })
+      docker wait $container
+      case $? in
+        1 )
+            echo 1 | sudo tee /proc/sys/kernel/sysrq
+            echo b | sudo tee /proc/sysrq-trigger
+            ;;
+        2 )
+            ipmitool -I open chassis power cycle ;;
+        127 )
+            exit 0 ;;
+        * )
+            echo 1 | sudo tee /proc/sys/kernel/sysrq
+            echo b | sudo tee /proc/sysrq-trigger
+            ;;
+      esac


### PR DESCRIPTION
depends on : https://github.com/RackHD/on-taskgraph/pull/149
depends on: https://github.com/RackHD/on-imagebuilder/pull/52/files
depends on : https://github.com/RackHD/on-tasks/pull/293

references:  
- https://osclouds.wordpress.com/2015/11/23/announcing-a-new-docker-based-hanlon-microkernel
- https://groups.google.com/forum/#!topic/rackhd/cSYYxhtPWY0