### PR TITLE
Create API to GET task schema

### DIFF
--- a/lib/api/2.0/schemas2.js
+++ b/lib/api/2.0/schemas2.js
@@ -7,6 +7,7 @@ var controller = injector.get('Http.Services.Swagger').controller;
 var schemaApiService = injector.get('Http.Api.Services.Schema');
 var nameSpace = '/api/2.0/schemas/';
 var Errors = injector.get('Errors');
+var taskOptionValidator = injector.get('TaskOption.Validator');
 
 // GET /api/2.0/schemas
 var schemasGet = controller(function() {
@@ -23,7 +24,33 @@ var schemasIdGet = controller(function(req) {
     throw new Errors.NotFoundError(schemaUid + ' Not Found');
 });
 
+// GET /api/2.0/schemas/tasks
+var taskSchemasGet = controller(function () {
+    return taskOptionValidator.getAllSchemaNames({ includeNameSpace: true });
+});
+
+// GET /api/2.0/schemas/tasks/:identifier
+var taskSchemasIdGet = controller(function (req) {
+     var name = req.swagger.params.identifier.value;
+     var resolveRef = req.swagger.params.resolveRef.value;
+     var schema;
+     if (resolveRef) {
+        schema = taskOptionValidator.getSchemaResolved(name);
+     }
+     else {
+        schema = taskOptionValidator.getSchema(name);
+     }
+
+     if (schema) {
+         return schema;
+     }
+
+     throw new Errors.NotFoundError(name + ' Not Found');
+});
+
 module.exports = {
     schemasGet: schemasGet,
-    schemasIdGet: schemasIdGet
+    schemasIdGet: schemasIdGet,
+    taskSchemasGet: taskSchemasGet,
+    taskSchemasIdGet: taskSchemasIdGet
 };

--- a/lib/api/2.0/schemas2.js
+++ b/lib/api/2.0/schemas2.js
@@ -26,7 +26,7 @@ var schemasIdGet = controller(function(req) {
 
 // GET /api/2.0/schemas/tasks
 var taskSchemasGet = controller(function () {
-    return taskOptionValidator.getAllSchemaNames({ includeNameSpace: true });
+    return taskOptionValidator.getAllSchemaNames({ includeNameSpace: false });
 });
 
 // GET /api/2.0/schemas/tasks/:identifier

--- a/spec/lib/api/2.0/schemas-spec.js
+++ b/spec/lib/api/2.0/schemas-spec.js
@@ -7,6 +7,7 @@ describe('Http.Api.Schemas', function () {
     var schemaService;
     var stubGetNamespace;
     var stubGetSchema;
+    var taskOptionValidator;
 
     before('start HTTP server', function () {
         this.timeout(10000);
@@ -14,6 +15,7 @@ describe('Http.Api.Schemas', function () {
             schemaService = helper.injector.get('Http.Api.Services.Schema');
             stubGetNamespace = sinon.stub(schemaService, "getNamespace");
             stubGetSchema = sinon.stub(schemaService, "getSchema");
+            taskOptionValidator = helper.injector.get('TaskOption.Validator');
         });
     });
 
@@ -86,6 +88,111 @@ describe('Http.Api.Schemas', function () {
             stubGetSchema.returns(undefined);
 
             return helper.request().get('/api/2.0/schemas/junk')
+                .expect('Content-Type', /^application\/json/)
+                .expect(404);
+        });
+    });
+
+    describe("GET /schemas/tasks", function() {
+        before(function () {
+            sinon.stub(taskOptionValidator, 'getAllSchemaNames');
+        });
+
+        beforeEach(function () {
+            taskOptionValidator.getAllSchemaNames.reset();
+        });
+
+        after(function () {
+            taskOptionValidator.getAllSchemaNames.restore();
+        });
+
+        it("should return a list of all task schemas", function() {
+
+            taskOptionValidator.getAllSchemaNames.returns([
+                "tasks/schema1",
+                "tasks/schema2"
+            ]);
+
+            return helper.request().get('/api/2.0/schemas/tasks')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(res.body).to.be.an("Array").with.length(2);
+                    expect(res.body[0]).to.equal("tasks/schema1");
+                    expect(res.body[1]).to.equal("tasks/schema2");
+                    expect(taskOptionValidator.getAllSchemaNames).to.be.called.once;
+                });
+        });
+
+        it("should return an empty array if no schemas exist", function() {
+
+            taskOptionValidator.getAllSchemaNames.returns([]);
+
+            return helper.request().get('/api/2.0/schemas/tasks')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(res.body).to.be.an("Array").with.length(0);
+                });
+        });
+    });
+
+    describe("GET /schemas/tasks/:identifier", function() {
+        var testSchema = {
+            title: 'schema',
+            description: 'a test schema',
+            properties: {
+                name: { type: 'string' },
+                uid: { type: 'number' }
+            }
+        };
+
+        before(function () {
+            sinon.stub(taskOptionValidator, 'getSchema');
+            sinon.stub(taskOptionValidator, 'getSchemaResolved');
+        });
+
+        beforeEach(function () {
+            taskOptionValidator.getSchema.reset();
+            taskOptionValidator.getSchemaResolved.reset();
+        });
+
+        after(function () {
+            taskOptionValidator.getSchema.restore();
+            taskOptionValidator.getSchemaResolved.restore();
+        });
+
+        it("should return a task schema", function() {
+            taskOptionValidator.getSchema.returns(testSchema);
+
+            return helper.request().get('/api/2.0/schemas/tasks/testSchema')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(taskOptionValidator.getSchema).to.be.called.once;
+                    expect(taskOptionValidator.getSchemaResolved).to.not.be.called;
+                    expect(res.body).to.deep.equals(testSchema);
+                });
+        });
+
+        it("should return a task schema with reference resolved", function() {
+            taskOptionValidator.getSchemaResolved.returns(testSchema);
+
+            return helper.request()
+                .get('/api/2.0/schemas/tasks/testSchema?resolveRef=true')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(taskOptionValidator.getSchemaResolved).to.be.called.once;
+                    expect(taskOptionValidator.getSchema).to.not.be.called;
+                    expect(res.body).to.deep.equals(testSchema);
+                });
+        });
+
+        it("should return a 404 if no schema can be found", function() {
+            taskOptionValidator.getSchema.returns();
+
+            return helper.request().get('/api/2.0/schemas/tasks/junk')
                 .expect('Content-Type', /^application\/json/)
                 .expect(404);
         });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -3298,6 +3298,57 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /schemas/tasks/{identifier}:
+    x-swagger-router-controller: schemas2
+    get:
+      operationId: taskSchemasIdGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Get a task schema
+      description: |
+        Get the specified task schema.
+      parameters:
+        - name: identifier
+          in: path
+          description: The identifier of the task schema
+          required: true
+          type: string
+        - name: resolveRef
+          in: query
+          description: The reference resolve flag
+          required: false
+          type: boolean
+      tags: [ "/api/2.0" ]
+      responses:
+        "200":
+          description: Successfully retrieved the task schema
+          schema:
+            type: object
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /schemas/tasks:
+    x-swagger-router-controller: schemas2
+    get:
+      operationId: taskSchemasGet
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Get all task schemas
+      description: |
+        Get a list of all task schemas currently stored in the system.
+      tags: [ "/api/2.0" ]
+      responses:
+        "200":
+          description: Successfully retrieved the list of task schemas
+          schema:
+            type: object
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /schemas/{identifier}:
     x-swagger-router-controller: schemas2
     get:


### PR DESCRIPTION
List all task schema names
- GET `/schemas/tasks`

Get a schema data with $ref resolved or not
- GET `/schemas/tasks/:id[?resolveRef=true|false]`

Dependency PR : 
https://github.com/RackHD/on-tasks/pull/290
https://github.com/RackHD/on-core/pull/186
@RackHD/corecommitters @iceiilin @cgx027 @pengz1 