### PR TITLE
Ztip centos kickstart update

### DIFF
--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -221,7 +221,7 @@ chmod +x /etc/rc.d/init.d/<%=rackhdCallbackScript%>
 chkconfig <%=rackhdCallbackScript%> on
 
 #signify ORA the installation completed
-/usr/bin/wget --spider http://<%=server%>:<%=port%>/api/current/templates/renasar-ansible.pub
+/usr/bin/curl -X POST -H 'Content-Type:application/json' http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>
 
 ) 2>&1 >>/root/install-post-sh.log
 EOF

--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -132,70 +132,70 @@ export PATH
 <% } %>
 
 # Setup static network configuration
+<%_ var macRegex = /(..:*){6}/i; _%>
 <% if (typeof networkDevices !== 'undefined') { %>
   <% ipv6 = 0 %>
   <% networkDevices.forEach(function(n) { %>
+    interface=<%=n.device%>
+    <%_ if (n.device.search(macRegex) === 0){ _%>
+      interface=`grep -i /sys/class/net/*/address -e  $interface | cut -d "/" -f 5`
+    <%_ } _%>
     <% if( undefined != n.ipv4 ) { %>
       <% if( undefined != n.ipv4.vlanIds ) { %>
         <% n.ipv4.vlanIds.forEach(function(vid) { %>
-          echo "Configuring vlan <%=vid%> on <%=n.device%>"
-          sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "DEVICE=<%=n.device%>.<%=vid%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "IPADDR=<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "NETMASK=<%=n.ipv4.netmask%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "GATEWAY=<%=n.ipv4.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "VLAN=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
+          echo "Configuring vlan <%=vid%> on $interface"
+          sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "DEVICE=$interface.<%=vid%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "IPADDR=<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "NETMASK=<%=n.ipv4.netmask%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "GATEWAY=<%=n.ipv4.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "VLAN=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
         <% }); %>
       <% } else { %>
-        echo "Configuring device <%=n.device%>"
-        sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "DEVICE=<%=n.device%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "HWADDR=<%=n.hwaddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "IPADDR=<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "NETMASK=<%=n.ipv4.netmask%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "GATEWAY=<%=n.ipv4.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+        echo "Configuring device $interface"
+        sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-$interface
+        sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "DEVICE=$interface" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        <%_ if (n.device.search(macRegex) === 0){ _%>
+            echo "HWADDR=<%=n.device%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        <%_ } _%>
+        echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "IPADDR=<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "NETMASK=<%=n.ipv4.netmask%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "GATEWAY=<%=n.ipv4.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
       <% } %>
     <% } %>
     <% if( undefined != n.ipv6 ) { %>
       <% if( undefined != n.ipv6.vlanIds ) { %>
         <% n.ipv6.vlanIds.forEach(function(vid) { %>
-          echo "Configuring vlan <%=vid%> on <%=n.device%>"
-          sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "DEVICE=<%=n.device%>.<%=vid%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "IPV6INIT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "IPV6ADDR=<%=n.ipv6.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "IPV6_DEFAULTGW=<%=n.ipv6.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
-          echo "VLAN=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>.<%=vid%>
+          echo "Configuring vlan <%=vid%> on $interface"
+          sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "DEVICE=$interface.<%=vid%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "IPV6INIT=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "IPV6ADDR=<%=n.ipv6.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "IPV6_DEFAULTGW=<%=n.ipv6.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
+          echo "VLAN=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface.<%=vid%>
           <% ipv6 = 1 %>
         <% }); %>
       <% } else { %>
-        echo "Configuring device <%=n.device%>"
-        sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "DEVICE=<%=n.device%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "IPV6INIT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "IPV6ADDR=<%=n.ipv6.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-        echo "IPV6_DEFAULTGW=<%=n.ipv6.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+        echo "Configuring device $interface"
+        sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-$interface
+        sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "DEVICE=$interface" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "IPV6INIT=yes" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "IPV6ADDR=<%=n.ipv6.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
+        echo "IPV6_DEFAULTGW=<%=n.ipv6.gateway%>" >> /etc/sysconfig/network-scripts/ifcfg-$interface
         <% ipv6 = 1 %>
       <% } %>
-    <% } %>
-    <% if( (undefined === n.ipv6) && (undefined === n.ipv4) ) { %>
-       sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-       sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-
-       echo 'BOOTPROTO=dhcp' >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
-       echo 'ONBOOT=yes' >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
     <% } %>
   <% }); %>
   <% if( ipv6 ) { %>

--- a/data/templates/centos-ks
+++ b/data/templates/centos-ks
@@ -154,6 +154,7 @@ export PATH
         sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "DEVICE=<%=n.device%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+        echo "HWADDR=<%=n.hwaddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "BOOTPROTO=none" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "ONBOOT=yes" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
         echo "IPADDR=<%=n.ipv4.ipAddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
@@ -189,6 +190,13 @@ export PATH
         <% ipv6 = 1 %>
       <% } %>
     <% } %>
+    <% if( (undefined === n.ipv6) && (undefined === n.ipv4) ) { %>
+       sed -i '/^BOOTPROTO=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+       sed -i '/^ONBOOT=/d' /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+
+       echo 'BOOTPROTO=dhcp' >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+       echo 'ONBOOT=yes' >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>
+    <% } %>
   <% }); %>
   <% if( ipv6 ) { %>
     grep -q -F 'NETWORKING_IPV6=yes' /etc/sysconfig/network || echo "NETWORKING_IPV6=yes" >> /etc/sysconfig/network
@@ -213,7 +221,8 @@ chmod +x /etc/rc.d/init.d/<%=rackhdCallbackScript%>
 chkconfig <%=rackhdCallbackScript%> on
 
 #signify ORA the installation completed
-/usr/bin/curl -X POST -H 'Content-Type:application/json' http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>
+/usr/bin/wget --spider http://<%=server%>:<%=port%>/api/current/templates/renasar-ansible.pub
+
 ) 2>&1 >>/root/install-post-sh.log
 EOF
 %end


### PR DESCRIPTION
- In a case of centos install it is almost impossible for the user to find out what the interface name would be ahead of time. ethx will not cut it as centos may use a different interface naming scheme.
The line below was added so that the interface name is forced to be <%=n.device%>
`echo "HWADDR=<%=n.hwaddr%>" >> /etc/sysconfig/network-scripts/ifcfg-<%=n.device%>`
See [https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/sec-Understanding_the_Device_Renaming_Procedure.html](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/sec-Understanding_the_Device_Renaming_Procedure.html) for refence.
- If the ipv6 or the ipv4 configurations are not specified set the interface for DHCP.