### PR TITLE
Migrate query.mac and query.ip to query.macs and query.ips

### DIFF
--- a/lib/api/1.1/southbound/profiles.js
+++ b/lib/api/1.1/southbound/profiles.js
@@ -41,7 +41,7 @@ function profilesRouterFactory (
      */
 
     router.get('/profiles', function (req, res) {
-        return profileApiService.setLookup(req)
+        return profileApiService.setLookup(req, res)
         .then(function() {
             var macs = req.query.mac || req.query.macs;
             if (macs) {

--- a/lib/api/2.0/profiles.js
+++ b/lib/api/2.0/profiles.js
@@ -32,7 +32,7 @@ var profilesPutLibByName  = controller({success: 201}, function(req) {
 
 // GET /api/2.0/profiles
 var profilesGet = controller(function (req, res) {
-    return profilesApiService.getProfiles(req, req.swagger.query)
+    return profilesApiService.getProfiles(req, req.swagger.query, res)
         .then(function (render) {
             return profilesApiService.renderProfile(render, req, res);
         });

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -75,36 +75,22 @@ function profileApiServiceFactory(
         return _.flattenDeep([macs]);
     };
 
-    ProfileApiService.prototype.setLookup = function(req) {
+    ProfileApiService.prototype.setLookup = function(req, res) {
         var query = req.swagger ? req.swagger.query : req.query;
-        if (query.mac && query.ip) {
-            return waterline.nodes.findByIdentifier(this.getMacs(query.mac))
-            .then(function (node) {
-                if (_.isUndefined(node)) {
-                    return lookupService.setIpAddress(
-                        query.ip,
-                        query.mac
-                    );
-                }
-            }).then(function (node) {
-                if ( node && req.get(Constants.HttpHeaders.ApiProxyIp) ) {
-                    var proxy =  'http://%s:%s'.format(
-                        req.get(Constants.HttpHeaders.ApiProxyIp),
-                        req.get(Constants.HttpHeaders.ApiProxyPort)
-                    );
-                    return waterline.lookups.upsertProxyToMacAddress(proxy, query.mac);
-                } else {
-                    return node;
-                }
-            });
-        }
 
         if (query.macs && query.ips) {
             var macAddresses = _.flattenDeep([query.macs]);
             var ipAddresses = _.flattenDeep([query.ips]);
             return Promise.map(ipAddresses, function(ip, index) {
-                if (ip && macAddresses[index]) {
+                if (ip && macAddresses[index] && (ip === res.locals.ipAddress)) {
                     return lookupService.setIpAddress(ip, macAddresses[index]);
+                }
+                if (req.get(Constants.HttpHeaders.ApiProxyIp) && macAddresses[index]) {
+                    var proxy =  'http://%s:%s'.format(
+                        req.get(Constants.HttpHeaders.ApiProxyIp),
+                        req.get(Constants.HttpHeaders.ApiProxyPort)
+                    );
+                    return waterline.lookups.upsertProxyToMacAddress(proxy, macAddresses[index]);
                 }
             });
         }
@@ -361,9 +347,9 @@ function profileApiServiceFactory(
         );
     };
 
-    ProfileApiService.prototype.getProfiles = function(req, query) {
+    ProfileApiService.prototype.getProfiles = function(req, query, res) {
         var self = this;
-        return this.setLookup(req)
+        return this.setLookup(req, res)
             .then(function() {
                 var macs = query.mac || query.macs;
                 if (macs) {


### PR DESCRIPTION
1. Deprecate query.mac and query.ip and use unified query.macs and query.ips. 
2. no matter node exist or don't exist, update lookup every time in case IP is changed for some reason.

@RackHD/corecommitters @jeamland @jlongever 