### PR TITLE
notification API design refactor

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -41,7 +41,7 @@ postLookup () {
   BODY="{"
   BODY=$BODY"\"macAddress\": \"$mac\","
   BODY=$BODY"\"ipAddress\": \"$2\","
-  BODY=$BODY"\"node\": \"<%=task.nodeId%>\""
+  BODY=$BODY"\"node\": \"<%=nodeId%>\""
   BODY=$BODY"}"
   BODYLEN=$(echo -n ${BODY} | wc -c )
   echo ${BODY} >> /vmfs/volumes/datastore1/firstboot.log

--- a/data/templates/install-photon/photon-os-ks
+++ b/data/templates/install-photon/photon-os-ks
@@ -73,6 +73,6 @@
                     "sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config",
 
                     "# Signify ORA the installation completed",
-                    "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%>/api/1.1/notification?nodeId=<%=nodeId%>'"
+                    "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>'"
                    ]
 }

--- a/data/templates/install-photon/photon-os-ks
+++ b/data/templates/install-photon/photon-os-ks
@@ -73,6 +73,6 @@
                     "sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config",
 
                     "# Signify ORA the installation completed",
-                    "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%>/api/current/notification?taskId=<%=taskid%>&data=finished'"
+                    "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%>/api/1.1/notification?nodeId=<%=nodeId%>'"
                    ]
 }

--- a/data/templates/install-photon/photon-os.rackhdcallback
+++ b/data/templates/install-photon/photon-os.rackhdcallback
@@ -35,7 +35,7 @@ do
         echo http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>
         # Retry 100 times, delay between retry set to 1 second, total operation limits
         # to 1000 seconds, each connection fail at 9 seconds
-        /bin/curl --max-time 1000 --connect-timeout 9 --retry-delay 1 --retry 100 http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>
+        /bin/curl --max-time 1000 --connect-timeout 9 --retry-delay 1 --retry 100 http://<%=server%>:<%=port%>/api/1.1/notification?nodeId=<%=nodeId%>
 
         # Only run this once to verify the OS was installed, then stop the service and remove itself forever
         systemctl disable photon-os.rackhdcallback.service

--- a/data/templates/install-photon/photon-os.rackhdcallback
+++ b/data/templates/install-photon/photon-os.rackhdcallback
@@ -32,10 +32,10 @@ do
 	
 	if [ $? -eq 0 ]
     	then
-        echo http://<%=server%>:<%=port%>/api/common/templates/<%=completionUri%>
+        echo http://<%=server%>:<%=port%>/api/current/templates/<%=completionUri%>
         # Retry 100 times, delay between retry set to 1 second, total operation limits
         # to 1000 seconds, each connection fail at 9 seconds
-        /bin/curl --max-time 1000 --connect-timeout 9 --retry-delay 1 --retry 100 http://<%=server%>:<%=port%>/api/1.1/notification?nodeId=<%=nodeId%>
+        /bin/curl -X POST --max-time 1000 --connect-timeout 9 --retry-delay 1 --retry 100 http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>
 
         # Only run this once to verify the OS was installed, then stop the service and remove itself forever
         systemctl disable photon-os.rackhdcallback.service

--- a/data/templates/install-photon/photon-os.rackhdcallback
+++ b/data/templates/install-photon/photon-os.rackhdcallback
@@ -35,7 +35,7 @@ do
         echo http://<%=server%>:<%=port%>/api/current/templates/<%=completionUri%>
         # Retry 100 times, delay between retry set to 1 second, total operation limits
         # to 1000 seconds, each connection fail at 9 seconds
-        /bin/curl -X POST --max-time 1000 --connect-timeout 9 --retry-delay 1 --retry 100 http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>
+        /bin/curl -X POST -H 'Content-Type:application/json' --max-time 1000 --connect-timeout 9 --retry-delay 1 --retry 100 http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>
 
         # Only run this once to verify the OS was installed, then stop the service and remove itself forever
         systemctl disable photon-os.rackhdcallback.service

--- a/lib/api/1.1/southbound/notification.js
+++ b/lib/api/1.1/southbound/notification.js
@@ -33,16 +33,7 @@ function notificationRouterFactory (
 
     router.post('/notification/', rest(function (req) {
         var message = _.defaults(req.query || {}, req.body || {});
-
-        if (_.has(message, 'nodeId')) {
-            return notificationApiService.postNodeNotification(message);
-        }
-        // Add other cases here if to support more notification types
-
-        // This will be a broadcast notification if no id (like nodeId) is specified
-        else {
-            return notificationApiService.postBroadcastNotification(message);
-        }
+        return notificationApiService.postNotification(message);
     }, {renderOptions: {success: 201}}));
 
     return router;

--- a/lib/api/1.1/southbound/notification.js
+++ b/lib/api/1.1/southbound/notification.js
@@ -33,7 +33,16 @@ function notificationRouterFactory (
 
     router.post('/notification/', rest(function (req) {
         var message = _.defaults(req.query || {}, req.body || {});
-        return notificationApiService.postNotification(message);
+
+        if (_.has(message, 'nodeId')) {
+            return notificationApiService.postNodeNotification(message);
+        }
+        // Add other cases here if to support more notification types
+
+        // This will be a broadcast notification if no id (like nodeId) is specified
+        else {
+            return notificationApiService.postBroadcastNotification(message);
+        }
     }, {renderOptions: {success: 201}}));
 
     return router;

--- a/lib/api/2.0/notification.js
+++ b/lib/api/2.0/notification.js
@@ -8,7 +8,7 @@ var notificationApiService = injector.get('Http.Services.Api.Notification');
 var _ = injector.get('_');    // jshint ignore:line
 
 var notificationPost = controller({success: 201}, function(req) {
-    var message = _.defaults(req.swagger.query || {}, req.body || {});
+    var message = _.defaults(req.swagger.query || {}, req.query || {}, req.body || {});
 
     if (_.has(message, 'nodeId')) {
             return notificationApiService.postNodeNotification(message);

--- a/lib/api/2.0/notification.js
+++ b/lib/api/2.0/notification.js
@@ -9,7 +9,16 @@ var _ = injector.get('_');    // jshint ignore:line
 
 var notificationPost = controller({success: 201}, function(req) {
     var message = _.defaults(req.swagger.query || {}, req.body || {});
-    return notificationApiService.postNotification(message);
+
+    if (_.has(message, 'nodeId')) {
+            return notificationApiService.postNodeNotification(message);
+        }
+    // Add other cases here if to support more notification types
+
+    // This will be a broadcast notification if no id (like nodeId) is specified
+    else {
+        return notificationApiService.postBroadcastNotification(message);
+    }
 });
 
 module.exports = {

--- a/lib/api/2.0/notification.js
+++ b/lib/api/2.0/notification.js
@@ -9,16 +9,7 @@ var _ = injector.get('_');    // jshint ignore:line
 
 var notificationPost = controller({success: 201}, function(req) {
     var message = _.defaults(req.swagger.query || {}, req.query || {}, req.body || {});
-
-    if (_.has(message, 'nodeId')) {
-            return notificationApiService.postNodeNotification(message);
-        }
-    // Add other cases here if to support more notification types
-
-    // This will be a broadcast notification if no id (like nodeId) is specified
-    else {
-        return notificationApiService.postBroadcastNotification(message);
-    }
+    return notificationApiService.postNotification(message);
 });
 
 module.exports = {

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -264,20 +264,8 @@ function CommonApiPresenterFactory(
                 nodes: baseUri + '/nodes'
             },
             context: graphContext,
-            task: {
-                nodeId: graphContext.target
-            },
-            taskid: _getActiveTaskId(graphContext.target)
+            nodeId: graphContext.target
         });
-    };
-
-    function _getActiveTaskId(nodeId) {
-        if (nodeId) {
-            return taskProtocol.activeTaskExists(nodeId)
-                .then(function (activeTask) {
-                    return activeTask.taskId;
-                })
-        }
     };
 
     presenter.use = function serializer(name, func) {

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -34,28 +34,34 @@ function notificationApiServiceFactory(
     function notificationApiService() {
     }
 
-    notificationApiService.prototype.postNotification = function(message) {
+    notificationApiService.prototype.postNodeNotification = function(message) {
         var self = this;
 
         return Promise.try(function() {
-            if (!message.taskId || !_.isString(message.taskId)) {
-                throw new Errors.BadRequestError('Missing task ID in query or body');
+            if (!message.nodeId || !_.isString(message.nodeId)) {
+                throw new Errors.BadRequestError('Invalid node ID in query or body');
             };
-            if (!message.data || !(_.isString(message.data) || _.isObject(message.data))) {
-                throw new Errors.BadRequestError('Missing notification data in query or body');
-            }            
         })
         .then(function () {
-            return eventsProtocol.publishTaskNotification(
-                message.taskId,
-                message.data
-            );
+            return waterline.nodes.needByIdentifier(message.nodeId)
         })
-        .then(function () {
-            return {
-                taskId: message.taskId,
-                data: message.data
+        .then(function (node) {
+            if(!node) {
+                throw new Errors.BadRequestError('Node not found');
             }
+            return eventsProtocol.publishNodeNotification(message.nodeId, message);
+        })
+        .then(function () {
+            return message;
+        });
+    };
+
+    notificationApiService.prototype.postBroadcastNodeNotification = function(message) {
+        var self = this;
+
+        return eventsProtocol.publishBroadcastNotification(message)
+        .then(function () {
+            return message;
         });
     };
 

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -34,6 +34,20 @@ function notificationApiServiceFactory(
     function notificationApiService() {
     }
 
+    notificationApiService.prototype.postNotification = function(message) {
+        var self = this;
+
+        if (_.has(message, 'nodeId')) {
+            return self.postNodeNotification(message);
+        }
+        // Add other cases here if to support more notification types
+
+        // This will be a broadcast notification if no id (like nodeId) is specified
+        else {
+            return self.postBroadcastNotification(message);
+        }
+    };
+
     notificationApiService.prototype.postNodeNotification = function(message) {
         var self = this;
 

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -56,7 +56,7 @@ function notificationApiServiceFactory(
         });
     };
 
-    notificationApiService.prototype.postBroadcastNodeNotification = function(message) {
+    notificationApiService.prototype.postBroadcastNotification = function(message) {
         var self = this;
 
         return eventsProtocol.publishBroadcastNotification(message)

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -278,9 +278,7 @@ function swaggerFactory(
                 nodes: baseUri + '/nodes'
             },
             context: context,
-            task: {
-                nodeId: context.target
-            }
+            nodeId: context.target
         });
     }
 

--- a/spec/lib/api/1.1/notification-spec.js
+++ b/spec/lib/api/1.1/notification-spec.js
@@ -5,9 +5,13 @@
 describe('Http.Api.Notification', function () {
     var notificationApiService;
 
-    var notificationMessage = {
-        taskId: '1234abcd5678effe9012dcba',
-        data: 'dummy data'
+    var nodeNotificationMessage = {
+        nodeId: '57a86b5c36ec578876878294',
+        randomData: 'random data'
+    };
+
+    var broadcastNotificationMessage = {
+        data: 'test data'
     };
 
     before('start HTTP server', function () {
@@ -18,7 +22,8 @@ describe('Http.Api.Notification', function () {
         this.timeout(5000);
         return helper.startServer([]).then(function () {
             notificationApiService = helper.injector.get('Http.Services.Api.Notification');
-            sinon.stub(notificationApiService, 'postNotification').resolves(notificationMessage);
+            sinon.stub(notificationApiService, 'postNodeNotification').resolves(nodeNotificationMessage);
+            sinon.stub(notificationApiService, 'postBroadcastNotification').resolves(broadcastNotificationMessage);
         });
 
     });
@@ -35,43 +40,46 @@ describe('Http.Api.Notification', function () {
     });
 
     describe('POST /notification', function () {
-        it('should return notification detail', function () {
+        it('should return node notification detail', function () {
             return helper.request()
-            .post(
-                '/api/1.1/notification?taskId='
-                + notificationMessage.taskId
-                + '&data='
-                + notificationMessage.data)
+            .post('/api/1.1/notification?nodeId='
+                + nodeNotificationMessage.nodeId
+                + '&randomData='
+                + nodeNotificationMessage.randomData)
             .set('Content-Type', 'application/json')
             .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
+            .expect(201, nodeNotificationMessage)
             .then(function () {
-                expect(notificationApiService.postNotification).to.have.been.calledOnce;
-                expect(notificationApiService.postNotification).to.have.been.calledWith(notificationMessage);
+                expect(notificationApiService.postNodeNotification).to.have.been.calledOnce;
+                expect(notificationApiService.postNodeNotification).to.have.been.calledWith(nodeNotificationMessage);
             });
         });
-        it('should pass with taskId in query body', function () {
+        it('should return broadcast notification detail', function () {
             return helper.request()
-            .post('/api/1.1/notification?data=' + notificationMessage.data)
-            .send({ taskId: notificationMessage.taskId })
+            .post('/api/1.1/notification')
+            .send(broadcastNotificationMessage)
+            .set('Content-Type', 'application/json')
             .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
+            .expect(201, broadcastNotificationMessage)
+            .then(function () {
+                expect(notificationApiService.postBroadcastNotification).to.have.been.calledOnce;
+                expect(notificationApiService.postBroadcastNotification).to.have.been.calledWith(broadcastNotificationMessage);
+            });
+        });
+        it('should pass with nodeId in query body', function () {
+            return helper.request()
+            .post('/api/1.1/notification')
+            .send({ nodeId: nodeNotificationMessage.nodeId })
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, nodeNotificationMessage)
         });
 
-        it('should pass with data in query body', function () {
+        it('should pass with nodeId in query body', function () {
             return helper.request()
-            .post('/api/1.1/notification?taskId=' + notificationMessage.taskId)
-            .send({ data: notificationMessage.data })
+            .post('/api/1.1/notification')
+            .send(nodeNotificationMessage)
             .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
-        });
-
-        it('should pass with data as an object in query body', function () {
-            return helper.request()
-            .post('/api/1.1/notification?taskId=' + notificationMessage.taskId)
-            .send(notificationMessage)
-            .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
+            .expect(201, nodeNotificationMessage)
         });
     });
 });

--- a/spec/lib/api/2.0/notification-spec.js
+++ b/spec/lib/api/2.0/notification-spec.js
@@ -5,9 +5,12 @@
 describe('Http.Api.Notification', function () {
     var notificationApiService;
 
-    var notificationMessage = {
-        taskId: '1234abcd5678effe9012dcba',
-        data: 'dummy data'
+    var nodeNotificationMessage = {
+        nodeId: '57a86b5c36ec578876878294'
+    };
+
+    var broadcastNotificationMessage = {
+        data: 'test data'
     };
 
     before('start HTTP server', function () {
@@ -18,7 +21,8 @@ describe('Http.Api.Notification', function () {
         this.timeout(5000);
         return helper.startServer([]).then(function () {
             notificationApiService = helper.injector.get('Http.Services.Api.Notification');
-            sinon.stub(notificationApiService, 'postNotification').resolves(notificationMessage);
+            sinon.stub(notificationApiService, 'postNodeNotification').resolves(nodeNotificationMessage);
+            sinon.stub(notificationApiService, 'postBroadcastNotification').resolves(broadcastNotificationMessage);
         });
 
     });
@@ -35,44 +39,44 @@ describe('Http.Api.Notification', function () {
     });
 
     describe('POST /notification', function () {
-        it('should return notification detail', function () {
+        it('should return node notification detail', function () {
             return helper.request()
-            .post(
-                '/api/2.0/notification?taskId='
-                + notificationMessage.taskId
-                + '&data='
-                + notificationMessage.data)
+            .post('/api/2.0/notification?nodeId='
+                + nodeNotificationMessage.nodeId)
             .set('Content-Type', 'application/json')
             .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
+            .expect(201, nodeNotificationMessage)
             .then(function () {
-                expect(notificationApiService.postNotification).to.have.been.calledOnce;
-                expect(notificationApiService.postNotification).to.have.been.calledWith(notificationMessage);
+                expect(notificationApiService.postNodeNotification).to.have.been.calledOnce;
+                expect(notificationApiService.postNodeNotification).to.have.been.calledWith(nodeNotificationMessage);
             });
         });
-        it('should pass with taskId in query body', function () {
+        it('should return broadcast notification detail', function () {
             return helper.request()
-            .post('/api/2.0/notification?data=' + notificationMessage.data)
-            .send({ taskId: notificationMessage.taskId })
+            .post('/api/2.0/notification')
+            .send(broadcastNotificationMessage)
+            .set('Content-Type', 'application/json')
             .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
+            .expect(201, broadcastNotificationMessage)
+            .then(function () {
+                expect(notificationApiService.postBroadcastNotification).to.have.been.calledOnce;
+                expect(notificationApiService.postBroadcastNotification).to.have.been.calledWith(broadcastNotificationMessage);
+            });
+        });
+        it('should pass with nodeId in query body', function () {
+            return helper.request()
+            .post('/api/2.0/notification')
+            .send({ nodeId: nodeNotificationMessage.nodeId })
+            .expect('Content-Type', /^application\/json/)
+            .expect(201, nodeNotificationMessage)
         });
 
-        it('should pass with data in query body', function () {
+        it('should pass with nodeId in query body', function () {
             return helper.request()
-            .post('/api/2.0/notification?taskId=' + notificationMessage.taskId)
-            .send({ data: notificationMessage.data })
+            .post('/api/2.0/notification')
+            .send(nodeNotificationMessage)
             .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
+            .expect(201, nodeNotificationMessage)
         });
-
-        it('should pass with data as an object in query body', function () {
-            return helper.request()
-            .post('/api/2.0/notification?taskId=' + notificationMessage.taskId)
-            .send(notificationMessage)
-            .expect('Content-Type', /^application\/json/)
-            .expect(201, notificationMessage)
-        });
-
     });
 });

--- a/spec/lib/api/2.0/notification-spec.js
+++ b/spec/lib/api/2.0/notification-spec.js
@@ -6,7 +6,8 @@ describe('Http.Api.Notification', function () {
     var notificationApiService;
 
     var nodeNotificationMessage = {
-        nodeId: '57a86b5c36ec578876878294'
+        nodeId: '57a86b5c36ec578876878294',
+        randomData: 'random data'
     };
 
     var broadcastNotificationMessage = {
@@ -42,7 +43,9 @@ describe('Http.Api.Notification', function () {
         it('should return node notification detail', function () {
             return helper.request()
             .post('/api/2.0/notification?nodeId='
-                + nodeNotificationMessage.nodeId)
+                + nodeNotificationMessage.nodeId
+                + '&randomData='
+                + nodeNotificationMessage.randomData)
             .set('Content-Type', 'application/json')
             .expect('Content-Type', /^application\/json/)
             .expect(201, nodeNotificationMessage)

--- a/spec/lib/services/notification-api-service-spec.js
+++ b/spec/lib/services/notification-api-service-spec.js
@@ -8,6 +8,8 @@ describe('Http.Api.Notification', function () {
     var waterline;
     var _;
     var needByIdentifier;
+    var postNodeNotification;
+    var postBroadcastNotification;
 
     var nodeNotificationMessage = {
         nodeId: "57a86b5c36ec578876878294",
@@ -35,7 +37,9 @@ describe('Http.Api.Notification', function () {
         sinon.stub(eventProtocol, 'publishBroadcastNotification').resolves();
 
         needByIdentifier = sinon.stub(waterline.nodes, 'needByIdentifier');
-        needByIdentifier.resolves(node)
+        needByIdentifier.resolves(node);
+        postNodeNotification = sinon.spy(notificationApiService, 'postNodeNotification');
+        postBroadcastNotification = sinon.spy(notificationApiService, 'postBroadcastNotification');
     });
 
     after('Reset mocks', function () {
@@ -50,6 +54,20 @@ describe('Http.Api.Notification', function () {
     });
 
     describe('POST /notification', function () {
+        it('should call postNodeNotification', function () {
+            return notificationApiService.postNotification(nodeNotificationMessage)
+            .then(function () {
+                expect(postNodeNotification).to.have.been.calledOnce;
+            });
+        });
+
+        it('should call postBroadcastNotification', function () {
+            return notificationApiService.postNotification({})
+            .then(function () {
+                expect(postBroadcastNotification).to.have.been.calledOnce;
+            });
+        });
+
         it('should return node notification detail', function () {
             return notificationApiService.postNodeNotification(nodeNotificationMessage)
             .then(function (resp) {

--- a/spec/lib/services/notification-api-service-spec.js
+++ b/spec/lib/services/notification-api-service-spec.js
@@ -4,30 +4,41 @@
 
 describe('Http.Api.Notification', function () {
     var notificationApiService;
-    var taskProtocol;
     var eventProtocol;
+    var waterline;
+    var _;
+    var needByIdentifier;
 
-    var notificationMessage = {
-        taskId: "73b8ca01-735b-40d6-897a-7003ef2fa988",
+    var nodeNotificationMessage = {
+        nodeId: "57a86b5c36ec578876878294",
         data: 'dummy data'
     };
 
-    var activeTask = {
-        taskId: notificationMessage.taskId,
+    var broadcastNotificationMessage = {
+        data: 'dummy data'
     };
 
-    before('start HTTP server', function () {
+    var node = {_id: nodeNotificationMessage.nodeId}
+
+    before('Setup mocks', function () {
         helper.setupInjector([
             helper.require("/lib/services/notification-api-service.js")
         ]);
         notificationApiService = helper.injector.get('Http.Services.Api.Notification');
-        taskProtocol = helper.injector.get('Protocol.Task');
+        _ = helper.injector.get('_');
         eventProtocol = helper.injector.get('Protocol.Events');
-        sinon.stub(taskProtocol, 'activeTaskExists').resolves(activeTask);
-        sinon.stub(eventProtocol, 'publishTaskNotification').resolves();
+        waterline = helper.injector.get('Services.Waterline');
+        waterline.nodes = {
+            needByIdentifier: function() {}
+        };
+        sinon.stub(eventProtocol, 'publishNodeNotification').resolves();
+        sinon.stub(eventProtocol, 'publishBroadcastNotification').resolves();
+
+        needByIdentifier = sinon.stub(waterline.nodes, 'needByIdentifier');
+        needByIdentifier.resolves(node)
     });
 
-    after('stop HTTP server', function () {
+    after('Reset mocks', function () {
         function resetMocks(obj) {
             _(obj).methods().forEach(function (method) {
                 if (typeof obj[method].restore === 'function') {
@@ -35,41 +46,52 @@ describe('Http.Api.Notification', function () {
                 }
             }).value();
         }
-        resetMocks(taskProtocol);
         resetMocks(eventProtocol);
     });
 
     describe('POST /notification', function () {
-        it('should return notification detail', function () {
-            return notificationApiService.postNotification(notificationMessage)
+        it('should return node notification detail', function () {
+            return notificationApiService.postNodeNotification(nodeNotificationMessage)
             .then(function (resp) {
-                expect(resp).to.deep.equal(notificationMessage);
+                expect(resp).to.deep.equal(nodeNotificationMessage);
             });
         });
 
-        it('should fail with no taskId in query parameter', function () {
-            notificationMessage = {
-                data: 'dummy data'
-            };
-            return notificationApiService.postNotification(notificationMessage)
+        it('should fail with no nodeId', function () {
+            return notificationApiService.postNodeNotification(_.omit(nodeNotificationMessage, 'nodeId'))
             .then(function (done) {
                 done(new Error("Expected service to fail"));
             })
             .catch(function (e) {
-                expect(e).to.have.property('message').that.equals('Missing task ID in query or body');
+                expect(e).to.have.property('message').that.equals('Invalid node ID in query or body');
             });
         });
 
-        it('should fail with no data in query parameter', function () {
-            notificationMessage = {
-                taskId: "73b8ca01-735b-40d6-897a-7003ef2fa988"
-            };
-            return notificationApiService.postNotification(notificationMessage)
+        it('should fail with nodeId that is not a string', function () {
+            return notificationApiService.postNodeNotification(_.assign({}, nodeNotificationMessage, {nodeId: {data: "I am an object"}}))
             .then(function (done) {
                 done(new Error("Expected service to fail"));
             })
             .catch(function (e) {
-                expect(e).to.have.property('message').that.equals('Missing notification data in query or body');
+                expect(e).to.have.property('message').that.equals('Invalid node ID in query or body');
+            });
+        });
+
+        it('should fail with non-exist node', function () {
+            needByIdentifier.resolves();
+            return notificationApiService.postNodeNotification(nodeNotificationMessage)
+            .then(function (done) {
+                done(new Error("Expected service to fail"));
+            })
+            .catch(function (e) {
+                expect(e).to.have.property('message').that.equals('Node not found');
+            });
+        });
+
+        it('should return post broadcast notification', function () {
+            return notificationApiService.postBroadcastNotification(broadcastNotificationMessage)
+            .then(function (resp) {
+                expect(resp).to.deep.equal(broadcastNotificationMessage);
             });
         });
     });

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -133,7 +133,7 @@ paths:
             Node instance identifier
           required: false
           type: string
-        - name: notification_body
+        - name: data
           in: body
           description: |
             notification data

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -127,18 +127,19 @@ paths:
       description: |
         post a notification
       parameters:
-        - name: taskId
+        - name: nodeId
           in: query
+          description: |
+            Node instance identifier
+          required: false
+          type: string
+        - name: notification_body
+          in: body
           description: |
             task instance identifier
           required: false
-          type: string
-        - name: data
-          in: query
-          description: |
-            notification data
-          required: false
-          type: string
+          schema:
+            $ref: '#/definitions/notification_obj'
       tags: [ "/api/2.0" ]
       responses:
         201:
@@ -155,7 +156,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-
   /swagger:
     x-swagger-pipe: swagger_raw
 
@@ -182,6 +182,11 @@ definitions:
       message:
         type: string
       fields:
+        type: string
+
+  notification_obj:
+    properties:
+      nodeId:
         type: string
 
   generic_obj:

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -136,7 +136,7 @@ paths:
         - name: notification_body
           in: body
           description: |
-            task instance identifier
+            notification data
           required: false
           schema:
             $ref: '#/definitions/notification_obj'


### PR DESCRIPTION
Notification API design refactor:
* Route set to /notification
* In most cases, a notification will send to a node, so the API will accept a nodeId parameter, either in query string or request body, both POST /notification?nodeId=<nodeId> and POST /notification –d ‘{“nodeId”: ”<nodeId>”}’ will work.
  * The notification will be routed by AMQP with key “notification.<nodeId>”
* If the notification is send to other identities, say a workflow, the request will look like POST /notification?workflowId=<workflowId> or POST /notification –d ‘{“workflowId”: ”< workflowId >”}’. 
  * The notification will be routed by AMQP with key “notification.<workflowId >”
  * I will not code for this and leave it till the need comes.
* If no Id are specified in the parameter, the notification will be route by AMQP with key ‘notification’. This is kind of like a broadcast notification.
* All parameters including the Id are optional, and are defined and interpreted by the notification sender and receiver.  This design is meant to leave flexibility to the applications that want to send/receive notification
  * In the Isilon case where a progress needs to be sent, suggested parameters would look like:
    * Progress: the progress to 
    * Message: the additional message to send. 

This PR depends on: 
* https://github.com/RackHD/on-core/pull/191
* https://github.com/RackHD/on-tasks/pull/311
