### PR TITLE
Set prefix as repo address to simplify ESXi boot.cfg design

### DIFF
--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -1,7 +1,7 @@
 iseq ${platform} efi && goto is_efi || goto not_efi
 
 :not_efi
-kernel <%=mbootFile%> -c <%=esxBootConfigTemplateUri%> BOOTIF=01-${netX/mac}
+kernel <%=repo%>/<%=mbootFile%> -c <%=esxBootConfigTemplateUri%> BOOTIF=01-${netX/mac}
 boot
 
 :is_efi

--- a/data/templates/esx-boot-cfg
+++ b/data/templates/esx-boot-cfg
@@ -1,6 +1,6 @@
 bootstate=0
 title=Loading ESXi installer
-prefix=<%=repo%>/
+prefix=<%=repo%>
 kernel=<%=tbootFile%>
 kernelopt=runweasel formatwithmbr com1_baud=115200 com1_Port=<%=comportaddress%> tty2Port=<%=comport%> debugLogToSerial=1 logPort=<%=comport%> ks=<%=installScriptUri%>
 modules=<%=moduleFiles%>

--- a/data/templates/esx-boot-cfg
+++ b/data/templates/esx-boot-cfg
@@ -1,5 +1,6 @@
 bootstate=0
 title=Loading ESXi installer
+prefix=<%=repo%>/
 kernel=<%=tbootFile%>
 kernelopt=runweasel formatwithmbr com1_baud=115200 com1_Port=<%=comportaddress%> tty2Port=<%=comport%> debugLogToSerial=1 logPort=<%=comport%> ks=<%=installScriptUri%>
 modules=<%=moduleFiles%>

--- a/data/templates/esx-pxelinux-cfg
+++ b/data/templates/esx-pxelinux-cfg
@@ -3,5 +3,5 @@ NOHALT 1
 PROMPT 0
 TIMEOUT 80
 LABEL install
-  KERNEL <%=mbootFile%>
+  KERNEL <%=repo%>/<%=mbootFile%>
   APPEND -c http://<%=server%>:<%=port%>/api/current/templates/<%=esxBootConfigTemplate%>


### PR DESCRIPTION
To address Young, Zachary's comment in PR (https://github.com/RackHD/on-http/pull/38), we can set the prefix as repo address in esx-boot-cfg file so that we don't need long "https://........" appear everywhere.
@RackHD/corecommitters @iceiilin @pengz1