### PR TITLE
fix discovery issue when using static file server

### DIFF
--- a/data/profiles/linux.ipxe
+++ b/data/profiles/linux.ipxe
@@ -1,4 +1,4 @@
 kernel <%=kernelUri%>
 initrd <%=initrdUri%>
-imgargs <%=kernelFile%> initrd=<%=initrdFile%> auto=true SYSLOGSERVER=<%=server%> API_CB=<%=server%>:<%=port%> BASEFS=<%=basefs%> OVERLAYFS=<%=overlayfs%> BOOTIF=01-<%=macaddress%> console=tty0 console=<%=comport%>,115200n8 <%=kargs%>
+imgargs <%=kernelFile%> initrd=<%=initrdFile%> auto=true SYSLOGSERVER=<%=server%> API_CB=<%=server%>:<%=port%> BASEFS=<%=basefsUri%> OVERLAYFS=<%=overlayfsUri%> BOOTIF=01-<%=macaddress%> console=tty0 console=<%=comport%>,115200n8 <%=kargs%>
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell


### PR DESCRIPTION
Node discovery fails when using static file server, because basefs and overlayfs are always pulled from API_CB(api.server) rather than file.server.
The solution is to change BASEFS and OVERLAYFS to be full URL instead of file path.
* use overlayfsUri and overlayfsFile to replace overlayfs in task options
* use basefsUri and basefsFile to replace basefs in task options

@RackHD/corecommitters @iceiilin @cgx027 @panpan0000 