### PR TITLE
ODR905: Fix the redfish API BootImage validation error

### DIFF
--- a/lib/api/redfish-1.0/event-service.js
+++ b/lib/api/redfish-1.0/event-service.js
@@ -4,7 +4,6 @@
 var urlParse = require('url-parse');
 var injector = require('../../../index.js').injector;
 var redfish = injector.get('Http.Api.Services.Redfish');
-var schemaApi = injector.get('Http.Api.Services.Schema');
 var Promise = injector.get('Promise'); // jshint ignore:line
 var _ = injector.get('_');  // jshint ignore:line
 var Constants = injector.get('Constants');
@@ -70,12 +69,12 @@ var eventCallback = function(events) {
                     record.EventId = event.reading.sensorId;
                     record.EventTimestamp = new Date().toISOString();
                     record.Severity = event.reading.status;
-                    record.Message = event.reading.entryIdName + ' ' + 
-                        event.reading.sensorReading + ' ' + 
+                    record.Message = event.reading.entryIdName + ' ' +
+                        event.reading.sensorReading + ' ' +
                         (event.reading.sensorReadingUnits ? event.reading.sensorReadingUnits : '');
-                    record.MessageId = "Alert.1.0." + 
-                        event.reading.sensorId.replace(/[^A-Za-z0-9.]/g,''); 
-                    return schemaApi.validate(record, 'Event.1.0.0.json#/definitions/EventRecord')
+                    record.MessageId = "Alert.1.0." +
+                        event.reading.sensorId.replace(/[^A-Za-z0-9.]/g,'');
+                    return redfish.validateSchema(record, 'Event.1.0.0.json#/definitions/EventRecord') //jshint ignore: line
                     .then(function(result) {
                         if(result.error) {
                             throw new Error(result.error);
@@ -99,11 +98,11 @@ var eventCallback = function(events) {
                     record.EventType = "StatusChange";
                     record.EventId = event.reading.sensorId;
                     record.EventTimestamp = new Date().toISOString();
-                    record.Message = event.reading.entryIdName + ', statesAsserted: ' + 
+                    record.Message = event.reading.entryIdName + ', statesAsserted: ' +
                         event.reading.statesAsserted.toString();
-                    record.MessageId = "StatusChange.1.0." + 
+                    record.MessageId = "StatusChange.1.0." +
                         event.reading.sensorId.replace(/[^A-Za-z0-9.]/g,'');
-                    return schemaApi.validate(record, 'Event.1.0.0.json#/definitions/EventRecord')
+                    return redfish.validateSchema(record, 'Event.1.0.0.json#/definitions/EventRecord') //jshint ignore: line
                     .then(function(result) {
                         if(result.error) {
                             throw new Error(result.error);
@@ -133,7 +132,7 @@ var eventCallback = function(events) {
                     record.EventTimestamp = new Date().toISOString();
                     record.Message = JSON.stringify(event.data);
                     record.MessageId = event.EventType + ".1.0.EndPoints";
-                    return schemaApi.validate(record, 'Event.1.0.0.json#/definitions/EventRecord')
+                    return redfish.validateSchema(record, 'Event.1.0.0.json#/definitions/EventRecord') //jshint ignore: line
                     .then(function(result) {
                         if(result.error) {
                             throw new Error(result.error);
@@ -181,7 +180,7 @@ var getEventsCollection = controller(function(req, res) {
 var createSubscription = controller(function(req, res) {
     var options = redfish.makeOptions(req, res);
     var event = req.swagger.params.payload.value;
-    return schemaApi.validate(event, 
+    return redfish.validateSchema(event,
         'EventDestination.1.0.0.json#/definitions/EventDestination'
     )
     .then(function validatePayload(result) {
@@ -191,7 +190,7 @@ var createSubscription = controller(function(req, res) {
         var index = _.findIndex(_.values(eventSubscriptions), function(subscription) {
             return subscription.Destination === event.Destination;
         });
-        
+
         if(index > -1) {
             var err = new Errors.BaseError('EventDestination Exists');
             err.status = 409;
@@ -203,7 +202,7 @@ var createSubscription = controller(function(req, res) {
     })
     .then(function(output) {
         eventListener(eventCallback);
-        res.setHeader('Location', 
+        res.setHeader('Location',
             options.basepath + '/EventService/Subscription/' + output.Id
         );
         res.status(201).json(output);
@@ -228,7 +227,7 @@ var testEvent = controller(function(req, res) {
             record.EventTimestamp = new Date().toISOString();
             record.Message = 'Generated TestEvent to ' + subscription.Destination;
             record.MessageId = 'TestEvent.1.0.0';
-            return schemaApi.validate(record, 'Event.1.0.0.json#/definitions/EventRecord')
+            return redfish.validateSchema(record, 'Event.1.0.0.json#/definitions/EventRecord')
             .then(function(result) {
                 if(result.error) {
                     throw new Error(result.error);
@@ -254,7 +253,7 @@ var getEvent = controller(function(req, res) {
         if(_.isUndefined(event)) {
             throw new Errors.NotFoundError(
                 'EventDestination ' + id + ' Not Found'
-            );       
+            );
         }
         options.subscription = event;
         return redfish.render('redfish.1.0.0.eventdestination.json',
@@ -274,7 +273,7 @@ var deleteEvent = controller(function(req, res) {
         if(_.isUndefined(event)) {
             throw new Errors.NotFoundError(
                 'EventDestination ' + id + ' Not Found'
-            );       
+            );
         }
         delete eventSubscriptions[id];
     })

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -4,7 +4,6 @@
 
 var injector = require('../../../index.js').injector;
 var redfish = injector.get('Http.Api.Services.Redfish');
-var schemaApi = injector.get('Http.Api.Services.Schema');
 var waterline = injector.get('Services.Waterline');
 var taskProtocol = injector.get('Protocol.Task');
 var Promise = injector.get('Promise');    // jshint ignore:line
@@ -497,7 +496,7 @@ var doReset = controller(function(req,res) {
     var options = redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
 
-    return schemaApi.validate(payload, 'RackHD.ResetAction.json#/definitions/ResetAction')
+    return redfish.validateSchema(payload, 'RackHD.ResetAction.json#/definitions/ResetAction')
     .then(function(result) {
         var map = {
             On: 'Graph.PowerOn.Node',
@@ -558,7 +557,7 @@ var doBootImage = controller(function(req,res) {
     var options = redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
 
-    return schemaApi.validate(payload, 'RackHD.BootImage.json#/definitions/BootImage')
+    return redfish.validateSchema(payload, 'RackHD.BootImage.json#/definitions/BootImage')
     .then(function validatePayload(result) {
         if(result.error) {
             throw new Error(result.error);

--- a/lib/services/redfish-validator-service.js
+++ b/lib/services/redfish-validator-service.js
@@ -91,7 +91,7 @@ function redfishValidatorFactory(
             _: _
         }).then(function(localOptions) {
             return Promise.all([
-                self.get(viewName, _.merge(options, localOptions) ), 
+                self.get(viewName, _.merge(options, localOptions) ),
                 ready
             ])
             .spread(function(output) {

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -34,6 +34,7 @@ describe('Redfish Systems Root', function () {
 
             redfish = helper.injector.get('Http.Api.Services.Redfish');
             sinon.spy(redfish, 'render');
+            sinon.spy(redfish, 'validateSchema');
 
             validator = helper.injector.get('Http.Api.Services.Schema');
             sinon.spy(validator, 'validate');
@@ -66,6 +67,8 @@ describe('Redfish Systems Root', function () {
 
         validator.validate.reset();
         redfish.render.reset();
+        redfish.validateSchema.reset();
+
         nodeApi.setNodeWorkflowById.reset();
 
         function resetStubs(obj) {
@@ -98,9 +101,10 @@ describe('Redfish Systems Root', function () {
     after('stop HTTP server', function () {
         validator.validate.restore();
         redfish.render.restore();
+        redfish.validateSchema.restore();
         view.get.restore();
         nodeApi.setNodeWorkflowById.restore();
-        
+
         function restoreStubs(obj) {
             _(obj).methods().forEach(function (method) {
                 if (obj[method] && obj[method].restore) {
@@ -124,7 +128,7 @@ describe('Redfish Systems Root', function () {
             host: '1.2.3.4',
             user: 'myuser',
             password: 'mypass'
-       }    
+       }
     }];
     // Node new mock data with OBM model change
     var node = {
@@ -194,7 +198,7 @@ describe('Redfish Systems Root', function () {
             }
         ],
         'Processor Information' : [
-            { 
+            {
                 'Socket Designation': 'test',
                 Manufacturer: 'test',
                 'Max Speed': '2300 MHz',
@@ -306,7 +310,7 @@ describe('Redfish Systems Root', function () {
                 expect(redfish.render.called).to.be.true;
             });
     });
-    
+
     it('should return a valid system with sku', function() {
         waterline.nodes.needByIdentifier.withArgs('1234abcd1234abcd1234abcd')
         .resolves(Promise.resolve({
@@ -354,7 +358,7 @@ describe('Redfish Systems Root', function () {
             source: 'dummysource',
             data: catalogData
         }));
-        
+
         return helper.request().get('/redfish/v1/Systems/' + node.id + '/Processors')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -382,8 +386,6 @@ describe('Redfish Systems Root', function () {
             .expect('Content-Type', /^application\/json/)
             .expect(404);
     });
- 
-    
 
     it('should return a valid processor', function() {
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
@@ -391,7 +393,7 @@ describe('Redfish Systems Root', function () {
             source: 'dummysource',
             data: catalogData
         }));
-        
+
         return helper.request().get('/redfish/v1/Systems/' + node.id + '/Processors/0')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -451,7 +453,7 @@ describe('Redfish Systems Root', function () {
             data: catalogData
         }));
 
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/SimpleStorage/0000_00_01_1')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -463,14 +465,14 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should 404 an invalid simple storage device', function() {
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/SimpleStorage/bad')
             .expect('Content-Type', /^application\/json/)
             .expect(404);
     });
 
     it('should return a valid log service', function() {
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/LogServices')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -490,7 +492,7 @@ describe('Redfish Systems Root', function () {
             selInformation: { '# of Alloc Units': 10, uid: "Reserved"}
         }]);
 
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/LogServices/sel')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -502,7 +504,7 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should 404 an invalid sel log service', function() {
-        return helper.request().get('/redfish/v1/Systems/bad' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/bad' + node.id +
                                     '/LogServices/sel')
             .expect('Content-Type', /^application\/json/)
             .expect(404);
@@ -526,7 +528,7 @@ describe('Redfish Systems Root', function () {
             }]
         }]);
 
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/LogServices/sel/Entries')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -536,7 +538,7 @@ describe('Redfish Systems Root', function () {
                 expect(redfish.render.called).to.be.true;
             });
     });
-    
+
     it('should return an empty sel log service entry collection', function() {
         waterline.workitems.findPollers.resolves([{
             config: { command: 'sel' }
@@ -546,7 +548,7 @@ describe('Redfish Systems Root', function () {
             sel: undefined
         }]);
 
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/LogServices/sel/Entries')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -560,7 +562,7 @@ describe('Redfish Systems Root', function () {
 
 
     it('should 404 an invalid sel log service entry list', function() {
-        return helper.request().get('/redfish/v1/Systems/bad' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/bad' + node.id +
                                     '/LogServices/sel/Entries')
             .expect('Content-Type', /^application\/json/)
             .expect(404);
@@ -584,7 +586,7 @@ describe('Redfish Systems Root', function () {
             }]
         }]);
 
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/LogServices/sel/Entries/abcd')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -596,7 +598,7 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should 404 an invalid sel log service entry', function() {
-        return helper.request().get('/redfish/v1/Systems/' + node.id + 
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     '/LogServices/sel/Entries/abcdefg')
             .expect('Content-Type', /^application\/json/)
             .expect(404);
@@ -643,16 +645,11 @@ describe('Redfish Systems Root', function () {
             });
     });
 
-    it('should perform the specified boot image installation', function() {
+    it('should perform the specified boot image installation with minimum payload', function() {
         var minimumValidBody = {
-            domain: "rackhd.com",
-            hostname: "rackhd",
-            osName: "ESXi",
             repo: "http://172.31.128.1:9080/esxi/5.5",
             version: "6.0",
-            rootPassword: "passw0rd",
-            dnsServers: [ "172.31.128.1" ],
-            installDisk: "firstdisk"
+            rootPassword: "passw0rd"
         };
         return Promise.map(['CentOS', 'CentOS+KVM', 'ESXi', 'RHEL', 'RHEL+KVM'], function(osName) {
             return helper.request().post('/redfish/v1/Systems/' + node.id +
@@ -663,6 +660,34 @@ describe('Redfish Systems Root', function () {
                 .expect(function(res) {
                     expect(tv4.validate.called).to.be.true;
                     expect(validator.validate.called).to.be.true;
+                    expect(redfish.validateSchema.called).to.be.true;
+                    expect(res.body['@odata.id']).to.equal('/redfish/v1/TaskService/Tasks/abcdef');
+                });
+        });
+    });
+
+    it('should perform the specified boot image installation', function() {
+        var minimumValidBody = {
+            domain: "rackhd.com",
+            hostname: "rackhd",
+            osName: "ESXi",
+            repo: "http://172.31.128.1:9080/esxi/5.5",
+            version: "6.0",
+            rootPassword: "passw0rd",
+            dnsServers: [ "172.31.128.1" ],
+            installDisk: "firstdisk",
+            postInstallCommands:['touch a.txt', 'ls /var']
+        };
+        return Promise.map(['CentOS', 'CentOS+KVM', 'ESXi', 'RHEL', 'RHEL+KVM'], function(osName) {
+            return helper.request().post('/redfish/v1/Systems/' + node.id +
+                                        '/Actions/RackHD.BootImage')
+                .send( _.merge(minimumValidBody, {osName: osName}) )
+                .expect('Content-Type', /^application\/json/)
+                .expect(202)
+                .expect(function(res) {
+                    expect(tv4.validate.called).to.be.true;
+                    expect(validator.validate.called).to.be.true;
+                    expect(redfish.validateSchema.called).to.be.true;
                     expect(res.body['@odata.id']).to.equal('/redfish/v1/TaskService/Tasks/abcdef');
                 });
         });
@@ -670,14 +695,10 @@ describe('Redfish Systems Root', function () {
 
     it('should 400 an invalid boot image installation', function() {
         var minimumInvalidBody = {
-            domain: "rackhd.com",
-            hostname: "rackhd",
             osName: "notESXi",
             repo: "http://172.31.128.1:9080/esxi/5.5",
             version: "6.0",
-            rootPassword: "passw0rd",
-            dnsServers: [ "172.31.128.1" ],
-            installDisk: "firstdisk"
+            rootPassword: "passw0rd"
         };
 
         return helper.request().post('/redfish/v1/Systems/' + node.id +

--- a/static/DSP8010_1.0.0/json-schema-oem/RackHD.BootImage.json
+++ b/static/DSP8010_1.0.0/json-schema-oem/RackHD.BootImage.json
@@ -17,7 +17,7 @@
                     "description": "This property shall specify a valid odata or Redfish property."
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "rootSshKey": {
                     "type": "string"
@@ -70,11 +70,10 @@
                 }
             },
             "required": [
-                "domain",
-                "hostname",
+                "version",
+                "repo",
                 "osName",
-                "rootPassword",
-                "dnsServers"
+                "rootPassword"
             ],
             "description": "This is the base type for the boot image installation action."
         },
@@ -106,7 +105,11 @@
                 "sshKey": {
                     "type": "string"
                 }
-            }
+            },
+            "required": [
+                "name",
+                "password"
+            ]
         },
         "NetworkDevice": {
             "patternProperties": {
@@ -133,7 +136,10 @@
                 "ipv6": {
                     "$ref": "http://redfish.dmtf.org/schemas/v1/RackHD.BootImage.json#/definitions/NetworkAddress"
                 }
-            }
+            },
+            "required": [
+                "device"
+            ]
         },
         "NetworkAddress": {
             "patternProperties": {
@@ -160,10 +166,18 @@
                 "gateway": {
                     "type": "string"
                 },
-                "vlanId": {
-                    "type": "string"
+                "vlanIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
                 }
-            }
+            },
+            "required": [
+                "ipAddr",
+                "netmask",
+                "gateway"
+            ]
         },
         "BootImageList": {
             "patternProperties": {
@@ -196,3 +210,4 @@
     },
     "copyright": "Copyright 2016 EMC, Inc."
 }
+

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -4655,11 +4655,10 @@ definitions:
       version:
         type: string
     required:
-    - domain
-    - hostname
+    - version
+    - repo
     - osName
     - rootPassword
-    - dnsServers
   RackHD.BootImage_BootImageList:
     properties:
       osName:
@@ -4678,8 +4677,14 @@ definitions:
         type: string
       netmask:
         type: string
-      vlanId:
-        type: string
+      vlanIds:
+        type: array
+        items:
+          type: number
+    required:
+    - ipAddr
+    - netmask
+    - gateway
   RackHD.BootImage_NetworkDevice:
     properties:
       device:
@@ -4688,6 +4693,8 @@ definitions:
         $ref: '#/definitions/RackHD.BootImage_NetworkAddress'
       ipv6:
         $ref: '#/definitions/RackHD.BootImage_NetworkAddress'
+    required:
+    - device
   RackHD.BootImage_Users:
     properties:
       name:
@@ -4698,6 +4705,9 @@ definitions:
         type: string
       uid:
         type: number
+    required:
+    - name
+    - password
   RackHD.ResetAction_ResetAction:
     description: This is the base type for the reset action.
     properties:


### PR DESCRIPTION
The issue link: https://hwjiraprd01.corp.emc.com/browse/ODR-905

Simplify change the "additionalProperties" to `true` will not totally fix this problem. All problems that I found are listed below:
- Not allowed additional properties, so that some OS specific parameters cannot pass the validation, such as the `switchDevices` and `ntpServers` for ESXi.
- `vlanId` should be `vlanIds`, and its item should be `number`.
- The JSON schema validator cannot find the BootImage schema file, as it doesn't be added into `tv4`. Use `redfish.validateSchema` will fix this problem.

@RackHD/corecommitters @zyoung51 @jlongever @keedya 