### PR TITLE
fix issue#430 about templates api in version 1.1

### DIFF
--- a/lib/api/1.1/northbound/templates.js
+++ b/lib/api/1.1/northbound/templates.js
@@ -4,7 +4,6 @@
 
 var di = require('di');
 var express = require('express');
-var parser = require('body-parser');
 
 module.exports = templatesRouterFactory;
 
@@ -35,7 +34,7 @@ function templatesRouterFactory (
 
     router.get('/templates/library', function (req, res) {
         Promise.map(templates.getAll(), function(t) {
-            return templates.get(t.name);
+            return templates.get(t.name, t.scope);
         })
         .then(function(t) {
             presenter(req, res).render(t);
@@ -62,7 +61,7 @@ function templatesRouterFactory (
 
     router.get('/templates/library/:identifier', function (req, res) {
         presenter(req, res)
-            .render(templates.get(req.params.identifier));
+            .render(templates.get(req.params.identifier, req.query.scope));
     });
 
 

--- a/spec/lib/api/1.1/templates-spec.js
+++ b/spec/lib/api/1.1/templates-spec.js
@@ -93,6 +93,29 @@ describe('Http.Api.Templates', function () {
                 expect(templates.get).to.have.been.calledWith('123');
             });
         });
+
+        it('should return a single template with scope', function () {
+            templates.get.resolves(template);
+            return helper.request().get('/api/1.1/templates/library/123?scope=abc')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200, template)
+            .then(function () {
+                expect(templates.get).to.have.been.calledOnce;
+                expect(templates.get).to.have.been.calledWith('123','abc');
+            });
+        });
+
+        it('should not return a single template with invalid scope', function () {
+            templates.get.resolves(undefined);
+            return helper.request().get('/api/1.1/templates/library/123?scope=noop')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404)
+            .then(function () {
+                expect(templates.get).to.have.been.calledOnce;
+                expect(templates.get).to.have.been.calledWith('123', 'noop');
+            });
+        });
+
     });
 
     describe('PUT /templates/library/:id', function () {


### PR DESCRIPTION
fix https://github.com/RackHD/RackHD/issues/430

templates.get() interface requires scope as a parameter. If it is not specified, this interface only returns the templates with "global" scope.

In templates/library API, add "scope" as a parameter when getting templates.
In templates/library/:id, add "?scope=xxx" to get a template for a specific scope, which is align with the behavior in API 2.0. If user doesn't use this query, the default scope is global.

@cgx027 @changev 