### PR TITLE
ODR905: add esxSwitchName (in networkDevices) support for ESXi installation

### DIFF
--- a/static/DSP8010_1.0.0/json-schema-oem/RackHD.BootImage.json
+++ b/static/DSP8010_1.0.0/json-schema-oem/RackHD.BootImage.json
@@ -125,7 +125,7 @@
                     "description": "This property shall specify a valid odata or Redfish property."
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "device": {
                     "type": "string"
@@ -155,7 +155,7 @@
                     "description": "This property shall specify a valid odata or Redfish property."
                 }
             },
-            "additionalProperties": false,
+            "additionalProperties": true,
             "properties": {
                 "netmask": {
                     "type": "string"

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -171,7 +171,7 @@ definitions:
         type: string
       options:
         properties:
-          default:
+          defaults:
             properties:
               graphOptions:
                 type: object

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -143,7 +143,7 @@ definitions:
         type: string
       options:
         properties:
-          default:
+          defaults:
             type: object
         type: object
     type: object


### PR DESCRIPTION
This is to fix the new issue that recorded in ODR905: https://hwjiraprd01.corp.emc.com/browse/ODR-905

The ESXi installation supports an additional parameter "esxSwitchName" in static network configuration, but the "additionalProperties: false" is set and thus cause the esxSwitchName cannot be specified.

@RackHD/corecommitters @zyoung51 @pengz1 @iceiilin @lanchongyizu

jenkins: depends on https://github.com/RackHD/on-tasks/pull/353
