### PR TITLE
Add sorting by name/id and unit-test

### DIFF
--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -72,21 +72,20 @@ function swaggerFactory(
 
     function _sortQuery(query){
         var sortParams = new Object();
-        var tempStr = query.raw;
-        var matchOperation = tempStr.match(/-/g)? true:false;
-        sortParams.sortBy = matchOperation? tempStr.split(/-/g)[1]:tempStr.split(/-/g)[0];
-        sortParams.dsc = matchOperation;
+        var match = query.raw.match(/([-+]{0,1})(.+)/);
+        sortParams.sortBy = match[2].trim();
+        sortParams.dsc= match[1] ==='-'? true:false;
         return sortParams;
     }
 
     function _sortByAny(field, reverse, primer) {
         var key = primer ?
-           function(x) {return primer(x[field])} : 
+           function(x) {return primer(x[field])} :
            function(x) {return x[field]};
         reverse = !reverse ? 1 : -1;
         return function (a, b) {
             return a = key(a), b = key(b), reverse * ((a > b) - (b > a));
-        } 
+        };
     }
 
     function swaggerController(options, callback) {
@@ -98,12 +97,9 @@ function swaggerFactory(
             var toSort = null;
             req.swagger.options = options;
             return Promise.try(function() {
-                var hasQuery = req.query.sort? true:false;
                 _parseQuery(req);
-                if (hasQuery){
-                    if(req.swagger.params.sort.raw){
-                        toSort = _sortQuery(req.swagger.params.sort);
-                    }
+                if (req.swagger.params.sort && req.swagger.params.sort.raw){
+                    toSort = _sortQuery(req.swagger.params.sort);
                 }
 
                 return callback(req, res);

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -113,7 +113,7 @@ function swaggerFactory(
                             return element.toJSON ? element.toJSON() : element;
                         });
                         if (toSort){
-                            (toSort.type === 'string') ? res.body.sort(_sortByAny(toSort.sortBy, toSort.dsc, function(a){return a.toUpperCase()})): res.body.sort(_sortByAny(toSort.sortBy, toSort.dsc, parseInt));
+                            (toSort.type === 'string') ? res.body.sort(_sortByAny(toSort.sortBy, toSort.dsc, function(a){return a.toUpperCase()})): res.body.sort(_sortByAny(toSort.sortBy, toSort.dsc, parseInt)); // jshint ignore:line
 
                         }
                     } else {

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -70,22 +70,56 @@ function swaggerFactory(
         }).value();
     }
 
+    function _sortQuery(query){
+        var sortParams = new Object();
+        var tempStr = query.raw;
+        var matchOperation = tempStr.match(/-/g)? true:false;
+        sortParams.sortBy = matchOperation? tempStr.split(/-/g)[1]:tempStr.split(/-/g)[0];
+        sortParams.dsc = matchOperation;
+        return sortParams;
+    }
+
+    function _sortByAny(field, reverse, primer) {
+        var key = primer ?
+           function(x) {return primer(x[field])} : 
+           function(x) {return x[field]};
+        reverse = !reverse ? 1 : -1;
+        return function (a, b) {
+            return a = key(a), b = key(b), reverse * ((a > b) - (b > a));
+        } 
+    }
+
     function swaggerController(options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = {};
         }
         return function(req, res, next) {
+            var toSort = null;
             req.swagger.options = options;
             return Promise.try(function() {
+                var hasQuery = req.query.sort? true:false;
                 _parseQuery(req);
+                if (hasQuery){
+                    if(req.swagger.params.sort.raw){
+                        toSort = _sortQuery(req.swagger.params.sort);
+                    }
+                }
+
                 return callback(req, res);
             }).then(function(result) {
                 if (!res.headersSent && result) {
                     if (_.isArray(result)) {
                         res.body = result.map(function(element) {
+                            if(toSort){
+                                toSort.type = typeof element[toSort.sortBy];
+                            }
                             return element.toJSON ? element.toJSON() : element;
                         });
+                        if (toSort){
+                            (toSort.type === 'string') ? res.body.sort(_sortByAny(toSort.sortBy, toSort.dsc, function(a){return a.toUpperCase()})): res.body.sort(_sortByAny(toSort.sortBy, toSort.dsc, parseInt));
+
+                        }
                     } else {
                         res.body = result.toJSON ? result.toJSON() : result;
                     }

--- a/spec/lib/services/swagger-api-service-spec.js
+++ b/spec/lib/services/swagger-api-service-spec.js
@@ -41,14 +41,14 @@ describe('Services.Http.Swagger', function() {
         });
 
         it('should call controller callback', function() {
-            var req = { 
+            var req = {
                 swagger: {
                     params: {
                         sort: {
-			}
-		    }
-		}, 
-                query: {} 
+                        }
+                    }
+                },
+                query: {}
             };
             var res = {
                 headersSent: false
@@ -179,8 +179,8 @@ describe('Services.Http.Swagger', function() {
             };
             var mockData = [
                 {
-                id: '1234',
-                name: 'dummy'
+                    id: '1234',
+                    name: 'dummy'
                 },
                 {
                     id: '5679',
@@ -215,8 +215,8 @@ describe('Services.Http.Swagger', function() {
             };
             var mockData = [
                 {
-                id: '1234',
-                name: 'dummy'
+                    id: '1234',
+                    name: 'dummy'
                 }];
             var optController = swaggerService.controller(mockController);
 

--- a/spec/lib/services/swagger-api-service-spec.js
+++ b/spec/lib/services/swagger-api-service-spec.js
@@ -41,7 +41,15 @@ describe('Services.Http.Swagger', function() {
         });
 
         it('should call controller callback', function() {
-            var req = { swagger: {} };
+            var req = { 
+                swagger: {
+                    params: {
+                        sort: {
+			}
+		    }
+		}, 
+                query: {} 
+            };
             var res = {
                 headersSent: false
             };
@@ -56,7 +64,16 @@ describe('Services.Http.Swagger', function() {
         });
 
         it('should process options', function() {
-            var req = { swagger: {} };
+            var req = {
+                swagger: {
+                    params: {
+                        sort: {
+                        }
+                    }
+                },
+                query: {}
+            };
+
             var res = {
                 headersSent: false
             };
@@ -78,6 +95,8 @@ describe('Services.Http.Swagger', function() {
                 query: {},
                 swagger: {
                     params: {
+                        sort: {
+                        },
                         firstName: {
                             parameterObject: {
                                 in: 'query',
@@ -142,8 +161,85 @@ describe('Services.Http.Swagger', function() {
             });
         });
 
+        it('should process sort query', function() {
+            var req = {
+                query:{
+                    sort:"id"
+                },
+                swagger: {
+                    params: {
+                        sort: {
+                            raw: "id"
+                        }
+                    }
+                }
+            };
+            var res = {
+                headersSent: false
+            };
+            var mockData = [
+                {
+                id: '1234',
+                name: 'dummy'
+                },
+                {
+                    id: '5679',
+                    name: 'dummy2'
+                }];
+            var optController = swaggerService.controller(mockController);
+
+            expect(optController).to.be.a('function');
+            mockController.resolves(mockData);
+            return optController(req, res, mockNext).then(function() {
+                expect(req.swagger.params.sort).to.have.property('raw');
+                expect(res.body).to.deep.equal(mockData);
+                expect(mockNext).to.be.called.once;
+
+            });
+        });
+
+        it('should not process sort function, when not present', function() {
+            var req = {
+                query:{
+                    id:"1234"
+                },
+                swagger: {
+                    params: {
+                        sort: {
+                        }
+                    }
+                }
+            };
+            var res = {
+                headersSent: false
+            };
+            var mockData = [
+                {
+                id: '1234',
+                name: 'dummy'
+                }];
+            var optController = swaggerService.controller(mockController);
+
+            expect(optController).to.be.a('function');
+            mockController.resolves(mockData);
+            return optController(req, res, mockNext).then(function() {
+                expect(res.body).to.deep.equal(mockData);
+                expect(mockNext).to.be.called.once;
+
+            });
+        });
+
         it('should not call next after sending headers', function() {
-            var req = { swagger: {} };
+            var req = {
+                swagger: {
+                    params: {
+                        sort: {
+                        }
+                    }
+                },
+                query: {}
+            };
+
             var res = {
                 headersSent: true
             };
@@ -158,7 +254,16 @@ describe('Services.Http.Swagger', function() {
         });
 
         it('should call next if an error occurs', function() {
-            var req = { swagger: {} };
+            var req = {
+                swagger: {
+                    params: {
+                        sort: {
+                        }
+                    }
+                },
+                query: {}
+            };
+
             var res = {
                 headersSent: false
             };

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -312,6 +312,12 @@ paths:
         name: query
         required: false
         type: string
+      - name: sort
+        in: query
+        description: Query string specifying properties to sort with
+        required: false
+        type: string
+        pattern: '[- +]{0,1}(name|id)'
       responses:
         '200':
           description: Successfully retrieved a list of catalogs
@@ -850,6 +856,12 @@ paths:
         name: $top
         required: false
         type: integer
+      - name: sort
+        in: query
+        description: Query string specifying properties to sort with
+        required: false
+        type: string
+        pattern: '[- +]{0,1}(name|id)'
       responses:
         200:
           description: Successfully retrieved the list of nodes
@@ -2116,6 +2128,12 @@ paths:
         name: $top
         required: false
         type: integer
+      - name: sort
+        in: query
+        description: Query string specifying properties to sort with
+        required: false
+        type: string
+        pattern: '[- +]{0,1}(id)'
       responses:
         200:
           description: 'Successful retrieval of the list of pollers
@@ -3580,6 +3598,13 @@ paths:
 
         '
       operationId: getAllTags
+      parameters:
+      - name: sort
+        in: query
+        description: Query string specifying properties to sort with
+        required: false
+        type: string
+        pattern: '[- +]{0,1}(name|id)'
       responses:
         200:
           description: 'Successfully retrieved all tags
@@ -4088,6 +4113,13 @@ paths:
 
         '
       operationId: templatesMetaGet
+      parameters:
+      - name: sort
+        in: query
+        description: Query string specifying properties to sort with
+        required: false
+        type: string
+        pattern: '[- +]{0,1}(name|id)'
       responses:
         200:
           description: 'Successfully retrieved all template metadata
@@ -4250,6 +4282,13 @@ paths:
 
         '
       operationId: listUsers
+      parameters:
+      - name: sort
+        in: query
+        description: Query string specifying properties to sort with
+        required: false
+        type: string
+        pattern: '[- +]{0,1}(name|id)'
       responses:
         200:
           description: 'Successfully retrieved the list of users
@@ -4630,6 +4669,12 @@ paths:
         name: $top
         required: false
         type: integer
+      - name: sort
+        in: query
+        description: Query string specifying properties to sort with
+        required: false
+        type: string
+        pattern: '[- +]{0,1}(name|id)'
       responses:
         200:
           description: 'Successfull retrieved workflows


### PR DESCRIPTION
Add sort by name/id in ASC(+) or DSC(-) order for following routes:
pollers
catalogs
workflows
tags
users
templates
nodes

NOTE: The property to sort can be changed in the YAML. Any property not defined in the  "pattern" will throw an validation error.

@RackHD/corecommitters @brianparry @BillyAbildgaard @dalebremner @geoff-reid 


