### PR TITLE
change esx-ks postInstallCommands to be unescaped

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -183,7 +183,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 
 <% if( typeof postInstallCommands !== 'undefined' ) { %>
   <% postInstallCommands.forEach(function(n) { %>
-    <%=n%>
+    <%-n%>
   <% }); %>
 <% } %>
 


### PR DESCRIPTION
To fix @wangzhizheng 's problem about `postInstallCommands` doesn't take effect.

Previous the input:
```
'postInstallCommands': ["esxcli system settings keyboard layout set -l 'Japanese'"]
```
will be rendered into:
```
esxcli system settings keyboard layout set -l &#39;Japanese&#39
```

Change the `<%=` to `<%-` will remain the unescaped raw output, so that the render result is exactly match with input.

@RackHD/corecommitters @zyoung51 @lanchongyizu @cgx027 @wangzhizheng