### PR TITLE
fixed validation error bug

### DIFF
--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -3812,6 +3812,7 @@ definitions:
         - pdu
         - mgmt
         - enclosure
+        - rack
         type: string
     type: object
 


### PR DESCRIPTION
fixes a validation error where the rack type is not included in one of the swagger validation schemas for partial node.

@RackHD/corecommitters  @pscharla 