### PR TITLE
Cleanup 2.0 API queries

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -48,7 +48,7 @@ var nodesPostSshById = controller({success: 201}, function(req) {
 });
 
 var nodesGetCatalogById = controller(function(req) {
-    return nodes.getNodeCatalogById(req.swagger.params.identifier.value);
+    return nodes.getNodeCatalogById(req.swagger.params.identifier.value, req.query);
 });
 
 var nodesGetCatalogSourceById = controller(function(req) {

--- a/lib/api/2.0/obms.js
+++ b/lib/api/2.0/obms.js
@@ -29,7 +29,7 @@ var obmsDefinitionsGetByName = controller(function(req) {
 
 // GET /api/2.0/obms
 var obmsGet = controller(function(req) {
-    return waterline.obms.find(req.swagger.params.query.value);
+    return waterline.obms.find(req.query);
 });
 
 // PUT /api/2.0/obms

--- a/lib/api/2.0/pollers.js
+++ b/lib/api/2.0/pollers.js
@@ -7,6 +7,7 @@ var controller = injector.get('Http.Services.Swagger').controller;
 var addLinks = injector.get('Http.Services.Swagger').addLinksHeader;
 var pollers = injector.get('Http.Services.Api.Pollers');
 var Errors = injector.get('Errors');
+var Constants = injector.get('Constants');
 
 /**
  * @api {get} /api/2.0/pollers/library GET /library
@@ -54,7 +55,10 @@ var pollersGet = controller(function(req, res) {
         skip: req.swagger.query.$skip,
         limit: req.swagger.query.$top
     };
-
+    if (req.query.type) {
+        req.query.name = Constants.WorkItems.Pollers[req.query.type.toUpperCase()];
+        delete req.query.type;
+    }
     return pollers.getPollers(req.query, options)
     .tap(function(pollers) {
         return addLinks(req, res, 'workitems', req.query);
@@ -109,6 +113,9 @@ var pollersIdGet = controller(function(req) {
  * }
  */
 var pollersPost = controller({success: 201}, function(req) {
+    req.body.name = Constants.WorkItems.Pollers[req.body.type.toUpperCase()];
+    delete req.body.type;
+
     return pollers.postPollers(req.body);
 });
 
@@ -128,6 +135,10 @@ var pollersPost = controller({success: 201}, function(req) {
  *     }
  */
 var pollersPatch = controller(function(req) {
+    if (req.body.type) {
+        req.body.name = Constants.WorkItems.Pollers[req.body.type.toUpperCase()];
+        delete req.body.type;
+    }
     return pollers.patchPollersById(req.swagger.params.identifier.value, req.body);
 });
 

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -440,10 +440,11 @@ function nodeApiServiceFactory(
             });
     };
 
-    NodeApiService.prototype.getNodeCatalogById = function(id) {
+    NodeApiService.prototype.getNodeCatalogById = function(id, query) {
         return waterline.nodes.needByIdentifier(id)
             .then(function (node) {
-                return waterline.catalogs.find({ node: node.id });
+                query = _.merge({ node: node.id }, query);
+                return waterline.catalogs.find(query);
             });
     };
 

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -63,9 +63,6 @@ function swaggerFactory(
         })
         .mapValues(function(param) {
             req.query = _(req.query).omit(param.parameterObject.definition.name).value();
-            if (typeof(param.value) === 'string' && param.value.match(/\+/)) {
-                return param.value.split(/\+/);
-            }
             return param.value;
         }).value();
     }

--- a/spec/lib/services/swagger-api-service-spec.js
+++ b/spec/lib/services/swagger-api-service-spec.js
@@ -94,14 +94,6 @@ describe('Services.Http.Swagger', function() {
                             },
                             value: 'HD'
                         },
-                        middleName: {
-                            parameterObject: {
-                                in: 'query',
-                                type: 'string',
-                                definition: { name: 'middleName' }
-                            },
-                            value:'John+Paul+George'
-                        },
                         undefinedName: {
                             parameterObject: {
                                 in: 'query',
@@ -135,8 +127,6 @@ describe('Services.Http.Swagger', function() {
                     .and.to.equal('Rack');
                 expect(req.swagger.query).to.have.property('lastName')
                     .and.to.equal('HD');
-                expect(req.swagger.query).to.have.property('middleName')
-                    .and.to.deep.equal(['John', 'Paul', 'George']);
                 expect(req.swagger.query).not.to.have.property('inBody');
                 expect(req.swagger.query).not.to.have.property('undefinedName');
             });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -1789,12 +1789,6 @@ paths:
 
         '
       operationId: obmsGet
-      parameters:
-      - description: Query string used to search for OBM information
-        in: query
-        name: query
-        required: false
-        type: string
       responses:
         200:
           description: 'Successfully retrieved the list of OBM service instances


### PR DESCRIPTION
* Add support for /nodes/:id/catalogs query
* Fix obms query
* Add support for querying pollers by type
* Remove unnecessary logical OR support from query parser.

@RackHD/corecommitters 