### PR TITLE
Add support to xForwardedFor

### DIFF
--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -224,6 +224,11 @@ function httpServiceFactory(
         app.use(rewriter('/api/current/*', '/api/' + versionPath + '/$1'));
         app.use(rewriter('/api/common/*', '/api/' + versionPath + '/$1'));
 
+        //enble/disable trusted proxy
+        if ((configuration.get('trustedProxy') || false) === true) {
+            app.enable('trust proxy');
+        }
+
         // API Docs Directory
         app.use('/docs',
             express.static(


### PR DESCRIPTION
- enabling trusted proxy in express
- make this option configurable by adding trustedProxy
  booleen  in the config file
- by enabling trust proxy in express, if header/x-forwardedFor 
data is available, then req.ip will be populated with the most left IP in xfowardedFor list
- Resolves: https://github.com/RackHD/RackHD/issues/278