### PR TITLE
coreos install: indicate complete after write to disk

### DIFF
--- a/data/templates/install-coreos.sh
+++ b/data/templates/install-coreos.sh
@@ -2,4 +2,5 @@
 set -e
 curl -O http://<%=server%>:<%=port%>/api/current/templates/pxe-cloud-config.yml
 sudo coreos-install -d <%=installDisk%> -c pxe-cloud-config.yml -b <%=repo%>
+wget --spider http://<%=server%>:<%=port%>/api/current/templates/<%=completionUri%>
 sudo reboot


### PR DESCRIPTION
Right now, the CoreOS install task says its finished once the
cloud-config file is downloaded, but this really before the install
even kicks off. Add a line to the install script to hit the
completionUri right before the reboot so we can trigger off that
instead.