### PR TITLE
Added admin and readonly to user.roles schema

### DIFF
--- a/static/schemas/2.0/user.2.0.json
+++ b/static/schemas/2.0/user.2.0.json
@@ -17,7 +17,8 @@
                 },
                 "role": {
                     "description": "The role of the user",
-                    "type": "string"
+                    "type": "string",
+                    "enum": ["Administrator", "ReadOnly"]
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
This is for ODR-833 https://hwjiraprd01.corp.emc.com/browse/ODR-833
This restricts the creation of users to two roles, Administrator and ReadOnly. Previously, anything could be in the roles field. Presently, these are the only two roles acceptable for 2.0.