### PR TITLE
Increase the buffer size of child process in bootstrap.js

### DIFF
--- a/data/templates/bootstrap.js
+++ b/data/templates/bootstrap.js
@@ -10,7 +10,9 @@ var http = require('http'),
     server = '<%=server%>',
     port = '<%=port%>',
     tasksPath = '/api/current/tasks/<%=identifier%>',
-    MAX_BUFFER = 1000 * 1024,
+    // Set the buffer size to ~5MB to accept all output in flashing bios
+    // Otherwise the process will be killed if exceeds the buffer size
+    MAX_BUFFER = 5000 * 1024,
     MAX_RETRY_TIMEOUT = 60 * 1000;
 /**
  * Synchronous each loop from caolan/async.


### PR DESCRIPTION
currently the max buffer size of child process in bootstrap.js is 1000*1024, but the stdout of flashing bios task is 1131830. from the child process document, "largest amount of data (in bytes) allowed on stdout or stderr - if exceeded child process is killed". The original setting prevents the flashing bios from finishing and would result in the successive catalogs task hanging.
Increase the max buffer size to 5MB