### PR TITLE
Add unit-testing for template files

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "istanbul": "^0.3.5",
     "jsdoc": "^3.3.0-alpha13",
     "jshint": "^2.5.11",
+    "jsonlint": "^1.6.2",
     "mocha": "^2.1.0",
     "nock": "~3.5.0",
     "rewire": "^2.5.1",

--- a/spec/data/profiles/install-centos-ipxe-spec.js
+++ b/spec/data/profiles/install-centos-ipxe-spec.js
@@ -1,0 +1,20 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var jsonlint = require('jsonlint');
+var fs = require('fs');
+var path = require('path');
+
+describe('install-centos.ipxe', function() {
+    var subject = 'data/profiles/install-centos.ipxe';
+    var context = jsonlint.parse(
+        fs.readFileSync(path.resolve(__dirname, '../samples/os-common-options.json')).toString()
+    );
+
+    it('should succeed to render', function() {
+        helper.startTemplateTest(subject)
+            .render(context)
+            .expectSuccess();
+    });
+});

--- a/spec/data/profiles/install-esx-ipxe-spec.js
+++ b/spec/data/profiles/install-esx-ipxe-spec.js
@@ -1,0 +1,24 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var jsonlint = require('jsonlint');
+var fs = require('fs');
+var path = require('path');
+
+describe('install-esx.ipxe', function() {
+    var subject = 'data/profiles/install-esx.ipxe';
+    var context = jsonlint.parse(
+        fs.readFileSync(path.resolve(__dirname, '../samples/os-common-options.json')).toString()
+    );
+    context = _.defaults({
+        mbootFile: 'http://172.31.128.1:9080/esxi/6.0/mboot.c32',
+        esxBootConfigTemplateUri: 'http://172.31.128.1:9080/api/current/templates/esx-boot-cfg'
+    }, context);
+
+    it('should succeed to render', function() {
+        helper.startTemplateTest(subject)
+            .render(context)
+            .expectSuccess();
+    });
+});

--- a/spec/data/samples/os-common-options.json
+++ b/spec/data/samples/os-common-options.json
@@ -1,0 +1,113 @@
+{
+    "version": "1.0",
+    "repo": "http://172.31.128.1:9080/os/repo",
+    "rootPassword": "MyPassword",
+    "rootPlainPassword": "MyPassword",
+    "rootEncryptedPassword": "****Pass****",
+    "hostname": "rackhd-node",
+    "domain": "example.com",
+    "ntpServers": ["ntp0.com", "ntp1.com"],
+    "comport": "com1",
+    "users": [
+        {
+            "name": "rackhd1",
+            "password": "123456",
+            "encryptedPassword": "***1***",
+            "uid": 1010,
+            "sshKey": "mysshkey1"
+        },
+        {
+            "name": "rackhd2",
+            "password": "123456",
+            "encryptedPassword": "***2***"
+        }
+    ],
+    "rootSshKey": "mysshkey2",
+    "dnsServers": ["172.12.88.91", "192.168.20.77"],
+    "networkDevices": [
+        {
+            "device": "eth0",
+            "ipv4": {
+                "ipAddr": "192.168.1.29",
+                "gateway": "192.168.1.1",
+                "netmask": "255.255.255.0",
+                "vlanIds": [104, 105]
+            },
+            "ipv6": {
+                "ipAddr": "fec0::6ab4:0:5efe:157.60.14.21",
+                "gateway": "fe80::5efe:131.107.25.1",
+                "netmask": "ffff.ffff.ffff.ffff.0.0.0.0",
+                "vlanIds": [101, 106]
+            }
+        },
+        {
+            "device": "eth1",
+            "ipv4": {
+                "ipAddr": "192.168.11.89",
+                "gateway": "192.168.11.1",
+                "netmask": "255.255.255.0",
+                "vlanIds": [110]
+            },
+            "ipv6": {
+                "ipAddr": "fec0::6ab4:0:5efe:159.45.14.11",
+                "gateway": "fe80::5efe:131.107.25.100",
+                "netmask": "ffff.ffff.ffff.ffff.0.0.0.0"
+            }
+        },
+        {
+            "device": "eth2",
+            "ipv4": {
+                "ipAddr": "192.168.22.34",
+                "gateway": "192.168.22.1",
+                "netmask": "255.255.255.0"
+            },
+            "ipv6": {
+                "ipAddr": "fec0::6ab4:0:5efe:159.45.22.11",
+                "gateway": "fe80::5efe:131.107.10.100",
+                "netmask": "ffff.ffff.ffff.ffff.0.0.0.0"
+            }
+        },
+        {
+            "device": "eth3",
+            "ipv4": {
+                "ipAddr": "192.168.33.56",
+                "gateway": "192.168.33.1",
+                "netmask": "255.255.255.0"
+            }
+        },
+        {
+            "device": "eth4",
+            "ipv6": {
+                "ipAddr": "fec0::6ab4:0:5efe:159.45.56.78",
+                "gateway": "fe80::5efe:131.107.32.100",
+                "netmask": "ffff.ffff.ffff.ffff.0.0.0.0"
+            }
+        }
+    ],
+    "installDisk": "/dev/sda",
+    "installPartitions": [
+        {
+            "mountPoint": "/boot",
+            "size": "128",
+            "fsType": "ext4"
+        },
+        {
+            "mountPoint": "/root",
+            "size": "128",
+            "fsType": "ext4"
+        },
+        {
+            "mountPoint": "swap",
+            "size": "128",
+            "fsType": "swap"
+        },
+        {
+            "mountPoint": "/",
+            "size": "0",
+            "fsType": "ext3"
+        }
+    ],
+    "rackhdCallbackScript": "rackhdcallback",
+    "installScriptUri": "http://abc.com/script",
+    "kvm": true
+}

--- a/spec/data/templates-syntax-check-spec.js
+++ b/spec/data/templates-syntax-check-spec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var ejs = require('ejs');
+var glob = require('glob');
+var path = require('path');
+var fs = require('fs');
+
+describe('Templates Syntax Check', function() {
+    var patterns = [
+        '/data/profiles/*',
+        '/data/templates/*'
+    ];
+
+    var files = _.reduce(patterns, function(acc, pattern) {
+        acc.push(glob.sync(process.cwd() + pattern, {nodir: true}));
+        return acc;
+    }, []);
+
+    _.forEach(_.flattenDeep(files), function(file) {
+        it(path.basename(file), function() {
+            var data = fs.readFileSync(file).toString();
+            //Ejs compilation success proves the template has no syntax error
+            ejs.compile(data, {compileDebug: true});
+        });
+    });
+});

--- a/spec/data/templates/centos-ks-spec.js
+++ b/spec/data/templates/centos-ks-spec.js
@@ -1,0 +1,31 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var jsonlint = require('jsonlint');
+
+describe('centos-ks', function() {
+    var subject = 'data/templates/centos-ks';
+    var context = jsonlint.parse(
+        fs.readFileSync(path.resolve(__dirname, '../samples/os-common-options.json')).toString()
+    );
+
+    it('should succeed to render', function() {
+        helper.startTemplateTest(subject)
+            .render(context)
+            .expectSuccess();
+    });
+
+    ['users', 'networkDevices', 'kvm', 'installPartitions', 'rootSshKey',
+            'dnsServers'].forEach(function(key) {
+        var cloneContext = _.cloneDeep(context);
+        delete cloneContext[key];
+        it('should still succeed to render if missing "' + key + '"', function() {
+            helper.startTemplateTest(subject)
+                .render(cloneContext)
+                .expectSuccess();
+        });
+    });
+});

--- a/spec/data/templates/esx-ks-spec.js
+++ b/spec/data/templates/esx-ks-spec.js
@@ -1,0 +1,45 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var jsonlint = require('jsonlint');
+
+describe('esx-ks', function() {
+    var subject = 'data/templates/esx-ks';
+    var context = jsonlint.parse(
+        fs.readFileSync(path.resolve(__dirname, '../samples/os-common-options.json')).toString()
+    );
+    context = _.defaults({
+        esxBootConfigTemplateUri: 'esx-boot-cfg',
+        postInstallCommands: ['cmd1', 'cmd2'],
+        switchDevices: [
+            {
+                'switchName': 'vSwitch0',
+                'uplinks': ['vmnic3', 'vmnic4']
+            },
+            {
+                'switchName': 'vSwitch1',
+                'uplinks': ['vmnic0', '3c:62:1c:ad:d6:ab']
+            }
+        ]
+    }, context);
+
+    it('should succeed to render', function() {
+        helper.startTemplateTest(subject)
+            .render(context)
+            .expectSuccess();
+    });
+
+    ['users', 'networkDevices', 'kvm', 'rootSshKey', 'ntpServers', 'postInstallCommands',
+            'hostname', 'domain', 'dnsServers', 'switchDevices'].forEach(function(key) {
+        var cloneContext = _.cloneDeep(context);
+        delete cloneContext[key];
+        it('should still succeed to render if missing ' + key, function() {
+            helper.startTemplateTest(subject)
+                .render(cloneContext)
+                .expectSuccess();
+        });
+    });
+});

--- a/spec/data/templates/install-photon/photon-os-ks-spec.js
+++ b/spec/data/templates/install-photon/photon-os-ks-spec.js
@@ -1,0 +1,35 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('photon-os-ks', function() {
+    var fs = require('fs');
+    var jsonlint = require('jsonlint');
+    var path = require('path');
+
+    var subject = 'data/templates/install-photon/photon-os-ks';
+    var context = jsonlint.parse(
+        fs.readFileSync(
+            path.resolve(__dirname, '../../samples/os-common-options.json')
+        ).toString()
+    );
+    context = _.defaults({
+        installType: "full"
+    }, context);
+
+    it('should succeed to render', function() {
+        helper.startTemplateTest(subject)
+            .render(context)
+            .expectFormat('json');
+    });
+
+    ['hostname', 'installPartitions'].forEach(function(key) {
+        var cloneContext = _.cloneDeep(context);
+        delete cloneContext[key];
+        it('should still succeed to render if missing "' + key + '"', function() {
+            helper.startTemplateTest(subject)
+                .render(cloneContext)
+                .expectFormat('json');
+        });
+    });
+});

--- a/spec/data/templates/install-photon/post-install-photon.sh-spec.js
+++ b/spec/data/templates/install-photon/post-install-photon.sh-spec.js
@@ -1,0 +1,35 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('post-install-photon.sh', function() {
+    var fs = require('fs');
+    var jsonlint = require('jsonlint');
+    var path = require('path');
+
+    var subject = 'data/templates/install-photon/post-install-photon.sh';
+    var context = jsonlint.parse(
+        fs.readFileSync(
+            path.resolve(__dirname, '../../samples/os-common-options.json')
+        ).toString()
+    );
+    context = _.defaults({
+        installType: "full"
+    }, context);
+
+    it('should succeed to render', function() {
+        helper.startTemplateTest(subject)
+            .render(context)
+            .expectSuccess();
+    });
+
+    ['networkDevices', 'dnsServers', 'users', 'domain'].forEach(function(key) {
+        var cloneContext = _.cloneDeep(context);
+        delete cloneContext[key];
+        it('should still succeed to render if missing "' + key + '"', function() {
+            helper.startTemplateTest(subject)
+                .render(cloneContext)
+                .expectSuccess();
+        });
+    });
+});

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -89,3 +89,35 @@ helper.request = function (url, options) {
 
     return agent;
 };
+
+helper.startTemplateTest = function (subject) {
+    var TemplateUnitTestHelper = require('./template-ut-helper.js');
+    var templateHelper = new TemplateUnitTestHelper();
+    templateHelper.setWorkingDir(process.cwd());
+    if (subject) {
+        templateHelper.setTemplateFile(subject);
+    }
+    var baseUrl = 'http://127.31.128.1:9080/api/current';
+    templateHelper.setCommonContext({
+        server: '172.31.128.1',
+        port: 9080,
+        ipaddress: '172.31.128.8',
+        netmask: '255.255.255.0',
+        gateway: '10.1.1.1',
+        macaddress: '11:22:33:44:55:66',
+        sku: {},
+        env: {},
+        api: {
+            server: 'http://172.31.128.1:9080',
+            base: baseUrl,
+            templates: baseUrl + '/templates',
+            profiles: baseUrl + '/profiles',
+            lookups: baseUrl + '/lookups',
+            files: baseUrl + '/files',
+            nodes: baseUrl + '/nodes'
+        },
+        context: {},
+        nodeId: 'testNode'
+    });
+    return templateHelper;
+};

--- a/spec/template-ut-helper-spec.js
+++ b/spec/template-ut-helper-spec.js
@@ -1,0 +1,404 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+describe('template-ut-helper', function() {
+    var TemplateUtHelper = require('./template-ut-helper.js');
+    var instance;
+    var sandbox;
+    var fs = require('fs');
+
+    var t1 = "foo=<%=a%>;bar=<%=b%>";
+    var r1 = "foo=1;bar=2";
+    var c = { a : 1, b : 2 };
+
+    before(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    beforeEach(function() {
+        sandbox.restore();
+        instance = new TemplateUtHelper();
+    });
+
+    describe('render', function() {
+        it('should generate rendered result and return this', function() {
+            var ret = instance.setTemplate(t1).render(c).expectSuccess();
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should not throw error even render fails', function() {
+            instance.setTemplate("<%=notExist%>").render(c);
+        });
+
+        it('should throw error if render context is not object', function() {
+            [1, 'abc', [1, 2]].forEach(function(val) {
+                expect(function() {
+                    instance.setTemplate(t1).render(val);
+                }).to.throw(Error);
+            });
+        });
+    });
+
+    describe('tap', function() {
+        it('should peek the generated result and return this', function() {
+            var ret = instance.setTemplate(t1).render(c).tap(function(result) {
+                expect(result).to.equal(r1);
+            });
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should fail if the tap argument is not function', function() {
+            [1, 'abc', { a: 1}, [1, 2], null].forEach(function(val) {
+                expect(function() {
+                    instance.setTemplate(t1).render(c).tap(val);
+                }).to.throw(Error);
+            });
+        });
+    });
+
+    describe('expectSuccess', function() {
+        it('should pass if render succeeds and return this', function() {
+            var ret = instance.setTemplate(t1).render(c).expectSuccess();
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should fail if render fails', function() {
+            expect(function() {
+                instance.setTemplate("<%=NotExist%>").render(c).expectSuccess();
+            }).to.throw(Error);
+        });
+
+        it('should fail if not call render before', function() {
+            expect(function() {
+                instance.setTemplate(t1).expectSuccess();
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('expectFailure', function() {
+        it('should pass if render fails and return this', function() {
+            var ret = instance.setTemplate("<%=NotExist%>").render(c).expectFailure();
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should fail if render succeeds', function() {
+            expect(function() {
+                instance.setTemplate(t1).render(c).expectFailure();
+            }).to.throw(/template render succeeds/);
+        });
+
+        it('should fail if not call render before', function() {
+            expect(function() {
+                instance.setTemplate("<%=NotExist%>").expectFailure();
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('setIgnoreWhiteSpaces', function() {
+        var t = "  \n\n foo=<%=a%>  \n\n\r\n  bar=<%=b%>\n\n\n";
+        var r = "foo=1\nbar=2";
+
+        it('should ignore white spaces by setIgnoreWhiteSpaces and return this', function() {
+            var ret = instance.setTemplate(t).setIgnoreWhiteSpaces().render(c).expect(r);
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should ignore white spaces by setFlags and return this', function() {
+            var ret = instance.setTemplate(t)
+                .setFlags( { ignoreWhiteSpaces: true } )
+                .render(c)
+                .expect(r);
+            expect(ret).to.deep.equal(instance);
+        });
+    });
+
+    describe('setBlankLines', function() {
+        var t = "  \n\n foo=<%=a%>  \n\n\r\n  bar=<%=b%>\n\n\n";
+        var r = " foo=1  \n  bar=2\n";
+        it('should ignore blank lines by setIgnoreBlankLines and return this', function() {
+            var ret = instance.setTemplate(t).setIgnoreBlankLines().render(c).expect(r);
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should ignore blank lines by setFlags and return this', function() {
+            var ret = instance.setTemplate(t)
+                .setFlags( { ignoreBlankLines: true } )
+                .render(c)
+                .expect(r);
+            expect(ret).to.deep.equal(instance);
+        });
+    });
+
+    describe('expect', function() {
+        it('should pass and return this', function() {
+            var ret = instance.setTemplate(t1).render(c).expect(r1);
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should fail if data is not matching', function() {
+            expect(function() {
+                instance.setTemplate(t1).render(c).expect('notexist');
+            }).to.throw(Error);
+        });
+
+        it('should fail if not call render before', function() {
+            expect(function() {
+                instance.setTemplate(t1).expect(r1);
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('expectJson', function() {
+        var t = ' { "foo": <%=a%>, "bar": <%=b%> } ';
+        var r = { foo: 1, bar: 2 };
+
+        it('should compare with JSON data and return this', function() {
+            var ret = instance.setTemplate(t).render(c).expectJson(r);
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should fail if expection input is not correct', function() {
+            expect(function() {
+                instance.setTemplate(t).render(c).expectJson({foo: 2, bar: 2});
+            }).to.throw(Error);
+        });
+
+        it('should fail if template is not valid JSON', function() {
+            expect(function() {
+                instance.setTemplate("foo:<%=a%>").render(c).expectJson(r);
+            }).to.throw(/Parse error/);
+        });
+
+        it('should fail if not call render before', function() {
+            expect(function() {
+                instance.setTemplate(t).expectJson(r);
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('toJson', function() {
+        var t = ' { "foo": <%=a%>, "bar": <%=b%> } ';
+        var r = { foo: 1, bar: 2 };
+
+        it('should generate correct JSON object and return this', function() {
+            var ret = instance.setTemplate(t)
+                .render(c)
+                .toJson()
+                .tap(function(result) {
+                    expect(result).to.deep.equal(r);
+                });
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should fail for invalid JSON template', function() {
+            expect(function() {
+                instance.setTemplate('"foo: <%=a%>')
+                    .render(c)
+                    .toJson();
+            }).to.throw(/Parse error/);
+        });
+
+        it('should fail if not call render before', function() {
+            expect(function() {
+                instance.setTemplate(t).toJson();
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('expectFormat', function() {
+        var t = ' { "foo": <%=a%>, "bar": <%=b%> } ';
+
+        it('should succeed to expect JSON format and return this', function() {
+            var ret = instance.setTemplate(t).render(c).expectFormat('json');
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should succeed to expect raw format', function() {
+            instance.setTemplate(t).render(c).expectFormat('raw');
+            instance.setTemplate("abc<%=a%>").render(c).expectFormat('raw');
+        });
+
+        it('should fail if input format is not supported', function() {
+            expect(function() {
+                instance.setTemplate(t).render(c).expectFormat('NotSupport');
+            }).to.throw(/invalid input format/);
+        });
+
+        it('should be case insensitive', function() {
+            instance.setTemplate(t).render(c).expectFormat('Json');
+            instance.setTemplate(t).render(c).expectFormat('JSON');
+            instance.setTemplate(t).render(c).expectFormat('JsoN');
+        });
+
+        it('should fail if not call render before', function() {
+            expect(function() {
+                instance.setTemplate(t).expectFormat('json');
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('setTemplateFile', function() {
+        it('should load template data from file and return this', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/file/path').returns(t1);
+            var ret = instance.setTemplateFile('/the/file/path').render(c).expect(r1);
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should work well in workingDir', function() {
+            sandbox.stub(fs, 'readFileSync')
+                .withArgs('/the/file/path').returns(t1)
+                .withArgs('file/path').throws();
+            instance.setWorkingDir('/the').setTemplateFile('file/path').render(c).expect(r1);
+            expect(fs.readFileSync).to.be.calledWith('/the/file/path');
+        });
+
+        it('should throw error if file is not exising', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/file/path').throws(
+                new Error('The file is not existing'));
+            expect(function() {
+                instance.setTemplateFile('/the/file/path').render(c).expect(r1);
+            }).to.throw('The file is not existing');
+        });
+
+        it('should throw error if filepath is not string', function() {
+            [null, 123, [1, 2], {a: 1}].forEach(function(val) {
+                expect(function() {
+                    instance.setTemplateFile(val);
+                }).to.throw(Error);
+            });
+        });
+    });
+
+    describe('expectFile', function() {
+        it('should load expection data from file and return this', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/expect/file/path').returns(r1);
+            var ret = instance.setTemplate(t1).render(c).expectFile('/the/expect/file/path');
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should work well in workingDir', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/expect/file/path').returns(r1);
+            instance.setWorkingDir('/the/expect').setTemplate(t1).render(c).expectFile('file/path');
+        });
+
+        it('should fail if filepath is not string', function() {
+            [null, 123, [1, 2], {a: 1}, ''].forEach(function(val) {
+                expect(function() {
+                    instance.setWorkingDir('').setTemplate(t1).render(c).expectFile(val);
+                }).to.throw(Error);
+            });
+        });
+
+        it('should fail if read file fails', function() {
+            sandbox.stub(fs, 'readFileSync').throws(new Error('Mock Read File Error'));
+            expect(function() {
+                instance.setTemplate(t1).render(c).expectFile('/the/expect/file/path');
+            }).to.throw('Mock Read File Error');
+        });
+
+        it('should fail if not call render before', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/expect/file/path').returns(r1);
+            expect(function() {
+                instance.setTemplate(t1).expectFile('/the/expect/file/path');
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('expectJsonFile', function() {
+        var t = ' { "foo": <%=a%>, "bar": <%=b%> } ';
+        var r = '{"foo":1, "bar":2}';
+
+        it('should read & parse JSON data from file and return this', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/file/path').returns(r);
+            var ret = instance.setTemplate(t).render(c).expectJsonFile('/the/file/path');
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should work well in workingDir', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/file/path').returns(r);
+            instance.setWorkingDir('/the').setTemplate(t).render(c).expectJsonFile('file/path');
+        });
+
+        it('should fail if input file is not valid JSON', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/file/path').returns("a:1");
+            expect(function() {
+                instance.setTemplate(t).render(c).expectJsonFile('/the/file/path');
+            }).to.throw(/Parse error/);
+        });
+
+        it('should fail if read file fails', function() {
+            sandbox.stub(fs, 'readFileSync').throws(new Error('Mock Read File Error'));
+            expect(function() {
+                instance.setTemplate(t1).render(c).expectJsonFile('/the/file/path');
+            }).to.throw('Mock Read File Error');
+        });
+
+        it('should fail if not call render before', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/file/path').returns(r);
+            expect(function() {
+                instance.setTemplate(t1).expectJsonFile('/the/file/path');
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('save', function() {
+        it('should write file and return this', function() {
+            sandbox.stub(fs, 'writeFileSync');
+            var ret = instance.setTemplate(t1).render(c).save('/the/file/path');
+            expect(fs.writeFileSync).to.be.calledWith('/the/file/path', r1);
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should work well in workingDir', function() {
+            sandbox.stub(fs, 'writeFileSync')
+                .withArgs('/the/file/path').returns()
+                .withArgs('file/path').throws();
+            instance.setWorkingDir('/the').setTemplate(t1).render(c).save('file/path');
+            expect(fs.writeFileSync).to.be.calledWith('/the/file/path', r1);
+        });
+
+        it('should fail if write file fails', function() {
+            sandbox.stub(fs, 'writeFileSync').throws(new Error('write file error'));
+            expect(function() {
+                instance.setTemplate(t1).render(c).save('/the/file/path');
+            }).to.throw('write file error');
+        });
+
+        it('should fail if not call render before', function() {
+            sandbox.stub(fs, 'writeFileSync');
+            expect(function() {
+                instance.setTemplate(t1).save('/the/file/path');
+            }).to.throw(/call render before/);
+        });
+    });
+
+    describe('setWorkingDir', function() {
+        it('should set default workingDir to empty', function() {
+            sandbox.stub(fs, 'readFileSync').withArgs('/the/expect/file/path').returns(r1);
+            var ret = instance.setTemplate(t1).render(c).expectFile('/the/expect/file/path');
+            expect(ret).to.deep.equal(instance);
+        });
+
+        it('should return this', function() {
+            expect(instance.setWorkingDir('/foo/bar')).to.deep.equal(instance);
+        });
+    });
+
+    describe('setCommonContext', function() {
+        it('should fetch options from common context', function() {
+            instance.setTemplate("foo=<%=foo%>,bar=<%=bar%>")
+                .setCommonContext({foo:1, bar:2})
+                .render({})
+                .expect("foo=1,bar=2");
+            instance.setTemplate("foo=<%=foo%>,bar=<%=bar%>")
+                .setCommonContext({foo:3})
+                .render({bar:4})
+                .expect("foo=3,bar=4");
+            instance.setTemplate("foo=<%=foo%>,bar=<%=bar%>")
+                .setCommonContext({foo:5, bar:6})
+                .render({bar:7})
+                .expect("foo=5,bar=7");
+        });
+    });
+});

--- a/spec/template-ut-helper.js
+++ b/spec/template-ut-helper.js
@@ -1,0 +1,368 @@
+// Copyright 2016, EMC, Inc.
+'use strict';
+
+module.exports = TemplateUnitTestHelper;
+
+var ejs = require('ejs');
+var fs = require('fs');
+var path = require('path');
+//jsonlint will report more beautiful error message and help identify problem
+var jsonlint = require('jsonlint');
+
+var SUPPORT_FORMATS = ['raw', 'json'];
+
+/**
+ * Remove all white spaces
+ *
+ * The white spaces including blank lines, heading and tailing white spaces for each line.
+ *
+ * @param {String} text - The data to process
+ * @return {String} The data that has been removed all white spaces.
+ */
+function removeWhiteSpaces(text) {
+    //remove all empty lines, heading & trailing white spaces
+    text = text.trim();
+    return text.replace(/\s*(?=\n|\r|\r\n)\s*/gm, '\n');
+}
+
+/**
+ * Remove all blank lines
+ *
+ * Compare with removeWhiteSpaces, this function only remove blank lines, the heading and tailing
+ * white spaces for each line will still be kept
+ *
+ * @param {String} text - The data to process
+ * @return {String} The data that has been removed all white spaces.
+ */
+function removeBlankLines(text) {
+    text = text.trim();
+    return text.replace(/(?=\n|\r|\r\n)(\n|\r|\r\n)+/gm, '\n');
+}
+
+/**
+ * Helper class that assists template unit-testing
+ */
+function TemplateUnitTestHelper() {
+    this.reset();
+}
+
+/**
+ * reset all parameters to default
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.reset = function() {
+    this.workingDir = '';
+    this.ejsOptions = { compileDebug: true };
+    this.flags = {};
+    this.renderResult = null;
+    this.renderError = null;
+    this.commonContext = {};
+    return this;
+};
+
+/**
+ * Check whether has valid render result
+ * @return {Boolean} true if has valid render result, otherwise false
+ */
+TemplateUnitTestHelper.prototype._hasValidResult = function() {
+    return (!this.renderError && _.isString(this.renderResult));
+};
+
+/**
+ * Adjust the data by flags
+ * @param {String} data - The data to be adjusted.
+ * @return {String} The new data that has adjusted.
+ */
+TemplateUnitTestHelper.prototype._adjustData = function(data) {
+    var newData = data;
+    if (this.flags.ignoreWhiteSpaces) {
+        newData = removeWhiteSpaces(newData);
+    } else if (this.flags.ignoreBlankLines) {
+        newData = removeBlankLines(newData);
+    }
+    return newData;
+};
+
+/**
+ * Set the template that to be tested
+ * @param {String} fileContent - The template content
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.setTemplate = function(fileContent) {
+    this.template = ejs.compile(fileContent, this.ejsOptions);
+    return this;
+};
+
+/**
+ * Set the template that to be tested from file path
+ * @param {String} filePath - The path of template file
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.setTemplateFile = function(filePath) {
+    var realPath = path.resolve(this.workingDir, filePath);
+    this.setTemplate(fs.readFileSync(realPath).toString());
+    return this;
+};
+
+/**
+ * Set the working directory
+ *
+ * If working directory is set, the following input file path should be use the relative path to
+ * the working directory
+ *
+ * @param {String} dir - the working directory name
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.setWorkingDir = function(dir) {
+    this.workingDir = dir;
+    return this;
+};
+
+/**
+ * Set the flags
+ *
+ * The flags will impact how to process the rendered result and input expectation data.
+ * Now only following flags are supported:
+ * - ignoreWhiteSpaces: ignore all white spaces while comparing render and result expectation data
+ * - ignoreBlanklines: ignore all blank lines while comparing render result and expectation data
+ *
+ * @param {Object} flags - The flags to be set
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.setFlags = function(flags) {
+    _.defaults(this.flags, flags);
+    if (this._hasValidResult()) {
+        this.renderResult = this._adjustData(this.renderResult);
+    }
+    return this;
+};
+
+/**
+ * Set to ignore all white spaces during assertion
+ * This is a shortcut for setFlags({ignoreWhiteSpaces: true})
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.setIgnoreWhiteSpaces = function() {
+    this.setFlags({ ignoreWhiteSpaces: true });
+    return this;
+};
+
+/**
+ * Set to ignore all blank lines during assertion
+ * This is a shortcut for setFlags({ignoreBlankLines: true})
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.setIgnoreBlankLines = function() {
+    this.setFlags({ ignoreBlankLines: true });
+    return this;
+};
+
+/**
+ * Do template render
+ *
+ * The render will not throw error even if the render fails. The render result or error will be
+ * stored and will be used in later assertion.
+ *
+ * @param {Object} context - The context that will be feed into template rendering
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.render = function(context) {
+    if (context) {
+        expect(context).to.be.an('Object');
+    }
+    else {
+        context = {};
+    }
+    context = _.defaults(context, this.commonContext);
+    if (!_.isFunction(this.template)) {
+        throw new Error('The template has not been set before doing render');
+    }
+    try {
+        this.renderResult = this._adjustData(this.template(context));
+        this.renderError = null;
+    }
+    catch (err) {
+        this.renderResult = null;
+        this.renderError = err;
+    }
+    return this;
+};
+
+/**
+ * The common check for both success and failure cases
+ * @return {this} Return this if check succeeds.
+ * @throw {Error} Throw error if check fails.
+ */
+TemplateUnitTestHelper.prototype._commonCheck = function() {
+    if (this.renderResult || this.renderResult === '' || this.renderError) {
+        return this;
+    }
+    throw new Error('You have to call render before doing assertion');
+};
+
+/**
+ * Check no error has happened during rendering
+ * @return {this} Return this if no rendering error.
+ * @throw {Error} Throw error if has rendering error.
+ */
+TemplateUnitTestHelper.prototype._successCheck = function() {
+    this._commonCheck();
+    if (this.renderError) {
+        throw this.renderError;
+    }
+    return this;
+};
+
+/**
+ * Check error has happened during rendering
+ * @return {this} Return this if has rendering error.
+ * @throw {Error} Throw error if no rendering error.
+ */
+TemplateUnitTestHelper.prototype._failureCheck = function() {
+    this._commonCheck();
+    if (!this.renderError) {
+        throw new Error('The template render succeeds, but you expect failure');
+    }
+    return this;
+};
+
+/**
+ * Peek the render result
+ * @param {Function} callback - The render result will be passed to the first argument of the
+ * callback function
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.tap = function(callback) {
+    expect(callback).to.be.a('Function');
+    this._successCheck();
+    callback(this.renderResult);
+    return this;
+};
+
+/**
+ * Assert there is failure happens for template rendering
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.expectFailure = function() {
+    this._failureCheck();
+    return this;
+};
+
+/**
+ * Assert there is no failure happens for template rendering
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.expectSuccess = function() {
+    this._successCheck();
+    return this;
+};
+
+/**
+ * Assert the render result equals to the input expectation.
+ * @param {String} expectedResult - The input expectation value
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.expect = function(expectedResult) {
+    expect(expectedResult).to.be.a('String');
+    this._successCheck();
+    expectedResult = this._adjustData(expectedResult);
+    expect(this.renderResult).to.equal(expectedResult);
+    return this;
+};
+
+/**
+ * Assert the render result equals to content of input file
+ * @param {String} expectedFilePath - The filepath that stores the expectation value.
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.expectFile = function(expectedFilePath) {
+    expect(expectedFilePath).to.be.a('String');
+    expect(expectedFilePath).to.not.be.empty;
+    this._successCheck();
+    var realPath = path.resolve(this.workingDir, expectedFilePath);
+    var expectedResult = fs.readFileSync(realPath).toString();
+    return this.expect(expectedResult);
+};
+
+/**
+ * Assert the render result is JSON and equals to the input object
+ * @param {JSON} expectedJson - The expected JSON data
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.expectJson = function(expectedJson) {
+    this._successCheck();
+    var resultJson = jsonlint.parse(this.renderResult);
+    expect(resultJson).to.deep.equal(expectedJson);
+    return this;
+};
+
+/**
+ * Assert the render result is JSON and equals to the content of input file
+ * @param {String} filePath - The input filepath that stores the expected JSON data
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.expectJsonFile = function(filePath) {
+    expect(filePath).to.be.a('String');
+    expect(filePath).to.not.be.empty;
+    this._successCheck();
+    var realPath = path.resolve(this.workingDir, filePath);
+    var expectedResult = jsonlint.parse(fs.readFileSync(realPath).toString());
+    return this.expectJson(expectedResult);
+};
+
+/**
+ * Assert the render result conforms to the input format
+ * @param {String} format - The expected format
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.expectFormat = function(format) {
+    this._successCheck();
+
+    format = format.toLowerCase();
+    if (SUPPORT_FORMATS.indexOf(format) < 0) {
+        throw new Error('invalid input format ' + JSON.stringify(format) +
+            ', only support ' + SUPPORT_FORMATS.toString());
+    }
+    if (format === 'json') {
+        jsonlint.parse(this.renderResult);
+    }
+    return this;
+};
+
+/**
+ * Convert the render result to JSON object
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.toJson = function() {
+    this._successCheck();
+    if (!_.isString(this.renderResult)) {
+        throw new Error('The cached render result is not string before converting to JSON');
+    }
+    this.renderResult = jsonlint.parse(this.renderResult);
+    return this;
+};
+
+/**
+ * Save the render result to a file
+ * @param {String} filePath - The output file path
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.save = function(filePath) {
+    expect(filePath).to.be.a('String');
+    expect(filePath).to.not.be.empty;
+    this._successCheck();
+    var realPath = path.resolve(this.workingDir, filePath);
+    fs.writeFileSync(realPath, this.renderResult);
+    return this;
+};
+
+/**
+ * Set the common context for rendering
+ * @param {Object} context - The common context that sharedby everying rendering.
+ * @return {this}
+ */
+TemplateUnitTestHelper.prototype.setCommonContext = function(context) {
+    expect(context).to.be.an('Object');
+    this.commonContext = context;
+    return this;
+};


### PR DESCRIPTION
As I found we put a lot logic into the template file, but it lacks the unit-testing to ensure these logic works as expected. So this PR is to add unit-testing for template files.

I specially created a helper class in [spec/template-ut-helper.js](https://github.com/yyscamper/on-http/blob/e1a5281ab24ddfc67b3ca2e621ada990171fddad/spec/template-ut-helper.js) (and corresponding unit-testing [spec/template-ut-helper-spec.js](https://github.com/yyscamper/on-http/blob/e1a5281ab24ddfc67b3ca2e621ada990171fddad/spec/template-ut-helper-spec.js)) to assist template unit-testing, this class defines a lot chainable methods to obtain the similar syntax just like the style we do unit-testing for API using supertest. 

I also choose some existing template files and write the test cases for them, these test cases can be considered as example to guide the design for other template files. 

Meanwhile, during the design, I also found some template error, so I fix it take this opportunity.

**Just like previous PRs for task-schema, though this PR includes a lot change, but most of  them are similliar**

@RackHD/corecommitters @iceiilin @WangWinson @pengz1 