### PR TITLE
Fix ODR869: Rename graph options 'osName' for Esx to ESXi in Redfish BootImage API

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -580,7 +580,7 @@ var doBootImage = controller(function(req,res) {
             graphOptions.defaults.osName = 'CentOS';
         } else if(payload.osName.indexOf('ESXi') !== -1) {
             graphName = 'Graph.InstallESXi';
-            graphOptions.defaults.osName = 'Esx';
+            graphOptions.defaults.osName = 'ESXi';
         } else if(payload.osName.indexOf('RHEL') !== -1) {
             graphName = 'Graph.InstallRHEL';
             graphOptions.defaults.osName = 'RHEL';


### PR DESCRIPTION
Fix [ODR869](https://hwjiraprd01.corp.emc.com/browse/ODR-869) and take this chance to fix an outstanding rename work that stated in this issue: https://github.com/RackHD/RackHD/issues/218

@RackHD/corecommitters @gpaulos @cgx027 @pengz1 @iceiilin @WangWinson 

Jenkins: depends on https://github.com/RackHD/on-tasks/pull/333