### PR TITLE
Get profiles with macs and ips

### DIFF
--- a/data/profiles/boilerplate.ipxe
+++ b/data/profiles/boilerplate.ipxe
@@ -8,6 +8,9 @@ set syslog <%=server%>
 # Interface that requested an IP originally.
 set interface <%=macaddress%>
 
+# If macaddress is null, don't need to find boot interface
+isset ${interface} || goto ifConfigured
+
 # Reboot Interval
 set rebootInterval:int8 5
 

--- a/data/profiles/error.zt
+++ b/data/profiles/error.zt
@@ -1,9 +1,0 @@
-#!/usr/bin/Cli -p2
-enable
-echo
-echo "Renasar: Error occurred while preparing your zerotouch profile:"
-echo
-<% error.split('\n').forEach(function (line) { %>
-	echo "<%=line%>"
-<% }); %>
-echo

--- a/data/profiles/ipxe-info.ipxe
+++ b/data/profiles/ipxe-info.ipxe
@@ -1,0 +1,4 @@
+echo RackHD: <%=message%>
+echo RackHD: Booting to disk in ${rebootInterval} seconds...        
+sleep ${rebootInterval}        
+exit

--- a/data/profiles/redirect.ipxe
+++ b/data/profiles/redirect.ipxe
@@ -1,9 +1,31 @@
-set i:int8 1
-set macs ${net0/mac:hex}
+set i:int8 0
+
 :loop
-set current ${net${i}/mac:hex}
-isset ${current} || goto done
-set macs ${macs}&macs=${net${i}/mac:hex}
+set CurrentIp ${net${i}/ip}
+isset ${CurrentIp} || goto noipqueryset
+set CurrentIpQuery ips=${CurrentIp}
+goto ipquerysetdone
+:noipqueryset
+set CurrentIpQuery ips=
+:ipquerysetdone
+
+set CurrentMac ${net${i}/mac:hex}
+isset ${CurrentMac} || goto done
+set CurrentMacQuery macs=${CurrentMac}
+
+iseq ${i} 0 || goto notnic0queryset
+set IpsQuery ${CurrentIpQuery}
+set MacsQuery ${CurrentMacQuery}
+goto querysetdone
+
+:notnic0queryset
+set IpsQuery ${IpsQuery}&${CurrentIpQuery}
+set MacsQuery ${MacsQuery}&${CurrentMacQuery}
+:querysetdone
+
+echo RackHD: NIC${i} MAC: ${CurrentMac}
+echo RackHD: NIC${i} IP: ${CurrentIp}
+
 inc i
 iseq ${i} 100 || goto loop
 :done
@@ -30,8 +52,8 @@ echo Failed to download profile, retrying in ${getProfileRetryDelay} seconds
 sleep ${getProfileRetryDelay}
 
 :getProfile
-echo Chainloading next profile
-chain http://<%=server%>:<%=port%>/api/current/profiles?macs=${macs} || goto getProfileRetry
+echo RackHD: Chainloading next profile
+chain http://<%=server%>:<%=port%>/api/current/profiles?${MacsQuery}&${IpsQuery} || goto getProfileRetry
 
 :complete
 exit

--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -58,7 +58,7 @@ function profilesRouterFactory (
                     });
                 });
             } else {
-                presenter(req, res).renderProfile('redirect.ipxe', { isLookUpNotChecked: true });
+                presenter(req, res).renderProfile('redirect.ipxe', { ignoreLookup: true });
             }
         })
         .catch(function (err) {

--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -52,17 +52,13 @@ function profilesRouterFactory (
 
                 return profileApiService.getNode(macAddresses, options)
                 .then(function (node) {
-                    if (node.newRecord) {
-                        presenter(req, res).renderProfile('redirect.ipxe');
-                    } else {
-                        return profileApiService.renderProfileFromTaskOrNode(node, 'compute')
-                        .then(function (render) {
-                            presenter(req, res).renderProfile(render.profile, render.options, 200, render.context);
-                        });
-                    }
+                    return profileApiService.getProfileFromTaskOrNode(node, 'compute')
+                    .then(function (render) {
+                        presenter(req, res).renderProfile(render.profile, render.options, 200, render.context);
+                    });
                 });
             } else {
-                presenter(req, res).renderProfile('redirect.ipxe');
+                presenter(req, res).renderProfile('redirect.ipxe', { isLookUpNotChecked: true });
             }
         })
         .catch(function (err) {
@@ -88,7 +84,7 @@ function profilesRouterFactory (
 
         profileApiService.getNode(macAddresses, options)
         .then(function(node) {
-            return profileApiService.renderProfileFromTaskOrNode(node, 'switch');
+            return profileApiService.getProfileFromTaskOrNode(node, 'switch');
         })
         .then(function(render) {
             presenter(req, res).renderProfile(

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -183,7 +183,7 @@ function CommonApiPresenterFactory(
         status = status || 200;
 
         var promises = [
-            self._buildContext(graphContext, options.isLookUpNotChecked),
+            self._buildContext(graphContext, options.ignoreLookup),
             profiles.get(profile, true, scope)
         ];
 
@@ -226,7 +226,7 @@ function CommonApiPresenterFactory(
         });
     };
 
-    CommonApiPresenter.prototype._buildContext = function(graphContext, isLookUpNotChecked) {
+    CommonApiPresenter.prototype._buildContext = function(graphContext, ignoreLookup) {
         var self = this;
         var scope = self.res.locals.scope;
         var config = CommonApiPresenter.configCache;
@@ -247,7 +247,7 @@ function CommonApiPresenterFactory(
             ipaddress: self.res.locals.ipAddress,
             netmask: config.dhcpSubnetMask || '255.255.255.0',
             gateway: config.dhcpGateway || '10.1.1.1',
-            macaddress: isLookUpNotChecked ?
+            macaddress: ignoreLookup ?
                 '' : lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
             sku: Env.get('config', {}, [ scope[0] ]),
             env: Env.get('config', {}, scope),

--- a/lib/services/common-api-presenter.js
+++ b/lib/services/common-api-presenter.js
@@ -183,19 +183,16 @@ function CommonApiPresenterFactory(
         status = status || 200;
 
         var promises = [
-            self._buildContext(graphContext),
+            self._buildContext(graphContext, options.isLookUpNotChecked),
             profiles.get(profile, true, scope)
         ];
 
         if (profile.endsWith('.ipxe')) {
-            promises.push(profiles.get('error.ipxe', true, scope));
             promises.push(profiles.get('boilerplate.ipxe', true, scope));
-        } else if (profile.endsWith('.zt')) {
-            promises.push(profiles.get('error.zt', true, scope));
         }
 
         Promise.all(promises).spread(
-            function (localOptions, contents, errorPlate, boilerPlate) {
+            function (localOptions, contents, boilerPlate) {
                 var output = null;
 
                 options = _.merge({}, options, localOptions);
@@ -206,7 +203,7 @@ function CommonApiPresenterFactory(
                     // Render error we'll try to render the error profile + options.
                     try {
                         output = ejs.render(
-                            boilerPlate + (errorPlate || ''), // Don't stringify undefined
+                            boilerPlate, // Don't stringify undefined
                             _.merge(options, { error: err.message })
                         );
                     } catch (error) {
@@ -229,7 +226,7 @@ function CommonApiPresenterFactory(
         });
     };
 
-    CommonApiPresenter.prototype._buildContext = function(graphContext) {
+    CommonApiPresenter.prototype._buildContext = function(graphContext, isLookUpNotChecked) {
         var self = this;
         var scope = self.res.locals.scope;
         var config = CommonApiPresenter.configCache;
@@ -250,7 +247,8 @@ function CommonApiPresenterFactory(
             ipaddress: self.res.locals.ipAddress,
             netmask: config.dhcpSubnetMask || '255.255.255.0',
             gateway: config.dhcpGateway || '10.1.1.1',
-            macaddress: lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
+            macaddress: isLookUpNotChecked ?
+                '' : lookupService.ipAddressToMacAddress(self.res.locals.ipAddress),
             sku: Env.get('config', {}, [ scope[0] ]),
             env: Env.get('config', {}, scope),
             // Build structure that mimics the task renderContext

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -76,7 +76,7 @@ function profileApiServiceFactory(
     };
 
     ProfileApiService.prototype.setLookup = function(req) {
-        var query = req.query;
+        var query = req.swagger ? req.swagger.query : req.query;
         if (query.mac && query.ip) {
             return waterline.nodes.findByIdentifier(this.getMacs(query.mac))
             .then(function (node) {
@@ -103,7 +103,7 @@ function profileApiServiceFactory(
             var macAddresses = _.flattenDeep([query.macs]);
             var ipAddresses = _.flattenDeep([query.ips]);
             return Promise.map(ipAddresses, function(ip, index) {
-                if (ip) {
+                if (ip && macAddresses[index]) {
                     return lookupService.setIpAddress(ip, macAddresses[index]);
                 }
             });
@@ -344,7 +344,7 @@ function profileApiServiceFactory(
 
         var promises = [
             swaggerService.makeRenderableOptions(req, res, graphContext,
-                    profile.isLookUpNotChecked),
+                    profile.ignoreLookup),
             profiles.get(profile.profile, true, scope)
         ];
 
@@ -380,7 +380,7 @@ function profileApiServiceFactory(
                                 });
                         });
                 } else {
-                    return { profile: 'redirect.ipxe', isLookUpNotChecked: true };
+                    return { profile: 'redirect.ipxe', ignoreLookup: true };
                 }
             })
             .catch(function (err) {

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -98,6 +98,17 @@ function profileApiServiceFactory(
                 }
             });
         }
+
+        if (query.macs && query.ips) {
+            var macAddresses = _.flattenDeep([query.macs]);
+            var ipAddresses = _.flattenDeep([query.ips]);
+            return Promise.map(ipAddresses, function(ip, index) {
+                if (ip) {
+                    return lookupService.setIpAddress(ip, macAddresses[index]);
+                }
+            });
+        }
+
         return Promise.resolve();
     };
 
@@ -251,7 +262,7 @@ function profileApiServiceFactory(
         throw err;
     };
 
-    ProfileApiService.prototype.renderProfileFromTaskOrNode = function(node) {
+    ProfileApiService.prototype.getProfileFromTaskOrNode = function(node) {
         var self = this;
         var defaultProfile;
 
@@ -315,11 +326,12 @@ function profileApiServiceFactory(
                                 'Unable to retrieve valid node bootSettings', node.type);
                     }
                 } else {
-                    return self._handleProfileRenderError(
-                        'Unable to locate active workflow or there are no bootSettings',
-                        node.type,
-                        400
-                    );
+                    return {
+                        profile: 'ipxe-info.ipxe',
+                        options: { message:
+                            'No active workflow and bootSettings, continue to boot' },
+                        context: undefined
+                    };
                 }
             }
         });
@@ -331,7 +343,8 @@ function profileApiServiceFactory(
         var graphContext = profile.context || {};
 
         var promises = [
-            swaggerService.makeRenderableOptions(req, res, graphContext),
+            swaggerService.makeRenderableOptions(req, res, graphContext,
+                    profile.isLookUpNotChecked),
             profiles.get(profile.profile, true, scope)
         ];
 
@@ -361,17 +374,13 @@ function profileApiServiceFactory(
 
                     return self.getNode(macAddresses, options)
                         .then(function (node) {
-                            if (node.newRecord) {
-                                return { profile: 'redirect.ipxe' };
-                            } else {
-                                return self.renderProfileFromTaskOrNode(node, 'compute')
-                                    .then(function (render) {
-                                        return(render);
-                                    });
-                            }
+                            return self.getProfileFromTaskOrNode(node, 'compute')
+                                .then(function (render) {
+                                    return(render);
+                                });
                         });
                 } else {
-                    return { profile: 'redirect.ipxe' };
+                    return { profile: 'redirect.ipxe', isLookUpNotChecked: true };
                 }
             })
             .catch(function (err) {
@@ -402,7 +411,7 @@ function profileApiServiceFactory(
                 return self.getNode(macAddresses, options);
             })
             .then(function(node) {
-                return self.renderProfileFromTaskOrNode(node, 'switch');
+                return self.getProfileFromTaskOrNode(node, 'switch');
             })
             .catch(function (err) {
                 throw err;

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -252,7 +252,7 @@ function swaggerFactory(
         };
     }
 
-    function makeRenderableOptions(req, res, context) {
+    function makeRenderableOptions(req, res, context, isLookUpNotChecked) {
         var scope = res.locals.scope;
         var apiServer = util.format('http://%s:%d',
             config.get('apiServerAddress'),
@@ -267,7 +267,8 @@ function swaggerFactory(
             ipaddress: res.locals.ipAddress,
             netmask: config.get('dhcpSubnetMask', '255.255.255.0'),
             gateway: config.get('dhcpGateway', '10.1.1.1'),
-            macaddress: lookupService.ipAddressToMacAddress(res.locals.ipAddress),
+            macaddress: isLookUpNotChecked ?
+                '' : lookupService.ipAddressToMacAddress(res.locals.ipAddress),
             sku: env.get('config', {}, [ scope[0] ]),
             env: env.get('config', {}, scope),
             // Build structure that mimics the task renderContext

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -252,7 +252,7 @@ function swaggerFactory(
         };
     }
 
-    function makeRenderableOptions(req, res, context, isLookUpNotChecked) {
+    function makeRenderableOptions(req, res, context, ignoreLookup) {
         var scope = res.locals.scope;
         var apiServer = util.format('http://%s:%d',
             config.get('apiServerAddress'),
@@ -267,7 +267,7 @@ function swaggerFactory(
             ipaddress: res.locals.ipAddress,
             netmask: config.get('dhcpSubnetMask', '255.255.255.0'),
             gateway: config.get('dhcpGateway', '10.1.1.1'),
-            macaddress: isLookUpNotChecked ?
+            macaddress: ignoreLookup ?
                 '' : lookupService.ipAddressToMacAddress(res.locals.ipAddress),
             sku: env.get('config', {}, [ scope[0] ]),
             env: env.get('config', {}, scope),

--- a/spec/lib/api/1.1/profiles-spec.js
+++ b/spec/lib/api/1.1/profiles-spec.js
@@ -188,14 +188,14 @@ describe('Http.Api.Profiles', function () {
                 .expect(500);
         });
 
-        it("should send a 400 for a known node with no active graph", function() {
+        it("should send a 200 for a known node with no active graph", function() {
             profileApiService.createNodeAndRunDiscovery.resolves({});
             profileApiService.getNode.resolves({});
             workflowApiService.findActiveGraphForTarget.resolves(null);
 
             return helper.request().get('/api/1.1/profiles')
                 .query({ macs: '00:00:de:ad:be:ef' })
-                .expect(400);
+                .expect(200);
         });
 
         it("should send a 503 on failing to retrieve workflow properties", function() {
@@ -252,12 +252,12 @@ describe('Http.Api.Profiles', function () {
                 .expect(500);
         });
 
-        it("should return a 400 for a known node with no active graph", function() {
+        it("should return a 200 for a known node with no active graph", function() {
             profileApiService.getNode.resolves({ type: 'switch' });
             workflowApiService.findActiveGraphForTarget.resolves(null);
 
             return helper.request().get('/api/1.1/profiles/switch/testswitchvendor')
-                .expect(400);
+                .expect(200);
         });
 
         it("should return a 503 on failing to retrieve workflow properties", function() {

--- a/spec/lib/api/1.1/profiles-spec.js
+++ b/spec/lib/api/1.1/profiles-spec.js
@@ -150,7 +150,7 @@ describe('Http.Api.Profiles', function () {
 
         it("should call getNode with a compute node type", function() {
             return helper.request().get('/api/1.1/profiles')
-                .query({ macs: [ '00:01:02:03:04:05' ] })
+                .query({ macs: [ '00:01:02:03:04:05' ], ips: [ '172.31.128.5'] })
                 .expect(200)
                 .expect(function() {
                     expect(profileApiService.getNode).to.have.been.calledWith(
@@ -173,7 +173,7 @@ describe('Http.Api.Profiles', function () {
             profileApiService.getNode.restore();
             profileApiService.createNodeAndRunDiscovery.restore();
             return helper.request().get('/api/1.1/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(200)
                 .expect(function() {
                     expect(profiles.get).to.have.been.calledWith('redirect.ipxe');
@@ -184,7 +184,7 @@ describe('Http.Api.Profiles', function () {
             profileApiService.getNode.rejects(new Error('asdf'));
 
             return helper.request().get('/api/1.1/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(500);
         });
 
@@ -194,7 +194,7 @@ describe('Http.Api.Profiles', function () {
             workflowApiService.findActiveGraphForTarget.resolves(null);
 
             return helper.request().get('/api/1.1/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(200);
         });
 
@@ -206,7 +206,7 @@ describe('Http.Api.Profiles', function () {
             taskProtocol.requestProperties.rejects(new Error('Test workflow properties error'));
 
             return helper.request().get('/api/1.1/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(503);
         });
 
@@ -218,7 +218,7 @@ describe('Http.Api.Profiles', function () {
             taskProtocol.requestProperties.resolves({});
 
             return helper.request().get('/api/1.1/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(200)
                 .expect(function() {
                     expect(profiles.get).to.have.been.calledWith('test.profile');

--- a/spec/lib/api/2.0/profiles-spec.js
+++ b/spec/lib/api/2.0/profiles-spec.js
@@ -193,7 +193,7 @@ describe('Http.Api.Profiles', function () {
 
         it("should call getNode with a compute node type", function() {
             return helper.request().get('/api/2.0/profiles')
-                .query({ macs: [ '00:01:02:03:04:05' ] })
+                .query({ macs: [ '00:01:02:03:04:05' ], ips: [ '172.31.128.5' ] })
                 .expect(200)
                 .expect(function() {
                     expect(profileApiService.getNode).to.have.been.calledWith(
@@ -218,7 +218,7 @@ describe('Http.Api.Profiles', function () {
             profileApiService.createNodeAndRunDiscovery.restore();
 
             return helper.request().get('/api/2.0/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(200)
                 .expect(function() {
                     expect(profiles.get).to.have.been.calledWith('redirect.ipxe');
@@ -229,7 +229,7 @@ describe('Http.Api.Profiles', function () {
             profileApiService.getNode.rejects(new Error('asdf'));
 
             return helper.request().get('/api/2.0/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(500);
         });
 
@@ -239,7 +239,7 @@ describe('Http.Api.Profiles', function () {
             workflowApiService.findActiveGraphForTarget.resolves(null);
 
             return helper.request().get('/api/2.0/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(200);
         });
 
@@ -251,7 +251,7 @@ describe('Http.Api.Profiles', function () {
             taskProtocol.requestProperties.rejects(new Error('Test workflow properties error'));
 
             return helper.request().get('/api/2.0/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(503)
                 .then(function(resp) {
                     expect(resp.body.message).to.equal('Error: Unable to retrieve workflow properties');
@@ -266,7 +266,7 @@ describe('Http.Api.Profiles', function () {
             taskProtocol.requestProperties.resolves({});
 
             return helper.request().get('/api/2.0/profiles')
-                .query({ macs: '00:00:de:ad:be:ef' })
+                .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(200)
                 .expect(function() {
                     expect(profiles.get).to.have.been.calledWith('test.profile');

--- a/spec/lib/api/2.0/profiles-spec.js
+++ b/spec/lib/api/2.0/profiles-spec.js
@@ -233,19 +233,14 @@ describe('Http.Api.Profiles', function () {
                 .expect(500);
         });
 
-        it("should send a 400 for a known node with no active graph", function() {
+        it("should send a 200 for a known node with no active graph", function() {
             profileApiService.createNodeAndRunDiscovery.resolves({});
             profileApiService.getNode.resolves({});
             workflowApiService.findActiveGraphForTarget.resolves(null);
 
-            var errorMsg = "Error: Unable to locate active workflow or there are no bootSettings";
-
             return helper.request().get('/api/2.0/profiles')
                 .query({ macs: '00:00:de:ad:be:ef' })
-                .expect(400)
-                .then(function(resp) {
-                    expect(resp.body.message).to.equal(errorMsg);
-                });
+                .expect(200);
         });
 
         it("should send a 503 on failing to retrieve workflow properties", function() {
@@ -325,13 +320,8 @@ describe('Http.Api.Profiles', function () {
             profileApiService.getNode.resolves({ type: 'switch' });
             workflowApiService.findActiveGraphForTarget.resolves(null);
 
-            var errorMsg = "Error: Unable to locate active workflow or there are no bootSettings";
-
             return helper.request().get('/api/2.0/profiles/switch/testswitchvendor')
-                .expect( 400)
-                .then(function(resp) {
-                    expect(resp.body.message).to.equal(errorMsg);
-                });
+                .expect(200);
         });
 
         it("should return a 503 on failing to retrieve workflow properties", function() {

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -84,6 +84,20 @@ describe("Http.Services.Api.Profiles", function () {
             }
         };
 
+        var profileReq = {
+            query: {
+                'ips': ['ip1', 'ip2'],
+                'macs': ['mac1', 'mac2']
+            }
+        };
+
+        var profileReq1 = {
+            query: {
+                'ips': ['ip1', ''],
+                'macs': ['mac1', 'mac2']
+            }
+        };
+
         it("setLookup should add IP lookup entry for new node", function() {
             this.sandbox.stub(waterline.nodes, 'findByIdentifier').resolves(node);
             this.sandbox.stub(waterline.lookups, 'upsertProxyToMacAddress')
@@ -135,6 +149,24 @@ describe("Http.Services.Api.Profiles", function () {
                 expect(lookupService.setIpAddress).to.not.be.called;
                 expect(waterline.lookups.upsertProxyToMacAddress).to.not.be.called;
                 expect(result).to.be.undefined;
+            });
+        });
+
+        it("setLookup should set lookup when macs and ips exists in query", function() {
+            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
+
+            return profileApiService.setLookup(profileReq)
+            .then(function(result) {
+                expect(lookupService.setIpAddress).to.be.calledTwice;
+            });
+        });
+
+        it("setLookup should not set lookup if one ip is null in query", function() {
+            this.sandbox.stub(lookupService, 'setIpAddress').resolves();
+
+            return profileApiService.setLookup(profileReq1)
+            .then(function(result) {
+                expect(lookupService.setIpAddress).to.be.calledOnce;
             });
         });
 

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -238,7 +238,7 @@ describe("Http.Services.Api.Profiles", function () {
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
             this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
 
-            var promise = profileApiService.renderProfileFromTaskOrNode(node);
+            var promise = profileApiService.getProfileFromTaskOrNode(node);
 
             return expect(promise).to.be.rejectedWith('Unable to retrieve valid node bootSettings')
             .then(function() {
@@ -261,7 +261,7 @@ describe("Http.Services.Api.Profiles", function () {
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
             this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
 
-            return profileApiService.renderProfileFromTaskOrNode(node)
+            return profileApiService.getProfileFromTaskOrNode(node)
             .then(function(result) {
                 expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
                 expect(taskProtocol.requestProperties).to.not.be.called;
@@ -269,19 +269,23 @@ describe("Http.Services.Api.Profiles", function () {
             });
         });
 
-        it("render profile fail due to no active graph or there are no bootSettings", function() {
+        it("render profile pass when no active graph and bootSettings", function() {
             var node = { id: 'test', type: 'compute' };
 
             this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves(undefined);
             this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
 
-            var promise = profileApiService.renderProfileFromTaskOrNode(node);
-            return expect(promise)
-            .to.be.rejectedWith('Unable to locate active workflow or there are no bootSettings')
-            .then(function() {
+            return profileApiService.getProfileFromTaskOrNode(node)
+            .then(function(result) {
                 expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
                 expect(taskProtocol.requestProperties).to.not.be.called;
-                expect(promise.reason().status).to.equal(400);
+                expect(result).to.deep.equal({
+                    context: undefined,
+                    profile: 'ipxe-info.ipxe',
+                    options: { message:
+                        'No active workflow and bootSettings, continue to boot' }
+                });
+
             });
         });
 
@@ -293,7 +297,7 @@ describe("Http.Services.Api.Profiles", function () {
             this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
             this.sandbox.stub(taskProtocol, 'requestProperties').resolves({});
 
-            return profileApiService.renderProfileFromTaskOrNode(node)
+            return profileApiService.getProfileFromTaskOrNode(node)
             .then(function(result) {
                 expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
                 expect(taskProtocol.requestProfile).to.have.been.calledOnce;
@@ -313,7 +317,7 @@ describe("Http.Services.Api.Profiles", function () {
             this.sandbox.stub(taskProtocol, 'requestProfile').resolves('profile');
             this.sandbox.stub(taskProtocol, 'requestProperties').rejects(new Error(''));
 
-            var promise = profileApiService.renderProfileFromTaskOrNode(node);
+            var promise = profileApiService.getProfileFromTaskOrNode(node);
 
             return expect(promise).to.be.rejectedWith('Unable to retrieve workflow properties')
             .then(function() {

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -998,6 +998,15 @@ paths:
           items:
             type: string
           collectionFormat: multi
+        - name: ips
+          in: query
+          description: |
+            List of IP addresses to lookup
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
         - name: mac
           in: query
           description: |


### PR DESCRIPTION
PR for proposal https://groups.google.com/forum/#!topic/rackhd/I81Tl2qkQMI
related on-dhcp-proxy PR  https://github.com/RackHD/on-dhcp-proxy/pull/52

changes:
1. support geting profiles with macs and ips instead of 'macs' and 'mac & ip' for static ip address for both 1.1 and 2.0 GET /profiles route
2. remove duplicated profile rendering for new node 'node.newRecord'
3. refine naming of 'renderProfileFromTaskOrNode' to 'getProfileFromTaskOrNode'
4. treat 'no active workflow and boot settings' as  expected information.
5. remove error.zt to be consistent with @benbp PR https://github.com/RackHD/on-http/pull/376  and also be consistent with 2.0 GET /profiles API
6. fix 2.0 profile service's 'self.res.xxxx' to 'res.xxxx'

@RackHD/corecommitters  @benno  @jlongever 