### PR TITLE
modify the convertion of error info in bootstrap template

### DIFF
--- a/data/templates/bootstrap.js
+++ b/data/templates/bootstrap.js
@@ -97,9 +97,12 @@ function updateTasks(data, timeout, retry, retries) {
 
     // Call error.toString() on certain errors so when it is JSON.stringified
     // it doesn't end up as '{}' before we send it back to the server.
-    if (data.error && !data.error.code) {
-        data.error = data.error.toString();
-    }
+    data.tasks.forEach(function(task) {
+        if (task.error && !task.error.code) {
+            task.error = task.error.toString();
+        }
+    });
+
     request.write(JSON.stringify(data));
     request.write("\n");
     request.end();


### PR DESCRIPTION
In bootstrap.js, the data that will be send to RackHD is in the following format
```
{ 
    tasks: [ 
    {
        cmd: 'echo testtest',
        stdout: undefined,
        stderr: undefined,
        error: [Error: stdout maxBuffer exceeded.] 
    } ]
}
```
the error object needs to be converted into string so that RackHD can parse it correctly, otherwise as the error field is empty, RackHD would view the task as success, leading successive task (if any) to run unexpectedly. 

Currently bootstrap.js modifies it by referring data.error, which does not exist at all. So changing the logic to modify data.task[index].error