### PR TITLE
Check kargs object type before parsing

### DIFF
--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -57,10 +57,12 @@ function profileApiServiceFactory(
             // for DOS disks (or linux) for saving
             // the trouble of having to write a
             // bunch of code in the EJS template.
-            properties.kargs = _.map(
-                properties.kargs, function (value, key) {
-                return key + '=' + value;
-            }).join(' ');
+            if(typeof properties.kargs === 'object') {
+                properties.kargs = _.map(
+                    properties.kargs, function (value, key) {
+                    return key + '=' + value;
+                }).join(' ');
+            }
         } else {
             // Ensure kargs is set for rendering.
             properties.kargs = null;


### PR DESCRIPTION
- Checks `kargs` option type is object before parsing to valid kernel boot string.  If non-object (i.e. string) will just be passed as-is.

@RackHD/corecommitters @uppalk1 @tannoa2 @zyoung51 @keedya 