### PR TITLE
added rack node type and node relation management

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -120,6 +120,24 @@ var nodesMasterDelTagById = controller({success: 204}, function(req) {
     return nodes.masterDelTagById(req.swagger.params.tagName.value);
 });
 
+var nodesDelRelations = controller(function(req) {
+   return nodes.editNodeRelations(req.swagger.params.identifier.value,
+           req.body,
+           nodes._removeRelation
+        );
+});
+
+var nodesAddRelations = controller(function(req) {
+   return nodes.editNodeRelations(req.swagger.params.identifier.value,
+           req.body,
+           nodes._addRelation
+        );
+});
+
+var nodesGetRelations = controller(function(req) {
+   return nodes.getNodeRelations(req.swagger.params.identifier.value);
+});
+
 module.exports = {
     nodesGetAll: nodesGetAll,
     nodesPost: nodesPost,
@@ -137,5 +155,8 @@ module.exports = {
     nodesGetTagsById: nodesGetTagsById,
     nodesDelTagById: nodesDelTagById,
     nodesPatchTagById: nodesPatchTagById,
-    nodesMasterDelTagById: nodesMasterDelTagById
+    nodesMasterDelTagById: nodesMasterDelTagById,
+    nodesDelRelations: nodesDelRelations,
+    nodesAddRelations: nodesAddRelations,
+    nodesGetRelations: nodesGetRelations
 };

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -280,6 +280,11 @@ function nodeApiServiceFactory(
                     }
                 };
                 return workflowApiService.createAndRunGraph(configuration);
+            } else if (node.type === Constants.NodeTypes.Rack) {
+                return eventsProtocol.publishNodeEvent(node, 'added')
+                .then(function() {
+                    return node;
+                });
             }
             return node;
         });

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -47,23 +47,27 @@ function nodeApiServiceFactory(
      * @param  {String}     type
      * @return {Promise}    array of target nodes
      */
-    NodeApiService.prototype._findTargetNodes = function(node, type) {
-        if (!_.has(node, 'relations')) {
+    NodeApiService.prototype._findTargetNodes = function(relations, type) {
+        return this._needTargetNodes(relations, type)
+        .catch(function (err) {
+            logger.warning("Error getting target node with type " + type,
+                { error: err });
+            return [];
+        });
+    };
+
+    NodeApiService.prototype._needTargetNodes = function(relations, type) {
+        if (!relations) {
             return Promise.resolve([]);
         }
 
-        var relation = _.find(node.relations, { relationType: type });
+        var relation = _.find(relations, { relationType: type });
         if (!relation || !_.has(relation, 'targets') ) {
             return Promise.resolve([]);
         }
 
         return Promise.map(relation.targets, function (targetNodeId) {
-            return waterline.nodes.needByIdentifier(targetNodeId)
-            .catch(function (err) {
-                logger.warning("Error getting target node with type " + type,
-                    { error: err });
-                return;
-            });
+            return waterline.nodes.needByIdentifier(targetNodeId);
         });
     };
 
@@ -71,20 +75,15 @@ function nodeApiServiceFactory(
      * Remove the relations to original node in target node. If the node is invalid
      * or doesn't have required relation, this function doesn't need to update the
      * node info and ignore silently with Promise.resolve(). If the relation field
-     * is empty after removing, delete this field.
+     * is empty after removing, delete this field. If the node to be updated is a component
+     * of a node delete it
      * @param  {Object}     node node whose relation needs to be updated
      * @param  {String}     type relation type that needs to be updated
      * @param  {String}     targetId id in relation type that needs to be deleted
      * @return {Promise}    node after removing relation
      */
-    NodeApiService.prototype._removeRelation = function(node, type, targetId) {
-
-        if (!node) {
-            return Promise.resolve();
-        }
-
-        // Remove the relationship between node and downstram node
-        if (!_.has(node, 'relations')) {
+    NodeApiService.prototype._removeRelation = function removeRelation(node, type, targets) {
+        if (!node || !type || !_.has(node, 'relations')) {
             return Promise.resolve();
         }
 
@@ -93,71 +92,47 @@ function nodeApiServiceFactory(
             return Promise.resolve();
         }
 
-        // Remove target node id in relation field
-        if (_.indexOf(node.relations[index].targets, targetId) !== -1) {
-            _.pull(node.relations[index].targets, targetId);
+        if ((Constants.NodeRelations[type].relationClass === 'component') &&
+            (type.indexOf('By') !== -1)) {
+            // Its components need to be deleted
+            return this.removeNode(node, type);
         }
+        // Remove target node id in relation field
+        targets = [].concat(targets);
+        node.relations[index].targets = _.difference(node.relations[index].targets, targets);
 
         // Remove the type of relation if no targets in it
         if (node.relations[index].targets.length === 0) {
             _.pull(node.relations, node.relations[index]);
         }
 
-        return waterline.nodes.updateByIdentifier(node.id,
-                                                  {relations: node.relations});
+        return waterline.nodes.updateByIdentifier(node.id, {relations: node.relations});
     };
 
     /**
-     * Handle target nodes. Update relation type field and remove the target
-     * node if needed.
-     * @param  {Array}      targetNodes array of target nodes
-     * @param  {String}     type relation type in the removing node
-     * @param  {String}     nodeId removing node id
-     * @return {Promise}
+     * Add the given target nodes to the given relationType on the given node. Fail
+     * silently with missing arguments. If a relation does not already exist on the node
+     * create it, otherwise append to the existing one.
+     * @param  {Object} node - node whose relation needs to be updated
+     * @param  {String} type - relation type that needs to be updated
+     * @param  {String | String[]}  targets -  id in relation type that needs to be deleted
+     * @return {Promise}  a promise to update the node
      */
-    NodeApiService.prototype._handleTargetNodes = function(targetNodes, type, nodeId) {
-        var self = this;
-        var targetType = '';
-        var relationClass = null;
-        var needDel = false;
-
-        if (Constants.NodeRelations.hasOwnProperty(type)) {
-            targetType = Constants.NodeRelations[type].mapping;
-            relationClass = Constants.NodeRelations[type].relationClass;
+    NodeApiService.prototype._addRelation = function addRelation(node, type, targets) {
+        if (!(node && type && targets)) {
+            return Promise.resolve();
         }
 
-        if ((relationClass === 'component') &&
-            (type.indexOf('By') === -1)) {
-            // Its components need to be deleted
-            needDel = true;
+        node.relations = (node.relations || []);
+        targets = [].concat(targets);
+        var index = _.findIndex(node.relations, { relationType: type });
+        if (index === -1) {
+            node.relations.push({relationType: type, targets: _.uniq(targets)});
+        } else {
+            node.relations[index].targets = _.uniq(node.relations[index].targets.concat(targets));
         }
 
-        return Promise.resolve()
-        .then(function () {
-            if (needDel === true) {
-                // Throw error when all target nodes need to be deleted
-                // but at least one of them have active workflow
-                return Promise.map(targetNodes, function(targetNode) {
-                    return self._delValidityCheck(targetNode.id);
-                });
-            }
-        })
-        .then(function () {
-            return Promise.map(targetNodes, function (targetNode) {
-                // Delete target nodes if it is required
-                if (needDel === true) {
-                    return self.removeNode(targetNode, targetType);
-                }
-
-                // Update relations in the target node
-                return self._removeRelation(targetNode, targetType, nodeId)
-                .then(function (targetNode) {
-                    if (targetNode) {
-                        logger.debug('node updated', {id: targetNode.id, relation: targetType});
-                    }
-                });
-            });
-        });
+        return waterline.nodes.updateByIdentifier(node.id, {relations: node.relations});
     };
 
     /**
@@ -185,13 +160,11 @@ function nodeApiServiceFactory(
      */
     NodeApiService.prototype.removeNode = function(node, srcType) {
         var self = this;
-
         return self._delValidityCheck(node.id)
         .then(function () {
             if (!node.hasOwnProperty('relations')) {
                 return Promise.resolve();
             }
-
             return Promise.map(node.relations, function(relation) {
 
                 var type = relation.relationType;
@@ -202,10 +175,22 @@ function nodeApiServiceFactory(
                     return Promise.resolve();
                 }
 
+                if (!Constants.NodeRelations[type]) {
+                    return Promise.resolve();
+                }
                 // Otherwise update targets node in its "relationType"
-                return self._findTargetNodes(node, type)
-                .then(function (targetNodes) {
-                    return self._handleTargetNodes(targetNodes, type, node.id);
+                return self._findTargetNodes(node.relations, type)
+                .tap(function(targetNodes) {
+                    return Promise.map(targetNodes, function(node) {
+                        return self._delValidityCheck(node.id);
+                    });
+                })
+                .map(function (targetNode) {
+                    return self._removeRelation(
+                        targetNode,
+                        Constants.NodeRelations[type].mapping,
+                        node.id
+                    );
                 });
             });
         })
@@ -299,6 +284,68 @@ function nodeApiServiceFactory(
                 );
             }
             return node;
+        });
+    };
+
+    NodeApiService.prototype.getNodeRelations = function(id) {
+        return waterline.nodes.needByIdentifier(id)
+        .then(function (node){
+            return node.relations || [];
+        });
+    };
+
+    /**
+     * Edit the relations of a given node, delegating the updates to the given handler.
+     *
+     * @param {String} id - a node id
+     * @param {Object} body - an object with relation types as keys and arrays of target
+     *      node ids as values.
+     * @param {Function} handler - a function(node, relationType, targets) which edits the
+     *      given node's relations and updates the node
+     */
+    NodeApiService.prototype.editNodeRelations = function(id, body, handler) {
+        var self = this;
+        return waterline.nodes.needByIdentifier(id).bind({})
+        .then(function(node) {
+            this.parentNode = node;
+            return Promise.all(_.transform(body, function(result, targets, relationType) {
+                result.push(self._needTargetNodes(
+                        [{relationType: relationType, targets:targets}],
+                        relationType
+                    )
+                );
+                result.push(relationType);
+            }, [])
+            );
+        })
+        .then(function(targetRelations) {
+            var parentNode = this.parentNode;
+            handler = handler.bind(self);
+            targetRelations = _.chunk(targetRelations, 2); //divide the array into subArray chunks
+                                                           //of [[targetNodes], relationType]
+            return Promise.all(_.transform(targetRelations, function(result, relationSet) {
+                var targetNodes = relationSet[0];
+                var relationType = relationSet[1];
+                if (!Constants.NodeRelations[relationType]) {
+                    return;
+                }
+                result.push(
+                    handler(
+                        parentNode,
+                        relationType,
+                        _.map(targetNodes, function(node) {return node.id;})
+                    )
+                );
+
+                _.forEach(targetNodes, function(node) {
+                    result.push(
+                        handler(
+                            node, Constants.NodeRelations[relationType].mapping, parentNode.id
+                        )
+                    );
+                });
+            })
+            ).then(_.compact);
         });
     };
 

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -43,7 +43,7 @@ function nodeApiServiceFactory(
 
     /**
      * Find target nodes that relate with the removing node
-     * @param  {Object}     node
+     * @param  {Object}     relations - The relations object of a node
      * @param  {String}     type
      * @return {Promise}    array of target nodes
      */
@@ -79,7 +79,7 @@ function nodeApiServiceFactory(
      * of a node delete it
      * @param  {Object}     node node whose relation needs to be updated
      * @param  {String}     type relation type that needs to be updated
-     * @param  {String}     targetId id in relation type that needs to be deleted
+     * @param  {String[]}     targets - node ids in the relation that needs to be deleted
      * @return {Promise}    node after removing relation
      */
     NodeApiService.prototype._removeRelation = function removeRelation(node, type, targets) {
@@ -115,7 +115,7 @@ function nodeApiServiceFactory(
      * create it, otherwise append to the existing one.
      * @param  {Object} node - node whose relation needs to be updated
      * @param  {String} type - relation type that needs to be updated
-     * @param  {String | String[]}  targets -  id in relation type that needs to be deleted
+     * @param  {String | String[]}  targets - node ids in relation type that needs to be added
      * @return {Promise}  a promise to update the node
      */
     NodeApiService.prototype._addRelation = function addRelation(node, type, targets) {
@@ -320,32 +320,32 @@ function nodeApiServiceFactory(
         })
         .then(function(targetRelations) {
             var parentNode = this.parentNode;
-            handler = handler.bind(self);
             targetRelations = _.chunk(targetRelations, 2); //divide the array into subArray chunks
                                                            //of [[targetNodes], relationType]
-            return Promise.all(_.transform(targetRelations, function(result, relationSet) {
+
+            var handlerArgs = _.transform(targetRelations, function(result, relationSet) {
                 var targetNodes = relationSet[0];
                 var relationType = relationSet[1];
                 if (!Constants.NodeRelations[relationType]) {
                     return;
                 }
                 result.push(
-                    handler(
+                    [
                         parentNode,
                         relationType,
                         _.map(targetNodes, function(node) {return node.id;})
-                    )
+                    ]
                 );
 
                 _.forEach(targetNodes, function(node) {
                     result.push(
-                        handler(
-                            node, Constants.NodeRelations[relationType].mapping, parentNode.id
-                        )
+                        [node, Constants.NodeRelations[relationType].mapping, parentNode.id]
                     );
                 });
-            })
-            ).then(_.compact);
+            });
+            return Promise.map(handlerArgs, function(args) {
+                return handler.apply(self, args);
+            }, {concurrency: 1}).then(_.compact);
         });
     };
 

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -253,7 +253,7 @@ describe('2.0 Http.Api.Nodes', function () {
         });
     });
 
-    describe('PATCH /nodes/:identifier/relations', function() {
+    describe('PUT /nodes/:identifier/relations', function() {
         var relationUpdate;
         beforeEach(function() {
             sinon.stub(nodeApiService, 'editNodeRelations');
@@ -280,7 +280,7 @@ describe('2.0 Http.Api.Nodes', function () {
             nodeApiService.editNodeRelations.resolves([
                 updatedComputeNode, updatedRackNode
             ]);
-            return helper.request().patch('/api/2.0/nodes/1234/relations')
+            return helper.request().put('/api/2.0/nodes/1234/relations')
                 .send(relationUpdate)
                 .expect('Content-Type', /^application\/json/)
                 .expect(200)
@@ -296,7 +296,7 @@ describe('2.0 Http.Api.Nodes', function () {
 
         it('should return a 404 if the node is not found', function() {
             nodeApiService.editNodeRelations.rejects(new Errors.NotFoundError("Not Found"));
-            return helper.request().patch('/api/2.0/nodes/1234/relations')
+            return helper.request().put('/api/2.0/nodes/1234/relations')
                 .send(relationUpdate)
                 .expect('Content-Type', /^application\/json/)
                 .expect(404);

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -16,6 +16,7 @@ describe("Http.Services.Api.Nodes", function () {
     var rackNode;
     var _;
     var eventsProtocol;
+    var Promise;
 
     before("Http.Services.Api.Nodes before", function() {
         helper.setupInjector([
@@ -31,6 +32,7 @@ describe("Http.Services.Api.Nodes", function () {
         waterline = helper.injector.get('Services.Waterline');
         _ = helper.injector.get('_');
         eventsProtocol = helper.injector.get('Protocol.Events');
+        Promise = helper.injector.get('Promise');
         waterline.nodes = {
             create: function() {},
             needByIdentifier: function() {},
@@ -564,10 +566,10 @@ describe("Http.Services.Api.Nodes", function () {
 
         it("should do nothing if arguments are missing", function() {
             var argList = [rackNode, "contains", [computeNode]];
-            _.forEach(argList, function(arg, index) {
+            return Promise.map(argList, function(arg, index) {
                 var argsCopy = [].concat(argList);
                 argsCopy[index] = undefined;
-                nodeApiService._addRelation(argsCopy[0], argsCopy[1], argsCopy[2])
+                return nodeApiService._addRelation(argsCopy[0], argsCopy[1], argsCopy[2])
                 .then(function() {
                     expect(updateByIdentifier).to.not.be.called;
                 });
@@ -583,6 +585,7 @@ describe("Http.Services.Api.Nodes", function () {
                 });
             }).then(function() {
                 rackNode.relations = [{relationType: 'contains', targets: [computeNode.id]}];
+                updateByIdentifier.reset();
                 return nodeApiService._addRelation(rackNode, 'contains', [computeNode2.id]);
             }).then(function() {
                 expect(updateByIdentifier).to.be.calledWithExactly(rackNode.id, {relations:
@@ -599,7 +602,7 @@ describe("Http.Services.Api.Nodes", function () {
             waterline.nodes.needByIdentifier.resolves(computeNode);
             return nodeApiService.getNodeRelations(computeNode.id)
             .then(function(relations) {
-                expect(relations).to.equal(computeNode.relations);
+                expect(relations).to.deep.equal(computeNode.relations);
                 expect(waterline.nodes.needByIdentifier).to.be.calledOnce;
             });
         });

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -213,6 +213,21 @@ describe("Http.Services.Api.Nodes", function () {
                 );
             });
         });
+
+        it('should publish a node added event if the node is a rack', function() {
+            var rackNode = {
+                id: 'someNodeId',
+                type: 'rack',
+                name: 'rackNode'
+            };
+            waterline.nodes.create.resolves(rackNode);
+            return nodeApiService.postNode({})
+            .then(function() {
+                expect(eventsProtocol.publishNodeEvent).to.be.calledWithExactly(
+                    rackNode, 'added'
+                );
+            });
+        });
     });
 
     describe('setNodeWorkflow/setNodeWorkflowById', function() {

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -2341,7 +2341,7 @@ paths:
       tags: [ "/api/2.0" ]
       responses:
         200:
-          description: Successfully retrieved the node's reltions
+          description: Successfully retrieved the node's relations
           schema:
             type: array
             items:
@@ -2362,7 +2362,7 @@ paths:
       summary: |
         Remove relations from nodes
       description: |
-        Edit the relations fields of a nodes to remove specific relationships
+        Edit the relations fields of nodes to remove specific relationships
       parameters:
         - name: identifier
           in: path
@@ -2391,7 +2391,7 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-    patch:
+    put:
       x-swagger-schema: relations.2.0.json#/definitions/Relation
       operationId: nodesAddRelations
       x-privileges: [ 'Write' ]
@@ -2399,7 +2399,7 @@ paths:
       summary: |
         Add relationships between nodes
       description: |
-        Patch the relations fields of nodes to add realtionships
+        Edit the relations fields of nodes to add realtionships
       parameters:
         - name: identifier
           in: path
@@ -2419,7 +2419,7 @@ paths:
       tags: [ "/api/2.0" ]
       responses:
         200:
-          description: patch succeeded
+          description: update succeeded
           schema:
             type: object
         404:

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -2321,7 +2321,115 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-
+  /nodes/{identifier}/relations:
+    x-swagger-router-controller: nodes
+    get:
+      operationId: nodesGetRelations
+      x-privileges: [ 'Read' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Get a node's relations
+      description: |
+        Get the relations field of a node
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+              The node identifier
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: Successfully retrieved the node's reltions
+          schema:
+            type: array
+            items:
+              type: object
+        404:
+          description: The node with the identifier was not found.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      x-swagger-schema: relations.2.0.json#/definitions/Relation
+      operationId: nodesDelRelations
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Remove relations from nodes
+      description: |
+        Edit the relations fields of a nodes to remove specific relationships
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+                The node identifier
+          required: true
+          type: string
+        - name: content
+          in: body
+          description: |
+              A json object with relation types as keys and arrays of node ids 
+              as values. The node's given relation types will be updated to remove
+              the nodes given by id 
+          required: true
+          schema:
+            $ref: '#/definitions/generic_obj'
+      tags: [ "/api/2.0" ]
+      responses:
+        204:
+          description: Successfully removed the relations 
+        404:
+          description: The node with the identifier was not found.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    patch:
+      x-swagger-schema: relations.2.0.json#/definitions/Relation
+      operationId: nodesAddRelations
+      x-privileges: [ 'Write' ]
+      x-authentication-type: [ 'jwt' ]
+      summary: |
+        Add relationships between nodes
+      description: |
+        Patch the relations fields of nodes to add realtionships
+      parameters:
+        - name: identifier
+          in: path
+          description: |
+            The identifier for the node
+          required: true
+          type: string
+        - name: content
+          in: body
+          description: |
+              A json object with relation types as keys and arrays of node ids 
+              as values. The node's given relation types will be updated with the 
+              nodes given by id  
+          required: true
+          schema:
+            $ref: '#/definitions/generic_obj'
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: patch succeeded
+          schema:
+            type: object
+        404:
+          description: Not found
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /nodes/{identifier}/tags:
     x-swagger-router-controller: nodes
     get:

--- a/static/schemas/2.0/node.2.0.json
+++ b/static/schemas/2.0/node.2.0.json
@@ -12,7 +12,7 @@
                 "type": {
                     "description": "Type of node",
                     "type": "string",
-                    "enum": ["compute", "switch", "dae", "pdu", "mgmt", "enclosure"]
+                    "enum": ["compute", "switch", "dae", "pdu", "mgmt", "enclosure", "rack"]
                 },
                 "obmSettings": {
                     "description": "OBM settings",
@@ -25,6 +25,10 @@
                 "bootSettings": {
                     "description": "Default ipxe profile settings",
                     "type": "object"
+                },
+                "relations": {
+                        "description": "Node relations",
+                        "type": "array"
                 },
                 "sshSettings": {
                     "description": "SSH settings",

--- a/static/schemas/2.0/relations.2.0.json
+++ b/static/schemas/2.0/relations.2.0.json
@@ -7,11 +7,21 @@
             "properties": {
                 "contains": {
                     "description": "an array of nodes contained by the rack",
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
                 },
                 "containedBy": {
                     "description": "the rack containing the node",
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
                 }
             },
             "anyOf": [

--- a/static/schemas/2.0/relations.2.0.json
+++ b/static/schemas/2.0/relations.2.0.json
@@ -1,0 +1,23 @@
+{
+    "title": "Relations.2.0",
+    "definitions": {
+        "Relation": {
+            "description": "A key value set of relations",
+            "type": "object",
+            "properties": {
+                "contains": {
+                    "description": "an array of nodes contained by the rack",
+                    "type": "array"
+                },
+                "containedBy": {
+                    "description": "the rack containing the node",
+                    "type": "array"
+                }
+            },
+            "anyOf": [
+                { "required": [ "containedBy" ] },
+                { "required": [ "contains" ] }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
adds a rack node type and capabilities to add and remove 'contains'/'containedBy' relationships as per
https://github.com/RackHD/RackHD/wiki/proposal-passively-add-remove-a-rack-node
and
https://github.com/RackHD/RackHD/wiki/proposal-neighborhood-physical-topology
depends on https://github.com/RackHD/on-core/pull/196
@RackHD/corecommitters @pscharla