### PR TITLE
Update the description of task schema API to be more accurate

### DIFF
--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -3310,12 +3310,15 @@ paths:
       parameters:
         - name: identifier
           in: path
-          description: The identifier of the task schema
+          description: The filename of the task schema
           required: true
           type: string
         - name: resolveRef
           in: query
-          description: The reference resolve flag
+          description: |
+            The reference resolve flag.
+            false - a simple schema with any internal reference only in the response.
+            true - all the internal references will be resolved and fully defined in the response.
           required: false
           type: boolean
       tags: [ "/api/2.0" ]
@@ -3335,13 +3338,13 @@ paths:
       x-privileges: [ 'Read' ]
       x-authentication-type: [ 'jwt' ]
       summary: |
-        Get all task schemas
+        Get all task schemas names
       description: |
-        Get a list of all task schemas currently stored in the system.
+        Get a list of all task schema names currently stored in the system.
       tags: [ "/api/2.0" ]
       responses:
         "200":
-          description: Successfully retrieved the list of task schemas
+          description: Successfully retrieved the list of task schema names
           schema:
             type: object
         default:


### PR DESCRIPTION
As @heckj suggested, update the swagger yml description for task schema API to avoid any misunderstanding of the usage of the API.

@RackHD/corecommitters @cgx027 