### PR TITLE
Fix http return code for POST node workflow

### DIFF
--- a/static/monorail.yml
+++ b/static/monorail.yml
@@ -1007,7 +1007,7 @@ paths:
         - workflow
         - post
       responses:
-        200:
+        201:
           description: |
             the workflow that was created
           schema:


### PR DESCRIPTION
Should be 201, not 200

reference: https://github.com/RackHD/on-http/blob/master/lib/api/1.1/northbound/nodes.js#L498


`gorackhd` code generated based on this swagger spec thinks this call fails because its expecting  `200`.