### PR TITLE
Fix issue that fails to POST workflow via tag

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -75,13 +75,15 @@ var nodesGetWorkflowById = controller(function(req) {
 });
 
 var nodesPostWorkflowById = controller({success: 201}, function(req) {
-    var config = _.defaults(req.swagger.query || {}, req.body || {});
+    var config = _.defaults(
+        req.swagger.params.name.value ? { name: req.swagger.params.name.value } : {},
+        req.swagger.params.body.value || {}
+    );
     return nodes.setNodeWorkflow(config, req.swagger.params.identifier.value);
 });
 
 var nodesWorkflowActionById = controller({success: 202}, function(req, res) {
     var command = req.body.command;
-    var options = req.body.options || {};
 
     var actionFunctions = {
         cancel: function() {

--- a/lib/api/2.0/tags.js
+++ b/lib/api/2.0/tags.js
@@ -12,7 +12,7 @@ var parseUrl = require('url').parse;
 
 function getTagName(req) {
     //TODO: sway 1.0.0 implements a fix for this, but it is lacking in the ^0.6.0 versions
-    //      so we duplicate the 1.0.0 implementation here. 
+    //      so we duplicate the 1.0.0 implementation here.
     // Ref: https://github.com/apigee-127/sway/commit/1b7acd9743aae2f2f94057d3f8911e2af72614f5
     var pathObject = req.swagger.operation.pathObject;
     var pathMatch = pathObject.regexp.exec(parseUrl(req.url).pathname);
@@ -57,9 +57,11 @@ var getNodesByTag = controller(function(req) {
 
 var postWorkflowById = controller({success: 202}, function(req) {
     return nodes.getNodesByTag(getTagName(req)).map(function(node) {
-        return nodes.setNodeWorkflow(node.id,
-            req.swagger.params.name.value || req.swagger.params.body.value.name,
-            req.swagger.params.body.value.options);
+        var config = _.defaults(
+            req.swagger.params.name.value ? { name: req.swagger.params.name.value } : {},
+            req.swagger.params.body.value || {}
+        );
+        return nodes.setNodeWorkflow(config, node.id);
     });
 });
 

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -540,8 +540,9 @@ describe('2.0 Http.Api.Nodes', function () {
         it('should create a workflow via the querystring', function () {
             nodeApiService.setNodeWorkflow.resolves(graph);
 
-            return helper.request().post('/api/2.0/nodes/123/workflows')
-                .send({ name: 'TestGraph.Dummy', domain: 'test' })
+            return helper.request()
+                .post('/api/2.0/nodes/123/workflows?name=TestGraph.Dummy')
+                .send({ domain: 'test' })
                 .expect('Content-Type', /^application\/json/)
                 .expect(201)
                 .expect(function () {
@@ -556,11 +557,31 @@ describe('2.0 Http.Api.Nodes', function () {
                 });
         });
 
+        it('should let the graph name in querystring take precedance over body', function () {
+            nodeApiService.setNodeWorkflow.resolves(graph);
+
+            return helper.request().post('/api/2.0/nodes/123/workflows?name=Graph.foo')
+                .send({ name: 'Graph.bar', options: { test: 'foo' }, domain: 'test' })
+                .expect('Content-Type', /^application\/json/)
+                .expect(201)
+                .expect(function () {
+                    expect(nodeApiService.setNodeWorkflow).to.have.been.calledOnce;
+                    expect(nodeApiService.setNodeWorkflow).to.have.been.calledWith(
+                        {
+                            name: 'Graph.foo',
+                            domain: 'test',
+                            options: { test: 'foo' }
+                        },
+                        '123'
+                    );
+                });
+        });
+
         it('should create a workflow with options via the querystring', function () {
             nodeApiService.setNodeWorkflow.resolves(graph);
 
-            return helper.request().post('/api/2.0/nodes/123/workflows')
-                .send({ name: 'TestGraph.Dummy', options: { test: 'foo' }, domain: 'test' })
+            return helper.request().post('/api/2.0/nodes/123/workflows?name=TestGraph.Dummy')
+                .send({ options: { test: 'foo' }, domain: 'test' })
                 .expect('Content-Type', /^application\/json/)
                 .expect(201)
                 .expect(function () {
@@ -720,5 +741,5 @@ describe('2.0 Http.Api.Nodes', function () {
                 });
         });
     });
-    
+
 });

--- a/spec/lib/api/2.0/tags-spec.js
+++ b/spec/lib/api/2.0/tags-spec.js
@@ -223,13 +223,13 @@ describe('Http.Api.Tags', function () {
                     });
             });
 
-            it('should 400 if tag name is not existing', function() {
+            it('should 404 if tag name is not existing', function() {
                 sandbox.stub(nodesApi, 'getNodesByTag').withArgs('tag001')
-                    .rejects(new Error('fail to find tag with name tag001'));
+                    .rejects(new Errors.NotFoundError('fail to find tag with name tag001'));
                 return helper.request()
                     .post('/api/2.0/tags/tag001/nodes/workflows')
                     .send({ name: 'Graph.test', options: { test: true} })
-                    .expect(400);
+                    .expect(404);
             });
 
             it('should 400 if run workflow fails for first node', function() {

--- a/spec/lib/api/2.0/tags-spec.js
+++ b/spec/lib/api/2.0/tags-spec.js
@@ -11,6 +11,7 @@ describe('Http.Api.Tags', function () {
     var Errors;
     var nodesApi;
     var tagsApi;
+    var sandbox = sinon.sandbox.create();
 
     before('start HTTP server', function () {
         this.timeout(10000);
@@ -48,6 +49,8 @@ describe('Http.Api.Tags', function () {
         lookupService = helper.injector.get('Services.Lookup');
         lookupService.ipAddressToMacAddress = sinon.stub().resolves();
         lookupService.ipAddressToNodeId = sinon.stub().resolves();
+
+        sandbox.restore();
     });
 
     after('stop HTTP server', function () {
@@ -153,6 +156,109 @@ describe('Http.Api.Tags', function () {
             tagsApi.getTag.rejects(new Errors.NotFoundError());
             return helper.request().delete('/api/2.0/tags/bad-tag-name')
                 .expect(204);
+        });
+
+        describe('POST /tags/:tagName/nodes/workflows', function() {
+            it('should support specify workflow name via body', function() {
+                sandbox.stub(nodesApi, 'getNodesByTag').withArgs('tag001').resolves([
+                    { id: 'nodeId1' },
+                    { id: 'nodeId2' }
+                ]);
+                sandbox.stub(nodesApi, 'setNodeWorkflow')
+                    .onFirstCall().resolves({ id: 'graphId1' })
+                    .onSecondCall().resolves({ id: 'graphId2' });
+                return helper.request()
+                    .post('/api/2.0/tags/tag001/nodes/workflows')
+                    .send({ name: 'Graph.test', domain: 'test', options: { test: true} })
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(202, [ {id: 'graphId1'}, {id: 'graphId2'}])
+                    .then(function() {
+                        expect(nodesApi.getNodesByTag).to.be.calledWith('tag001');
+                        expect(nodesApi.setNodeWorkflow).to.be.calledTwice;
+                        expect(nodesApi.setNodeWorkflow.firstCall).to.be.calledWith(
+                            {name: 'Graph.test', domain: 'test', options: { test: true } },
+                            'nodeId1' );
+                        expect(nodesApi.setNodeWorkflow.secondCall).to.be.calledWith(
+                            {name: 'Graph.test', domain: 'test', options: { test: true } },
+                            'nodeId2' );
+                    });
+            });
+
+            it('should support specify workflow name via query', function() {
+                sandbox.stub(nodesApi, 'getNodesByTag').withArgs('tag001').resolves([
+                    { id: 'nodeId1' },
+                    { id: 'nodeId2' }
+                ]);
+                sandbox.stub(nodesApi, 'setNodeWorkflow')
+                    .onFirstCall().resolves({ id: 'graphId1' })
+                    .onSecondCall().resolves({ id: 'graphId2' });
+                return helper.request()
+                    .post('/api/2.0/tags/tag001/nodes/workflows?name=Graph.test')
+                    .send({ domain: 'test',  options: { test: true} })
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(202, [ {id: 'graphId1'}, {id: 'graphId2'}])
+                    .then(function() {
+                        expect(nodesApi.getNodesByTag).to.be.calledWith('tag001');
+                        expect(nodesApi.setNodeWorkflow).to.be.calledTwice;
+                        expect(nodesApi.setNodeWorkflow.firstCall).to.be.calledWith(
+                            {name: 'Graph.test', domain: 'test', options: { test: true } },
+                            'nodeId1' );
+                        expect(nodesApi.setNodeWorkflow.secondCall).to.be.calledWith(
+                            {name: 'Graph.test', domain: 'test', options: { test: true } },
+                            'nodeId2' );
+                    });
+            });
+
+            it('should succeed if no nodes are binded with tag', function() {
+                sandbox.stub(nodesApi, 'getNodesByTag').withArgs('tag001').resolves([]);
+                sandbox.stub(nodesApi, 'setNodeWorkflow').resolves({id: 'graphId'});
+                return helper.request()
+                    .post('/api/2.0/tags/tag001/nodes/workflows')
+                    .send({ name: 'Graph.test', options: { test: true} })
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(202)
+                    .then(function() {
+                        expect(nodesApi.getNodesByTag).to.be.calledWith('tag001');
+                        expect(nodesApi.setNodeWorkflow).to.not.be.called;
+                    });
+            });
+
+            it('should 400 if tag name is not existing', function() {
+                sandbox.stub(nodesApi, 'getNodesByTag').withArgs('tag001')
+                    .rejects(new Error('fail to find tag with name tag001'));
+                return helper.request()
+                    .post('/api/2.0/tags/tag001/nodes/workflows')
+                    .send({ name: 'Graph.test', options: { test: true} })
+                    .expect(400);
+            });
+
+            it('should 400 if run workflow fails for first node', function() {
+                sandbox.stub(nodesApi, 'getNodesByTag').withArgs('tag001').resolves([
+                    { id: 'nodeId1' },
+                    { id: 'nodeId2' }
+                ]);
+                sandbox.stub(nodesApi, 'setNodeWorkflow')
+                    .onFirstCall().rejects(new Error('graph error'))
+                    .onSecondCall().resolves({ id: 'graphId2' });
+                return helper.request()
+                    .post('/api/2.0/tags/tag001/nodes/workflows')
+                    .send({ name: 'Graph.test', options: { test: true} })
+                    .expect(400);
+            });
+
+            it('should 400 if run workflow fails for second node', function() {
+                sandbox.stub(nodesApi, 'getNodesByTag').withArgs('tag001').resolves([
+                    { id: 'nodeId1' },
+                    { id: 'nodeId2' }
+                ]);
+                sandbox.stub(nodesApi, 'setNodeWorkflow')
+                    .onFirstCall().resolves({ id: 'graphId1' })
+                    .onSecondCall().rejects(new Error('graph error'));
+                return helper.request()
+                    .post('/api/2.0/tags/tag001/nodes/workflows')
+                    .send({ name: 'Graph.test', options: { test: true} })
+                    .expect(400);
+            });
         });
     });
 });


### PR DESCRIPTION
Resolves https://github.com/RackHD/on-http/issues/429

Root cause:
The argument order for setNodeWorkflow is not correct.

@RackHD/corecommitters @lhw4d4 @srinia6 