### PR TITLE
Cleanup of 2.0 API schemas

### DIFF
--- a/spec/lib/api/2.0/lookups-spec.js
+++ b/spec/lib/api/2.0/lookups-spec.js
@@ -108,12 +108,13 @@ describe('Http.Api.Lookup 2.0', function () {
 
         describe('POST', function () {
             it('should call waterline.lookups.create', function() {
+                var postData = _.omit(data[0], [ 'id', 'createdAt', 'updatedAt' ]);
                 return helper.request().post('/api/2.0/lookups')
-                    .send(data[0])
+                    .send(postData)
                     .expect('Content-Type', /^application\/json/)
                     .expect(201)
                     .expect(function () {
-                        expect(create).to.have.been.calledWith(sinon.match(data[0]));
+                        expect(create).to.have.been.calledWith(sinon.match(postData));
                     });
             });
             it('should reject invalid input', function() {
@@ -140,12 +141,13 @@ describe('Http.Api.Lookup 2.0', function () {
 
         describe('PATCH', function () {
             it('should call waterline.lookups.updateOneById with 123', function() {
+                var patchData = _.omit(data[0], [ 'id', 'createdAt', 'updatedAt' ]);
                 return helper.request().patch('/api/2.0/lookups/123')
-                    .send(data[0])
+                    .send(patchData)
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .expect(function () {
-                        expect(updateOneById).to.have.been.calledWith('123', sinon.match(data[0]));
+                        expect(updateOneById).to.have.been.calledWith('123', patchData);
                     });
             });
 

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -14,7 +14,7 @@ describe('2.0 Http.Api.Nodes', function () {
     var nodesApi;
 
     before('start HTTP server', function () {
-        this.timeout(5000);
+        this.timeout(10000);
         return helper.startServer([
         ]).then(function () {
             configuration = helper.injector.get('Services.Configuration');
@@ -106,6 +106,12 @@ describe('2.0 Http.Api.Nodes', function () {
         type: 'compute',
         workflows: '/api/2.0/nodes/1234abcd1234abcd1234abcd/workflows'
     };
+
+    var postNode = {
+        name: 'name',
+        type: 'compute'
+    };
+
     var rawNode = {
         autoDiscover: "false",
         id: '1234abcd1234abcd1234abcd',
@@ -140,13 +146,13 @@ describe('2.0 Http.Api.Nodes', function () {
             nodeApiService.postNode.resolves(node);
 
             return helper.request().post('/api/2.0/nodes')
-                .send(rawNode)
+                .send(postNode)
                 .expect('Content-Type', /^application\/json/)
                 .expect(201, node)
                 .expect(function () {
                     expect(nodeApiService.postNode).to.have.been.calledOnce;
                     expect(nodeApiService.postNode.firstCall.args[0])
-                        .to.have.property('id').that.equals(node.id);
+                        .to.have.property('name').that.equals(node.name);
                 });
         });
     });

--- a/spec/lib/api/2.0/pollers-spec.js
+++ b/spec/lib/api/2.0/pollers-spec.js
@@ -257,9 +257,8 @@ describe('Http.Api.Pollers', function () {
         });
 
         it('should update with PATCH /pollers', function () {
-            poller.pollInterval = 20000;
             return helper.request().patch('/api/2.0/pollers/' + poller.id)
-            .send(poller)
+            .send( { pollInterval: 20000} )
             .expect('Content-Type', /^application\/json/)
             .expect(200)
             .expect(function (res) {

--- a/spec/lib/api/2.0/skus-spec.js
+++ b/spec/lib/api/2.0/skus-spec.js
@@ -85,7 +85,7 @@ describe('Http.Api.Skus.2.0', function() {
         sku: '0987'
     };
 
-    var input = {
+    var record = {
         name: 'my test sku',
         rules: [
             {
@@ -116,48 +116,56 @@ describe('Http.Api.Skus.2.0', function() {
         var sku;
 
         it('should create a sku', function(){
-            skuApiService.postSku.resolves(input);
+            skuApiService.postSku.resolves(_.assign({}, record));
             return helper.request().post('/api/2.0/skus')
-                .send(input)
+                .send(_.omit(record, 'id'))
                 .expect('Content-Type', /^application\/json/)
                 .expect(201)
                 .then(function (req) {
                     sku = req.body;
-                    expect(sku).to.have.property('name').that.equals(input.name);
-                    expect(sku).to.have.property('rules').that.deep.equals(input.rules);
+                    expect(sku).to.have.property('name').that.equals(record.name);
+                    expect(sku).to.have.property('rules').that.deep.equals(record.rules);
                     expect(sku).to.have.property('discoveryGraphName')
-                        .that.equals(input.discoveryGraphName);
+                        .that.equals(record.discoveryGraphName);
                     expect(sku).to.have.property('discoveryGraphOptions')
-                        .that.deep.equals(input.discoveryGraphOptions);
+                        .that.deep.equals(record.discoveryGraphOptions);
                 });
         });
 
         it('should contain the new sku in GET /skus', function () {
-            skuApiService.getSkus.resolves([input]);
+            skuApiService.getSkus.resolves([_.assign({}, record)]);
             return helper.request().get('/api/2.0/skus')
                 .expect('Content-Type', /^application\/json/)
-                .expect(200, [sku])
-                .then(function () {
+                .expect(200)
+                .then(function (res) {
                     expect(skuApiService.getSkus).to.have.been.called;
+                    var checkSku = res.body;
+                    expect(res.body).to.have.lengthOf(1);
+                    expect(res.body[0]).to.have.property('name').that.equals(record.name);
+                    expect(res.body[0]).to.have.property('rules').that.deep.equals(record.rules);
+                    expect(res.body[0]).to.have.property('discoveryGraphName')
+                        .that.equals(record.discoveryGraphName);
+                    expect(res.body[0]).to.have.property('discoveryGraphOptions')
+                        .that.deep.equals(record.discoveryGraphOptions);
             });
         });
 
         it('should return the same sku from GET /skus/:id', function () {
-            skuApiService.getSkusById.resolves(input);
+            skuApiService.getSkusById.resolves(_.assign({}, record));
             return helper.request().get('/api/2.0/skus/' + sku.id)
                 .expect('Content-Type', /^application\/json/)
                 .expect(200)
                 .then(function (res) {
                     expect(skuApiService.getSkusById).to.have.been.called;
                     var checkSku = res.body;
-                    expect(checkSku).to.have.property('name').that.equals(input.name);
+                    expect(checkSku).to.have.property('name').that.equals(record.name);
                 });
         });
 
         it('should 201 reputting the same sku', function() {
-            skuApiService.upsertSku.resolves(input);
+            skuApiService.upsertSku.resolves(_.assign({}, record));
             return helper.request().put('/api/2.0/skus')
-                .send(input)
+                .send(_.omit(record, 'id'))
                 .expect(201)
                 .then(function () {
                     expect(skuApiService.upsertSku).to.have.been.called;
@@ -191,7 +199,7 @@ describe('Http.Api.Skus.2.0', function() {
                 sku.name = 'updated sku name';
                 skuApiService.patchSku.resolves(updatedInput);
                 return helper.request().patch('/api/2.0/skus/0987')
-                    .send(input)
+                    .send(_.omit(record, 'id'))
                     .expect('Content-Type', /^application\/json/)
                     .expect(200)
                     .then(function (res) {

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -2548,7 +2548,7 @@ paths:
       operationId: lookupsPost
       x-privileges: [ 'Write' ]
       x-authentication-type: [ 'jwt' ]
-      x-swagger-schema: Lookups.2.0.json#/definitions/LookupPost
+      x-swagger-schema: lookups.2.0.json#/definitions/LookupPost
       summary: |
         Post a lookup
       description: |
@@ -2629,7 +2629,7 @@ paths:
       operationId: lookupsPatchById
       x-privileges: [ 'Write' ]
       x-authentication-type: [ 'jwt' ]
-      x-swagger-schema: Lookups.2.0.json#/definitions/LookupBase
+      x-swagger-schema: lookups.2.0.json#/definitions/LookupBase
       summary: |
         Patch a lookup
       description: |

--- a/static/schemas/2.0/lookups.2.0.json
+++ b/static/schemas/2.0/lookups.2.0.json
@@ -16,7 +16,8 @@
                     "type": "string",
                     "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "LookupPost": {
             "allOf": [

--- a/static/schemas/2.0/node.2.0.json
+++ b/static/schemas/2.0/node.2.0.json
@@ -5,6 +5,10 @@
             "description": "A node discovered by RackHD",
             "type": "object",
             "properties": {
+                "autoDiscover": {
+                    "description": "Enable automatic discovery",
+                    "type": "string"
+                },
                 "name": {
                     "description": "Name of the node",
                     "type": "string"
@@ -29,8 +33,16 @@
                 "sshSettings": {
                     "description": "SSH settings",
                     "type": "object"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "uniqueItems": true
+                    }
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "Node": {
             "allOf": [

--- a/static/schemas/2.0/poller.2.0.json
+++ b/static/schemas/2.0/poller.2.0.json
@@ -22,7 +22,8 @@
                     "description": "Poller configuration object",
                     "type": "object"
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "Poller": {
             "allOf": [

--- a/static/schemas/2.0/skus.2.0.json
+++ b/static/schemas/2.0/skus.2.0.json
@@ -83,7 +83,8 @@
                 "discoveryGraphOptions": {
                     "type": "object"
                 }
-            }
+            },
+            "additionalProperties": false
         }
     }
 }


### PR DESCRIPTION
* Clear additionalProperties for all schemas.
* Add tags property to nodes schema
* Change unit tests to abide by new schema rules.