### PR TITLE
Changes to 2.0 pollers/data route

### DIFF
--- a/lib/api/2.0/pollers.js
+++ b/lib/api/2.0/pollers.js
@@ -157,15 +157,7 @@ var pollersDelete = controller({success: 204}, function(req) {
  *     }
  */
 var pollersDataGet = controller( {send204OnEmpty:true}, function (req){
-    return pollers.getPollersByIdData(req.swagger.params.identifier.value)
-        .catch(function (err) {
-            if (err.name === 'NoActivePollerError') {
-                //Return with no data, this will cause a 204 to be sent
-                return;
-            }
-            // throw a NotFoundError
-            throw new Errors.NotFoundError('Not Found');
-        });
+    return pollers.getPollersByIdData(req.swagger.params.identifier.value);
 });
 
 
@@ -185,16 +177,8 @@ var pollersDataGet = controller( {send204OnEmpty:true}, function (req){
  *     }
  */
 var pollersCurrentDataGet = controller( {send204OnEmpty:true}, function(req) {
-    return pollers.getPollersByIdDataCurrent(req.swagger.params.identifier.value)
-        .catch(function (err) {
-            if (err.name === 'NoActivePollerError') {
-                //Return with no data, this will cause a 204 to be sent
-                return;
-            }
-            // throw a NotFoundError
-            throw new Errors.NotFoundError('Not Found');
-        });
-
+    return pollers.getPollersByIdData(req.swagger.params.identifier.value,
+                                      { latestOnly: true });
 });
 
 

--- a/lib/services/pollers-api-service.js
+++ b/lib/services/pollers-api-service.js
@@ -11,7 +11,8 @@ di.annotate(pollerApiServiceFactory,
         'Services.Waterline',
         'Protocol.Task',
         'Errors',
-        '_'
+        '_',
+        'Promise'
     )
 );
 
@@ -19,7 +20,8 @@ function pollerApiServiceFactory(
     waterline,
     taskProtocol,
     Errors,
-    _
+    _,
+    Promise
 ) {
 
     function PollerApiService() {
@@ -131,20 +133,18 @@ function pollerApiServiceFactory(
         return waterline.workitems.destroyByIdentifier(id);
     };
 
-    PollerApiService.prototype.getPollersByIdData = function(id) {
+    PollerApiService.prototype.getPollersByIdData = function(id, options) {
         var self = this;
-        return taskProtocol.requestPollerCache(id)
-        .catch(function() {
-            throw new self.NoActivePollerError('');
-        });
-    };
-
-
-    PollerApiService.prototype.getPollersByIdDataCurrent = function(id) {
-        var self = this;
-        return taskProtocol.requestPollerCache(id, { latestOnly: true })
-        .catch(function() {
-            throw new self.NoActivePollerError('');
+        return Promise.try(function() {
+            return waterline.workitems.needByIdentifier(id);
+        })
+        .then(function() {
+            return taskProtocol.requestPollerCache(id, options)
+            .catch(function(err) {
+                if (err.name !== 'NotFoundError') {
+                    throw err;
+                }
+            });
         });
     };
 

--- a/spec/lib/services/pollers-api-service-spec.js
+++ b/spec/lib/services/pollers-api-service-spec.js
@@ -213,7 +213,7 @@ describe("Http.Services.Api.Pollers", function () {
     describe("getPollersByIdData", function() {
         it("should expose the appropriate methods", function() {
             pollerService.should.have.property("getPollersByIdData")
-            .that.is.a("function").with.length(1);
+            .that.is.a("function").with.length(2);
         });
 
         it("Run getPollersByIdData", function() {
@@ -223,31 +223,10 @@ describe("Http.Services.Api.Pollers", function () {
                 config: {}
             }];
 
-
+            waterline.workitems.needByIdentifier.resolves();
             taskProtocol.requestPollerCache.resolves(mockPoller);
 
             return pollerService.getPollersByIdData().then(function (pollers) {
-                expect(pollers).to.deep.equal(mockPoller);
-            });
-        });
-    });
-
-
-    describe("getPollersByIdDataCurrent", function() {
-        it("should expose the appropriate methods", function() {
-            pollerService.should.have.property("getPollersByIdDataCurrent")
-            .that.is.a("function").with.length(1);
-        });
-
-        it("Run getPollersByIdDataCurrent", function() {
-            var mockPoller = [{
-                id: "1234",
-                name: "Pollers.IPMI",
-                config: {}
-            }];
-
-            taskProtocol.requestPollerCache.resolves(mockPoller);
-            return pollerService.getPollersByIdDataCurrent().then(function (pollers) {
                 expect(pollers).to.deep.equal(mockPoller);
             });
         });


### PR DESCRIPTION
* Check if poller exists and return 404 if it does not.
* Collapse getPollersByIdDataCurrent into getPollersByIdData.

@RackHD/corecommitters @srinia6 @dalebremner @BillyAbildgaard @keedya @jlongever 