### PR TITLE
Issue#363: Fix the API response of /api/1.1/workflows/libary

### DIFF
--- a/lib/api/1.1/northbound/workflows.js
+++ b/lib/api/1.1/northbound/workflows.js
@@ -102,20 +102,51 @@ function workflowsRouterFactory (
     }));
 
     /**
+     * @api {get} /api/1.1/workflows/tasks/library/:injectableName GET /library/:injectableName
+     * @apiVersion 1.1.0
+     * @apiDescription get a specific task definition from the library.
+     * @apiParam {String} injectableName of task definition
+     * @apiName tasks-library-item
+     * @apiSuccess {json} task the task that has the <code>injectableName</code>
+     * @apiGroup workflows
+     */
+
+    router.get('/workflows/tasks/library/:injectableName', rest(function (req) {
+        return workflowApiService.getTaskDefinitions(req.params.injectableName)
+        .then(function(tasks) {
+            if (_.isEmpty(tasks)) {
+                throw new Errors.NotFoundError(
+                    'Could not find task definition for ' + req.params.injectableName);
+            } else {
+                return tasks[0];
+            }
+        });
+    }));
+
+    /**
+     * @api {get} /api/1.1/workflows/library GET /library
+     * @apiVersion 1.1.0
+     * @apiDescription To get all known workflow definitions
+     * @apiName workflows-library-item
+     * @apiSuccess {json} workflows List of all known workflow definition
+     * @apiGroup workflows
+     */
+
+    router.get('/workflows/library', rest(function () {
+        return workflowApiService.getGraphDefinitions();
+    }));
+
+    /**
      * @api {get} /api/1.1/workflows/library/:injectableName GET /library/:injectableName
      * @apiVersion 1.1.0
-     * @apiDescription get a specific workflow definition from the library. To get all
-     *                 known workflow definitions, use the '*' wildcard (GET /library/*)
+     * @apiDescription get a specific workflow definition from the library.
      * @apiParam {String} injectableName of workflow definition
      * @apiName workflows-library-item
-     * @apiSuccess {json} workflow the workflow that have the <code>injectableName</code>
+     * @apiSuccess {json} workflow the workflow that has the <code>injectableName</code>
      * @apiGroup workflows
      */
 
     router.get('/workflows/library/:injectableName', rest(function (req) {
-        if (req.params.injectableName === '*') {
-            return workflowApiService.getGraphDefinitions();
-        }
         return workflowApiService.getGraphDefinitions(req.params.injectableName)
         .then(function(graphs) {
             if (_.isEmpty(graphs)) {

--- a/spec/lib/api/1.1/workflows-spec.js
+++ b/spec/lib/api/1.1/workflows-spec.js
@@ -112,7 +112,7 @@ describe('Http.Api.Workflows', function () {
 
     describe('PUT /workflows/tasks', function () {
         it('should persist a task', function () {
-            var task = { name: 'foobar' };
+            var task = { injectableName: 'foobar' };
             workflowApiService.defineTask.resolves(task);
 
             return helper.request().put('/api/1.1/workflows/tasks')
@@ -124,7 +124,7 @@ describe('Http.Api.Workflows', function () {
 
     describe('GET /workflows/tasks/library', function () {
         it('should retrieve the task library', function () {
-            var task = { name: 'foobar' };
+            var task = { injectableName: 'foobar' };
             workflowApiService.getTaskDefinitions.resolves([task]);
 
             return helper.request().get('/api/1.1/workflows/tasks/library')
@@ -133,28 +133,69 @@ describe('Http.Api.Workflows', function () {
         });
     });
 
-    describe('GET /workflows/library/*', function () {
-        it('should retrieve the graph library', function () {
-            var graph = { name: 'foobar' };
-            workflowApiService.getGraphDefinitions.resolves([graph]);
+    describe('GET /workflows/tasks/library/:id', function () {
+        it('should retrieve a task from the task library', function () {
+            var task = { injectableName: 'foobar' };
+            workflowApiService.getTaskDefinitions.withArgs('foobar').resolves([task]);
 
-            return helper.request().get('/api/1.1/workflows/library/*')
+            return helper.request().get('/api/1.1/workflows/tasks/library/foobar')
             .expect('Content-Type', /^application\/json/)
-            .expect(200, [graph]);
+            .expect(200, task)
+            .expect(function () {
+                expect(workflowApiService.getTaskDefinitions).to.have.been.calledOnce;
+                expect(workflowApiService.getTaskDefinitions).to.have.been.calledWith('foobar');
+            });
+        });
+
+        it('should get NotFoundError if task definition is not existing', function () {
+            workflowApiService.getTaskDefinitions.withArgs('foobar').resolves([]);
+
+            return helper.request().get('/api/1.1/workflows/tasks/library/foobar')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404)
+            .expect(function () {
+                expect(workflowApiService.getTaskDefinitions).to.have.been.calledOnce;
+                expect(workflowApiService.getTaskDefinitions).to.have.been.calledWith('foobar');
+            });
+        });
+    });
+
+    describe('GET /workflows/library', function () {
+        it('should retrieve the graph library', function () {
+            var graph1 = { injectableName: 'foo' };
+            var graph2 = { injectableName: 'bar' };
+            workflowApiService.getGraphDefinitions.resolves([graph1, graph2]);
+
+            return helper.request().get('/api/1.1/workflows/library')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200, [graph1, graph2]);
         });
     });
 
     describe('GET /workflows/library/:id', function () {
         it('should retrieve a graph from the graph library', function () {
-            var graph = { friendlyName: 'foobar' };
-            workflowApiService.getGraphDefinitions.resolves([graph]);
+            var graph = { injectableName: 'foobar' };
+            workflowApiService.getGraphDefinitions.withArgs('foobar').resolves([graph]);
 
-            return helper.request().get('/api/1.1/workflows/library/1234')
+            return helper.request().get('/api/1.1/workflows/library/foobar')
             .expect('Content-Type', /^application\/json/)
             .expect(200, graph)
             .expect(function () {
                 expect(workflowApiService.getGraphDefinitions).to.have.been.calledOnce;
-                expect(workflowApiService.getGraphDefinitions).to.have.been.calledWith('1234');
+                expect(workflowApiService.getGraphDefinitions).to.have.been.calledWith('foobar');
+            });
+        });
+
+        it('should return 404 if graph definition is not existing', function () {
+            var graph = { injectableName: 'foobar' };
+            workflowApiService.getGraphDefinitions.withArgs('foobar').resolves([]);
+
+            return helper.request().get('/api/1.1/workflows/library/foobar')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404)
+            .expect(function () {
+                expect(workflowApiService.getGraphDefinitions).to.have.been.calledOnce;
+                expect(workflowApiService.getGraphDefinitions).to.have.been.calledWith('foobar');
             });
         });
     });


### PR DESCRIPTION
Resolves https://github.com/RackHD/RackHD/issues/363

To align the 1.1 & 2.0 APIs and fix the mismatching of getting workflow definition & task definition.

- Use `/api/1.1/workflows/library` to get all workflow definitions rather than `/api/1.1/workflows/library/*`

- Use `/api/1.1/workflows/tasks/library` to get all task definitions rather than `/api/1.1/workflows/tasks/library/*`

- Add `/api/1.1/workflows/tasks/library/:injectableName` to get a specific task definition. This is to align the API `/api/1.1/workflows/library/:injectableName` to get a specific graph definition.

@RackHD/corecommitters @codenrhoden @heckj 