### PR TITLE
Update base to rackhd/on-tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
 # Copyright 2016, EMC, Inc.
 
-FROM rackhd/on-core
+FROM rackhd/on-tasks
 
 COPY . /RackHD/on-http/
 WORKDIR /RackHD/on-http
 
 RUN mkdir -p ./node_modules \
+  && ln -s /RackHD/on-tasks ./node_modules/on-tasks \
   && ln -s /RackHD/on-core ./node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
-  && npm install --ignore-scripts \
-  && npm install apidoc && npm run apidoc && npm run taskdoc \
   && echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
   && apk add --update ipmitool@testing unzip curl \
-  && /RackHD/on-http/install-web-ui.sh \
+  && npm install --ignore-scripts \
+  && npm install apidoc \
+  && npm run apidoc \
+  && npm run taskdoc \
   && /RackHD/on-http/install-swagger-ui.sh \
+  && /RackHD/on-http/install-web-ui.sh \
   && npm prune --production
 
 EXPOSE 9080 9090


### PR DESCRIPTION
Needs: https://github.com/RackHD/on-tasks/pull/318

Changes the base image to `rackhd/on-tasks` so `on-tasks` dependency can be symlinked from `/RackHD/on-tasks`