### PR TITLE
Ssh obm service

### DIFF
--- a/data/views/ibms.2.0.json
+++ b/data/views/ibms.2.0.json
@@ -1,0 +1,8 @@
+{
+  "id" : "<%=id%>",
+  <% if (node !== null) { %>
+  "node": "<%=basepath%>/nodes/<%=node%>",
+  <% } %>
+  "service": "<%= service %>",
+  "config": <%- JSON.stringify(config) %>
+}

--- a/data/views/node.2.0.json
+++ b/data/views/node.2.0.json
@@ -50,5 +50,19 @@
     <% } %>
     <% } %>
     "type": "<%=type%>",
-    "workflows": "<%=basepath %>/nodes/<%=id%>/workflows" 
+    "workflows": "<%=basepath %>/nodes/<%=id%>/workflows",
+    <% if (ibms === null) { %>
+    "ibms": null,
+    <% } else { %>
+    "ibms":[
+    <% ibms.forEach(function (value, i, arr){ %>
+    {
+        "service": "<%=value.service%>",
+        "ref":"<%=basepath %>/ibms/<%=value.id%>"
+    }
+    <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
+    <% }); %>
+    ]
+    <% } %>
+
 }

--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -21,7 +21,7 @@ di.annotate(nodesRouterFactory, new di.Inject(
         '_',
         'Assert',
         'Errors'
-)
+    )
 );
 
 function nodesRouterFactory (
@@ -46,7 +46,7 @@ function nodesRouterFactory (
      * @param {object} node - node model instance
      * @return {object} Promise that fulfills to the rendered node
      */
-    function _renderNodeObmSettings(node) {
+    function _renderNodeMgmtSettings(node) {
         // This function exists to allow backward compatibility of the 1.1 API
         // with 2.0 API OBM and SSH resources.
         assert.object(node, 'node should be a node model instance.');
@@ -68,10 +68,10 @@ function nodesRouterFactory (
                     password: 'REDACTED'
                 };
             } else {
-                delete node['sshSettings'];
+                delete node.sshSettings;
             }
             return node;
-        })
+        });
     }
 
     /**
@@ -87,7 +87,7 @@ function nodesRouterFactory (
         return nodeApiService.getAllNodes(req.query)
         .then(function (nodes){
             return Promise.map(nodes, function(node) {
-                return _renderNodeObmSettings(node);
+                return _renderNodeMgmtSettings(node);
             });
         }); 
     }));
@@ -154,7 +154,7 @@ function nodesRouterFactory (
     router.get('/nodes/:identifier', rest(function (req) {
         return nodeApiService.getNodeById(req.params.identifier)
         .then(function (node){
-            return _renderNodeObmSettings(node);
+            return _renderNodeMgmtSettings(node);
         });
     }));
 
@@ -198,7 +198,7 @@ function nodesRouterFactory (
         })
         .then(function() {
             // lastly render obmSettings into the node.
-            return _renderNodeObmSettings(node);
+            return _renderNodeMgmtSettings(node);
         });
     }));
 
@@ -247,7 +247,7 @@ function nodesRouterFactory (
     router.get('/nodes/:identifier/obm', rest(function (req) {
         return nodeApiService.getNodeObmById(req.params.identifier)
         .then(function (node){
-            return _renderNodeObmSettings(node)
+            return _renderNodeMgmtSettings(node)
             .then(function (retNode){
                 return retNode.obmSettings;
             });
@@ -298,7 +298,7 @@ function nodesRouterFactory (
             });
         })
         .then(function() {
-            return _renderNodeObmSettings(node);
+            return _renderNodeMgmtSettings(node);
         });
     }));
 
@@ -344,7 +344,7 @@ function nodesRouterFactory (
     router.get('/nodes/:identifier/ssh', rest(function (req) {
         return nodeApiService.getNodeById(req.params.identifier)
         .then(function(node) {
-            return _renderNodeObmSettings(node)
+            return _renderNodeMgmtSettings(node)
             .then(function (retNode){
                 return retNode.sshSettings;
             });
@@ -390,7 +390,7 @@ function nodesRouterFactory (
             return waterline.ibms.upsertByNode(req.params.identifier, newBody);
         })
         .then(function() {
-            return _renderNodeObmSettings(node);
+            return _renderNodeMgmtSettings(node);
         });
     }, {
         renderOptions: { success: 201 }

--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -19,8 +19,9 @@ di.annotate(nodesRouterFactory, new di.Inject(
         'Logger',
         'Promise',
         '_',
-        'Assert'
-    )
+        'Assert',
+        'Errors'
+)
 );
 
 function nodesRouterFactory (
@@ -34,30 +35,41 @@ function nodesRouterFactory (
     Logger,
     Promise,
     _,
-    assert
+    assert,
+    Errors
 ) {
     var router = express.Router();
 
     /**
-     * Renders obmSettings property into a node.
+     * Renders obmSettings and sshSettings properties into a node.
      *
      * @param {object} node - node model instance
      * @return {object} Promise that fulfills to the rendered node
      */
     function _renderNodeObmSettings(node) {
         // This function exists to allow backward compatibility of the 1.1 API
-        // with 2.0 API OBM resources.
+        // with 2.0 API OBM and SSH resources.
         assert.object(node, 'node should be a node model instance.');
         assert.ok(!node.obmSettings, 'node should not have obmSettings property');
 
-        node = _.omit(node.toJSON(), 'obms');
-        return Promise.map(waterline.obms.find({node: node.id}), function(obm) {
-           return _.pick(obm.toJSON(), 'service', 'config');
-        })
-        .then(function(obms) {
-            node.obmSettings = obms;
-            return node;
+        node = _.omit(node.toJSON(), ['obms', 'ibms']);
+
+        var obms = Promise.map(waterline.obms.find({node: node.id}), function(obm) {
+            return _.pick(obm.toJSON(), 'service', 'config');
         });
+        var sshSettings = waterline.ibms.findByNode(node.id, 'ssh-ibm-service');
+        return Promise.all([obms, sshSettings])
+        .spread(function(obms, sshSettings) {
+            node.obmSettings = obms;
+            if (sshSettings) {
+                node.sshSettings = {
+                    host: sshSettings.config.host,
+                    user: sshSettings.config.user,
+                    password: 'REDACTED'
+                };
+            }
+            return node;
+        })
     }
 
     /**
@@ -328,10 +340,13 @@ function nodesRouterFactory (
      */
 
     router.get('/nodes/:identifier/ssh', rest(function (req) {
-        return nodeApiService.getNodeSshById(req.params.identifier);
-    }, {
-        serializer: 'Serializables.V1.Ssh',
-        isObject: true
+        return nodeApiService.getNodeById(req.params.identifier)
+        .then(function(node) {
+            return _renderNodeObmSettings(node)
+            .then(function (retNode){
+                return retNode.sshSettings;
+            });
+        });
     }));
 
 
@@ -353,13 +368,31 @@ function nodesRouterFactory (
      */
 
     router.post('/nodes/:identifier/ssh', rest(function (req) {
-        return nodeApiService.postNodeSshById(req.params.identifier, req.body);
+        var node;
+        var newBody;
+
+        return Promise.try(function() {
+            if (req.body.host && req.body.user && req.body.password) {
+                return waterline.nodes.needByIdentifier(req.params.identifier);
+            } else {
+                throw new Errors.BadRequestError('Invalid SSH body');
+            }
+        })
+        .then(function(queryNode) {
+            node = queryNode;
+            newBody = {
+                nodeId: req.params.identifier,
+                service: 'ssh-ibm-service',
+                config: req.body
+            };
+            return waterline.ibms.upsertByNode(req.params.identifier, newBody);
+        })
+        .then(function() {
+            return _renderNodeObmSettings(node);
+        });
     }, {
-        deserializer: 'Serializables.V1.Ssh',
-        serializer: 'Serializables.V1.Node',
         renderOptions: { success: 201 }
     }));
-
 
     /**
      * @api {get} /api/1.1/nodes/:identifier/catalogs GET /:id/catalogs

--- a/lib/api/1.1/northbound/nodes.js
+++ b/lib/api/1.1/northbound/nodes.js
@@ -67,6 +67,8 @@ function nodesRouterFactory (
                     user: sshSettings.config.user,
                     password: 'REDACTED'
                 };
+            } else {
+                delete node['sshSettings'];
             }
             return node;
         })

--- a/lib/api/2.0/ibms.js
+++ b/lib/api/2.0/ibms.js
@@ -1,0 +1,119 @@
+// Copyright 2016, EMC, Inc.
+
+'use strict';
+
+var injector = require('../../../index.js').injector;
+var controller = injector.get('Http.Services.Swagger').controller;
+var schemaApiService = injector.get('Http.Api.Services.Schema');
+var nameSpace = '/api/2.0/ibms/definitions/';
+var waterline = injector.get('Services.Waterline');
+var eventsProtocol = injector.get('Protocol.Events');
+var Errors = injector.get('Errors');
+var nodes = injector.get('Http.Services.Api.Nodes');
+var _ = injector.get('_'); // jshint ignore:line
+
+
+// GET /api/2.0/ibms
+var ibmsGet = controller(function(req) {
+    return waterline.ibms.find(req.query);
+});
+
+// PUT /api/2.0/ibms
+var ibmsPut = controller({success: 201}, function(req) {
+    var nodeId = req.swagger.params.body.value.nodeId;
+    delete req.swagger.params.body.value.nodeId;
+    return waterline.ibms.upsertByNode(nodeId, req.swagger.params.body.value);
+});
+
+// GET /api/2.0/ibms/identifier
+var ibmsGetById = controller(function(req) {
+    return waterline.ibms.needByIdentifier(req.swagger.params.identifier.value);
+});
+
+// PATCH /api/2.0/ibms/identifier
+var ibmsPatchById = controller( function(req) {
+    var ibmId = req.swagger.params.identifier.value;
+    var values = req.swagger.params.body.value;
+    return waterline.ibms.needByIdentifier(ibmId)
+        .then(function(oldIbm) {
+            /* Get nodes that need to publish events */
+            if (oldIbm.node && !values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(oldIbm.node)]);
+            } else if (!oldIbm.node && values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(values.node)]);
+            } else if (oldIbm.node && values.nodeId && oldIbm.node === values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(oldIbm.node)]);
+            } else if (oldIbm.node && values.nodeId && oldIbm.node !== values.nodeId) {
+                return Promise.all([waterline.nodes.getNodeById(oldIbm.node),
+                        waterline.nodes.getNodeById(values.nodeId)]);
+            }
+        })
+        .then(function(oldNodes) {
+            return waterline.ibms.updateByIdentifier(ibmId, values)
+            .tap(function() {
+                /* Publish events of nodes got beofre update */
+                _.forEach(oldNodes, function(oldNode) {
+                    if (oldNode) {
+                        /* asynchronous, don't wait promise return for performance*/
+                        return waterline.nodes.getNodeById(oldNode.id)
+                        .then(function(newNode) {
+                            return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'ibms');
+                        })
+                        .catch(function (error) {
+                            logger.error('Error occurs', error);
+                        });
+                    }
+                });
+            });
+        });
+});
+
+// DELETE /api/2.0/ibms/identifier
+var ibmsDeleteById = controller({success: 204}, function(req) {
+    var ibmId = req.swagger.params.identifier.value;
+    return waterline.ibms.needByIdentifier(ibmId)
+        .then(function (ibm) {
+            return waterline.nodes.getNodeById(ibm.node);
+        })
+        .then(function (oldNode) {
+            return waterline.ibms.destroyByIdentifier(ibmId)
+            .tap(function () {
+                if (oldNode) {
+                    /* asynchronous, don't wait promise return for performance*/
+                    waterline.nodes.getNodeById(oldNode.id)
+                    .then(function (newNode) {
+                        return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'ibms');
+                    })
+                    .catch(function (error) {
+                        logger.error('Error occurs', error);
+                    });
+                }
+            });
+        });
+
+});
+
+// GET /ibms/definitions
+var ibmsDefinitionsGetAll = controller(function() {
+    return schemaApiService.getNamespace(nameSpace);
+});
+
+// GET /ibms/definitions/{name}
+var ibmsDefinitionsGetByName = controller(function(req) {
+    var schemaUid = nameSpace + req.swagger.params.name.value;
+    var schema = schemaApiService.getSchema(schemaUid);
+    if (schema) {
+        return schema;
+    }
+    throw new Errors.NotFoundError(schemaUid + ' Not Found');
+});
+
+module.exports = {
+    ibmsGet: ibmsGet,
+    ibmsPut: ibmsPut,
+    ibmsGetById: ibmsGetById,
+    ibmsPatchById: ibmsPatchById,
+    ibmsDeleteById: ibmsDeleteById,     
+    ibmsDefinitionsGetAll: ibmsDefinitionsGetAll,
+    ibmsDefinitionsGetByName: ibmsDefinitionsGetByName
+};

--- a/lib/api/2.0/ibms.js
+++ b/lib/api/2.0/ibms.js
@@ -9,7 +9,6 @@ var nameSpace = '/api/2.0/ibms/definitions/';
 var waterline = injector.get('Services.Waterline');
 var eventsProtocol = injector.get('Protocol.Events');
 var Errors = injector.get('Errors');
-var nodes = injector.get('Http.Services.Api.Nodes');
 var _ = injector.get('_'); // jshint ignore:line
 
 
@@ -60,7 +59,7 @@ var ibmsPatchById = controller( function(req) {
                             return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'ibms');
                         })
                         .catch(function (error) {
-                            logger.error('Error occurs', error);
+                            throw new Errors.BaseError('Error Occured', error.message);
                         });
                     }
                 });
@@ -85,7 +84,7 @@ var ibmsDeleteById = controller({success: 204}, function(req) {
                         return eventsProtocol.publishNodeAttrEvent(oldNode, newNode, 'ibms');
                     })
                     .catch(function (error) {
-                        logger.error('Error occurs', error);
+                        throw new Errors.BaseError('Error Occured', error.message);
                     });
                 }
             });

--- a/lib/fittings/rackhd_validator.js
+++ b/lib/fittings/rackhd_validator.js
@@ -21,6 +21,13 @@ module.exports = function create(fittingDef) {
                     schemaName = 'noop-obm-service' + suffix;
                 }
             }
+            else if (schemaName === 'ibm') {
+                var suffix = '.json#/definitions/Ibm';
+                var service = context.request.body.service;
+                if (service) {
+                    schemaName = service + suffix;
+                }
+            }
             validate(schemaName, context.request.body, next);
         }
     };

--- a/lib/fittings/rackhd_validator.js
+++ b/lib/fittings/rackhd_validator.js
@@ -12,9 +12,11 @@ module.exports = function create(fittingDef) {
             var schemaNameKey = fittingDef.schemaNameKey;
             var operation = context.request.swagger.operation;
             var schemaName = operation[schemaNameKey];
+            var suffix = null;
+            var service = null;
             if (schemaName === 'obm') {
-                var suffix = '.json#/definitions/Obm';
-                var service = context.request.body.service;
+                suffix = '.json#/definitions/Obm';
+                service = context.request.body.service;
                 if (service) {
                     schemaName = service + suffix;
                 } else {
@@ -22,8 +24,8 @@ module.exports = function create(fittingDef) {
                 }
             }
             else if (schemaName === 'ibm') {
-                var suffix = '.json#/definitions/Ibm';
-                var service = context.request.body.service;
+                suffix = '.json#/definitions/Ibm';
+                service = context.request.body.service;
                 if (service) {
                     schemaName = service + suffix;
                 }

--- a/lib/serializables/v1/ssh.js
+++ b/lib/serializables/v1/ssh.js
@@ -20,39 +20,15 @@ function SshFactory (Promise, Serializable, encryption) {
     Ssh.schema = {
         id: 'Serializables.V1.Ssh',
         type: 'object',
-        anyOf: [
-            {
-                required: ['host', 'user', 'password'],
-                properties: {
-                    $ref: '#/definitions/credentials'
-                }
+        properties:{
+            service: {
+                type: 'string'
             },
-            {
-                required: ['host', 'user', 'privateKey'],
-                properties: {
-                    $ref: '#/definitions/credentials'
-                }
+            config: {
+                type: 'object'
             }
-        ],
-        definitions: {
-            credentials: {
-                host: {
-                    type: 'string'
-                },
-                user: {
-                    type: 'string'
-                },
-                password: {
-                    type: 'string'
-                },
-                publicKey: {
-                    type: 'string'
-                },
-                privateKey: {
-                    type: 'string'
-                }
-            }
-        }
+        },
+        required: ['service', 'config'],
     };
 
     Serializable.register(SshFactory, Ssh);

--- a/lib/serializables/v1/ssh.js
+++ b/lib/serializables/v1/ssh.js
@@ -20,15 +20,48 @@ function SshFactory (Promise, Serializable, encryption) {
     Ssh.schema = {
         id: 'Serializables.V1.Ssh',
         type: 'object',
+        definitions:{
+            credentials: {
+                host: {
+                    type: 'string'
+                },
+                user: {
+                    type: 'string'
+                },
+                password: {
+                    type: 'string'
+                },
+                publicKey: {
+                    type: 'string'
+                },
+                privateKey: {
+                    type: 'string'
+                }
+            }
+        },
         properties:{
             service: {
                 type: 'string'
             },
             config: {
-                type: 'object'
+                type: 'object',
+                anyOf:[
+                    {
+                        required: ['host', 'user', 'password'],
+                        properties: {
+                            $ref: '#/definitions/credentials'
+                        }
+                    },
+                    {
+                        required: ['host', 'user', 'privateKey'],
+                        properties: {
+                            $ref: '#/definitions/credentials'
+                        }
+                    }
+                ]
             }
         },
-        required: ['service', 'config'],
+        required: ['service', 'config']
     };
 
     Serializable.register(SshFactory, Ssh);
@@ -49,11 +82,11 @@ function SshFactory (Promise, Serializable, encryption) {
 
         self.defaults(target);
 
-        if (self.password) {
-            self.password = encryption.encrypt(self.password);
+        if (self.config.password) {
+            self.config.password = encryption.encrypt(self.config.password);
         }
-        if (self.privateKey) {
-            self.privateKey = encryption.encrypt(self.privateKey);
+        if (self.config.privateKey) {
+            self.config.privateKey = encryption.encrypt(self.config.privateKey);
         }
 
         return self.validateAsModel();

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -252,7 +252,7 @@ function nodeApiServiceFactory(
             if (options.skip) query.skip(options.skip);
             if (options.limit) query.limit(options.limit);
 
-            return query.populate('obms');
+            return query.populate('obms').populate('ibms');
         });
     };
 
@@ -449,26 +449,29 @@ function nodeApiServiceFactory(
     };
 
     NodeApiService.prototype.getNodeSshById = function(id) {
-        return waterline.nodes.needByIdentifier(id)
+        return waterline.nodes.getNodeById(id)
             .then(function (node) {
                 if (node) {
-                    if (_.isEmpty(node.sshSettings)) {
-                        throw new Errors.NotFoundError(
-                            'No Ssh Found (' + id + ').'
-                        );
-                    }
-                    return node.sshSettings;
+                    return waterline.ibms.findAllByNode(id, false);
                 }
             });
     };
 
-    NodeApiService.prototype.postNodeSshById = function(id, body) {
-        return waterline.nodes.needByIdentifier(id)
+    /**
+     * Create an OBM for the specified Node id
+     * @param  {String}     id
+     * @param  {Object}     obm
+     * @return {Promise}
+     */
+    NodeApiService.prototype.postNodeSshById = function(id, ibm) {
+        return waterline.nodes.getNodeById(id)
             .then(function (node) {
-                return waterline.nodes.updateByIdentifier(
-                    node.id,
-                    { sshSettings: body }
-                );
+                if (!node) {
+                    throw new Errors.NotFoundError(
+                        'Node not Found ' + id
+                    );
+                }
+                return waterline.ibms.upsertByNode(id, ibm);
             });
     };
 

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -279,7 +279,11 @@ function swaggerFactory(
         schemaPath = path.resolve(__dirname, '../../static/schemas/obms');
         var namespace2Added = schemaApiService.addNamespace(schemaPath, namespace);
 
-        var namespacesAdded = Promise.all([namespace1Added, namespace2Added]);
+        namespace = '/api/2.0/ibms/definitions/';
+        schemaPath = path.resolve(__dirname, '../../static/schemas/ibms');
+        var namespace3Added = schemaApiService.addNamespace(schemaPath, namespace);
+
+        var namespacesAdded = Promise.all([namespace1Added, namespace2Added, namespace3Added]);
 
         return function(schemaName, data, next) {
             namespacesAdded.then(function () {

--- a/spec/lib/api/2.0/ibms-spec.js
+++ b/spec/lib/api/2.0/ibms-spec.js
@@ -1,0 +1,232 @@
+// Copyright 2016, EMC, Inc.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Ibms', function () {
+    var waterline, stub, Errors;
+
+    var goodSendData = 
+        {
+            nodeId: '12345678',
+            service: 'ssh-ibm-service',
+            config: {
+                host: '1.1.1.1',
+                user: 'user',
+                password: 'passw'
+            }
+        };
+
+    var goodData = [
+        {
+            id: '12341234',
+            node: '12345678',
+            service: 'ssh-ibm-service',
+            config: {
+                host: '1.1.1.1',
+                user: 'user',
+                password: 'passw'
+            }
+        },
+        {
+            id: '56785678',
+            node: '12345678',
+            service: 'ssh-ibm-service',
+            config: {
+                host: '2.1.1.1',
+                user: 'user',
+                password: 'passw'
+            }
+        }
+    ];
+
+    var badData1 = {
+        service: 'zzzssh-ibm-service',
+        config: {
+            host: '1.1.1.1',
+            user: 'user',
+            password: 'passw'
+        }
+    };
+    var badData2 = {
+        service: 'ssh-ibm-service',
+        config: {
+            zzzhost: '1.1.1.1',
+            user: 'user',
+            password: 'passw'
+        }
+    };
+
+    before('start HTTP server', function () {
+        this.timeout(5000);
+        return helper.startServer().then(function() {
+            waterline = helper.injector.get('Services.Waterline');
+            Errors = helper.injector.get('Errors');
+        });
+    });
+
+    afterEach(function () {
+        if (stub) {
+            stub.restore();
+            stub = undefined;
+        }
+    });
+
+    after('stop HTTP server', function () {
+        return helper.stopServer();
+    });
+    
+    describe('/api/2.0/ibms/definitions', function () {
+        it('should return a list of IBM schemas', function () {
+            return helper.request().get('/api/2.0/ibms/definitions')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(res.body).to.be.an.instanceOf(Array);
+                });
+        });
+
+        it('should get the ssh IBM schema', function () {
+            return helper.request().get('/api/2.0/ibms/definitions/ssh-ibm-service.json')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(res.body).to.have.property('title', 'ssh-ibm-service');
+                    expect(res.body).to.have.deep.property(
+                        'definitions.Ibm.properties.service').that.is.an('object');
+                    expect(res.body).to.have.deep.property(
+                        'definitions.Ibm.properties.config').that.is.an('object');
+                });
+        });
+
+    });
+    
+    describe('/api/2.0/ibms', function () {
+        it('should return a list of IBM instances', function () {
+            stub = sinon.stub(waterline.ibms, 'find').resolves(goodData);
+
+            return helper.request().get('/api/2.0/ibms')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(stub).to.have.been.called.once;
+                    expect(res.body).to.be.an.instanceOf(Array);
+                    expect(res.body.service).to.equal(goodData.service);
+                    expect(res.body.node).to.equal(goodData.node);
+                    expect(res.body.config).to.deep.equal(goodData.config);
+                });
+        });
+        
+        it('should put an IBM instance', function () {
+            stub = sinon.stub(waterline.ibms, 'upsertByNode').resolves(goodData[0]);
+
+            return helper.request().put('/api/2.0/ibms')
+                .send(goodSendData)
+                .expect('Content-Type', /^application\/json/)
+                .expect(201)
+                .expect(function () {
+                    expect(stub).to.have.been.called.once;
+                });
+        });
+
+        it('should 400 when put with unloaded schema', function () {
+            stub = sinon.stub(waterline.ibms, 'upsertByNode');
+
+            return helper.request().put('/api/2.0/ibms')
+                .send(badData1)
+                .expect('Content-Type', /^application\/json/)
+                .expect(400)
+                .expect(function () {
+                    expect(stub).not.to.have.been.called;
+                });
+        });
+
+        it('should 400 when put with missing field', function () {
+            stub = sinon.stub(waterline.ibms, 'upsertByNode');
+
+            return helper.request().put('/api/2.0/ibms')
+                .send(badData2)
+                .expect('Content-Type', /^application\/json/)
+                .expect(400)
+                .expect(function () {
+                    expect(stub).not.to.have.been.called;
+                });
+        });
+
+    });
+
+    describe('/api/2.0/ibms/:id', function () {
+        beforeEach(function() {
+            sinon.stub(waterline.ibms, 'needByIdentifier');
+            sinon.stub(waterline.ibms, 'updateByIdentifier');
+            sinon.stub(waterline.ibms, 'destroyByIdentifier');
+        });
+
+        afterEach(function() {
+            waterline.ibms.needByIdentifier.restore();
+            waterline.ibms.updateByIdentifier.restore();
+            waterline.ibms.destroyByIdentifier.restore();
+        });
+
+        it('should get an IBM instance', function () {
+            waterline.ibms.needByIdentifier.resolves(goodData[0]);
+
+            return helper.request().get('/api/2.0/ibms/123')
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function (res) {
+                    expect(res.body.service).to.equal(goodData[0].service);
+                    expect(res.body.node).to.equal('/api/2.0/nodes/'+goodData[0].node);
+                });
+        });
+
+        it('should 404 if IBM instance is not found', function () {
+            waterline.ibms.needByIdentifier.rejects( new Errors.NotFoundError('not found'));;
+
+            return helper.request().get('/api/2.0/ibms/123')
+                .expect(404);
+        });
+
+        it('should patch an IBM instance', function () {
+
+            waterline.ibms.needByIdentifier.resolves(goodData[0]);
+            stub = sinon.stub(waterline.nodes, 'getNodeById').resolves(goodData[0]);
+            waterline.ibms.updateByIdentifier.resolves(goodData[0]);
+            return helper.request().patch('/api/2.0/ibms/123')
+                .send(goodSendData)
+                .expect('Content-Type', /^application\/json/)
+                .expect(200)
+                .expect(function () {
+                    expect(stub).to.have.been.called.once;
+                });
+        });
+
+        it('should 400 when patching with bad data', function () {
+            waterline.ibms.needByIdentifier.resolves([]);
+            stub = sinon.stub(waterline.nodes, 'getNodeById').resolves([]);
+            waterline.ibms.updateByIdentifier.resolves([]);
+
+            return helper.request().patch('/api/2.0/ibms/123')
+                .send(badData1)
+                .expect('Content-Type', /^application\/json/)
+                .expect(400)
+                .expect(function () {
+                    expect(stub).not.to.have.been.called;
+                });
+        });
+
+        it('should delete an IBM instance', function () {
+            waterline.ibms.needByIdentifier.resolves([]);
+            stub = sinon.stub(waterline.nodes, 'getNodeById');
+            waterline.ibms.destroyByIdentifier.resolves([]);
+
+            return helper.request().delete('/api/2.0/ibms/123')
+                .expect(204)
+                .expect(function () {
+                    expect(stub).to.have.been.called.once;
+                });
+        });
+
+    });
+
+});

--- a/spec/lib/api/2.0/ibms-spec.js
+++ b/spec/lib/api/2.0/ibms-spec.js
@@ -181,7 +181,7 @@ describe('Http.Api.Ibms', function () {
         });
 
         it('should 404 if IBM instance is not found', function () {
-            waterline.ibms.needByIdentifier.rejects( new Errors.NotFoundError('not found'));;
+            waterline.ibms.needByIdentifier.rejects( new Errors.NotFoundError('not found'));
 
             return helper.request().get('/api/2.0/ibms/123')
                 .expect(404);

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -421,12 +421,7 @@ describe('2.0 Http.Api.Nodes', function () {
                 password: 'mypass'
             }
         };
-        
-        var outputIbm = 
-            {
-                service: "ssh-ibm-service",
-                ref: "/api/2.0/ibms/1234"
-            };
+
         var tempNode = 
         {
             autoDiscover: "false",

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -83,10 +83,14 @@ describe('2.0 Http.Api.Nodes', function () {
     }];
 
     var ibm =[{
-        config: {},
+        config: {
+            host: '1234',
+            user: 'fake-password',
+            password: 'fake-password'
+        },
         id: "11111111111111111111111111",
         node: "12341234abcd123412341234",
-        service: "ssh"
+        service: "ssh-ibm-service"
     }];
 
     var relations =[{
@@ -112,7 +116,7 @@ describe('2.0 Http.Api.Nodes', function () {
             ref: '/api/2.0/obms/574dcd5794ab6e2506fd107a'
         }],
         ibms: [{
-            service: 'ssh',
+            service: 'ssh-ibm-service',
             ref: '/api/2.0/ibms/11111111111111111111111111'
         }],
         type: 'compute',
@@ -134,7 +138,7 @@ describe('2.0 Http.Api.Nodes', function () {
         ibms: ibm,
         type: 'compute'
     };
-    
+
     describe('2.0 GET /nodes', function () {
         it('should return a list of nodes', function () {
             waterline.nodes.find.resolves([rawNode]);
@@ -365,10 +369,13 @@ describe('2.0 Http.Api.Nodes', function () {
 
     describe('GET /nodes/:identifier/ssh', function () {
         var sshNode = _.cloneDeep(node);
-        sshNode.sshSettings = {
+        sshNode.ibms = {
+            service: "ssh-ibm-service",
+            config:{
             host: '1.2.3.4',
             user: 'myuser',
             password: 'mypass'
+            }
         };
 
         it('should return a list of the node\'s ssh settings', function () {
@@ -379,7 +386,7 @@ describe('2.0 Http.Api.Nodes', function () {
                 .expect('Content-Type', /^application\/json/)
                 .expect(200, ibm);
         });
-
+        
         it('should return a 404 if the node was not found', function () {
             waterline.nodes.getNodeById.rejects(new Errors.NotFoundError('Not Found'));
 
@@ -398,19 +405,17 @@ describe('2.0 Http.Api.Nodes', function () {
         });
 
     });
-     
+
     describe('POST /nodes/:identifier/ssh', function () {
         var sshNode = _.cloneDeep(node);
-        sshNode.ibms = 
-            [{ 
-                service: 'ssh',
-                ref: '/api/2.0/ibms/1234' 
-             }];
+        sshNode.ibms = [{
+            service: "ssh-ibm-service",
+            ref: '/api/2.0/ibms/1234'
+        }];
 
         var sendSsh = {
-            id: "1234",
-            service: "test",
-            config: {
+            service: "ssh-ibm-service",
+            config:{
                 host: "5.5.5.5",
                 user: "myuser2",
                 password: 'mypass'
@@ -419,8 +424,8 @@ describe('2.0 Http.Api.Nodes', function () {
         
         var outputIbm = 
             {
-                service: 'test',
-                ref: '/api/2.0/ibms/1234'
+                service: "ssh-ibm-service",
+                ref: "/api/2.0/ibms/1234"
             };
         var tempNode = 
         {
@@ -429,7 +434,7 @@ describe('2.0 Http.Api.Nodes', function () {
             id: '1234foo',
             name: 'name',
             identifiers: []
-        }
+        };
         
         it('should replace existing settings with a new set of ssh settings', function () {
             waterline.nodes.getNodeById.resolves(node);
@@ -480,7 +485,7 @@ describe('2.0 Http.Api.Nodes', function () {
                 .expect(404);
         });
     });
-    
+
     describe('GET /nodes/:identifier/catalogs', function() {
         it('should get a list of catalogs', function () {
             var node = {
@@ -924,5 +929,5 @@ describe('2.0 Http.Api.Nodes', function () {
                 });
         });
     });
-  
+
 });

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -25,6 +25,7 @@ describe('2.0 Http.Api.Nodes', function () {
 
             waterline = helper.injector.get('Services.Waterline');
             sinon.stub(waterline.nodes);
+            sinon.stub(waterline.ibms);
             sinon.stub(waterline.catalogs);
             sinon.stub(waterline.workitems);
             sinon.stub(waterline.graphobjects);
@@ -81,6 +82,13 @@ describe('2.0 Http.Api.Nodes', function () {
         service: "noop-obm-service"
     }];
 
+    var ibm =[{
+        config: {},
+        id: "11111111111111111111111111",
+        node: "12341234abcd123412341234",
+        service: "ssh"
+    }];
+
     var relations =[{
         relationType: "enclosedBy",
         targets: [ "5678abcd5678abcd5678abcd" ]
@@ -103,6 +111,10 @@ describe('2.0 Http.Api.Nodes', function () {
             service: 'noop-obm-service',
             ref: '/api/2.0/obms/574dcd5794ab6e2506fd107a'
         }],
+        ibms: [{
+            service: 'ssh',
+            ref: '/api/2.0/ibms/11111111111111111111111111'
+        }],
         type: 'compute',
         workflows: '/api/2.0/nodes/1234abcd1234abcd1234abcd/workflows'
     };
@@ -119,9 +131,10 @@ describe('2.0 Http.Api.Nodes', function () {
         identifiers: [],
         relations: relations,
         obms: obm,
+        ibms: ibm,
         type: 'compute'
     };
-
+    
     describe('2.0 GET /nodes', function () {
         it('should return a list of nodes', function () {
             waterline.nodes.find.resolves([rawNode]);
@@ -357,22 +370,18 @@ describe('2.0 Http.Api.Nodes', function () {
             user: 'myuser',
             password: 'mypass'
         };
-        var serializedSshSettings = {
-            host: '1.2.3.4',
-            user: 'myuser',
-            password: 'REDACTED'
-        };
 
         it('should return a list of the node\'s ssh settings', function () {
-            waterline.nodes.needByIdentifier.resolves(sshNode);
+            waterline.nodes.getNodeById.resolves(sshNode);
+            waterline.ibms.findAllByNode.resolves(ibm);
 
             return helper.request().get('/api/2.0/nodes/1234/ssh')
                 .expect('Content-Type', /^application\/json/)
-                .expect(200, serializedSshSettings);
+                .expect(200, ibm);
         });
 
         it('should return a 404 if the node was not found', function () {
-            waterline.nodes.needByIdentifier.rejects(new Errors.NotFoundError('Not Found'));
+            waterline.nodes.getNodeById.rejects(new Errors.NotFoundError('Not Found'));
 
             return helper.request().get('/api/2.0/nodes/1234/ssh')
                 .expect('Content-Type', /^application\/json/)
@@ -380,90 +389,98 @@ describe('2.0 Http.Api.Nodes', function () {
         });
 
         it('should return a 404 if the node has no ssh settings', function () {
-            waterline.nodes.needByIdentifier.resolves({ id: node.id });
+            waterline.nodes.getNodeById.resolves({ id: node.id });
+            waterline.ibms.findAllByNode.rejects(new Errors.NotFoundError('Not Found'));
 
             return helper.request().get('/api/2.0/nodes/1234/ssh')
                 .expect('Content-Type', /^application\/json/)
                 .expect(404);
         });
-    });
 
+    });
+     
     describe('POST /nodes/:identifier/ssh', function () {
         var sshNode = _.cloneDeep(node);
-        sshNode.sshSettings = {
-            host: '1.2.3.4',
-            user: 'myuser',
-            password: 'mypass'
-        };
-        var updatedSshSettings = {
-            'host': '5.5.5.5',
-            'user': 'myuser2',
-            'password': 'mypassword2'
-        };
+        sshNode.ibms = 
+            [{ 
+                service: 'ssh',
+                ref: '/api/2.0/ibms/1234' 
+             }];
 
+        var sendSsh = {
+            id: "1234",
+            service: "test",
+            config: {
+                host: "5.5.5.5",
+                user: "myuser2",
+                password: 'mypass'
+            }
+        };
+        
+        var outputIbm = 
+            {
+                service: 'test',
+                ref: '/api/2.0/ibms/1234'
+            };
+        var tempNode = 
+        {
+            autoDiscover: "false",
+            catalogs:'/api/2.0/nodes/1234abcd1234abcd1234abcd/catalogs',
+            id: '1234foo',
+            name: 'name',
+            identifiers: []
+        }
+        
         it('should replace existing settings with a new set of ssh settings', function () {
-            var updated = _.cloneDeep(node);
-            updated.sshSettings = updatedSshSettings;
-            waterline.nodes.needByIdentifier.resolves(node);
-            waterline.nodes.updateByIdentifier.resolves(updated);
-            return helper.request().post('/api/2.0/nodes/1234/ssh')
-                .send(updatedSshSettings)
+            waterline.nodes.getNodeById.resolves(node);
+            waterline.ibms.upsertByNode.resolves(sshNode);
+            return helper.request().post('/api/2.0/nodes/1234abcd1234abcd1234abcd/ssh')
+                .send(sendSsh)
                 .expect('Content-Type', /^application\/json/)
                 .expect(201)
                 .expect(function (data) {
-                    expect(data.body.sshSettings).to.deep.equal(updatedSshSettings);
-                    expect(waterline.nodes.updateByIdentifier).to.have.been.calledOnce;
-                    expect(waterline.nodes.updateByIdentifier).to.have.been.calledWith(node.id);
-                    expect(waterline.nodes.updateByIdentifier.firstCall.args[1].sshSettings.host)
-                        .to.equal(updatedSshSettings.host);
+                    expect(data.body.ibms).to.deep.equal(sshNode.ibms);
+                    expect(waterline.nodes.getNodeById).to.have.been.calledOnce;
                 });
         });
 
         it('should add a new set of ssh settings if none exist', function () {
-            waterline.nodes.needByIdentifier.resolves({ id: node.id });
-            var updated = _.cloneDeep(node);
-            updated.sshSettings = updatedSshSettings;
-            waterline.nodes.updateByIdentifier.resolves(updated);
-            return helper.request().post('/api/2.0/nodes/1234/ssh')
-                .send(updatedSshSettings)
+            waterline.nodes.getNodeById.resolves(tempNode);
+            waterline.ibms.upsertByNode.resolves(sendSsh);
+            return helper.request().post('/api/2.0/nodes/1234foo/ssh')
+                .send(sendSsh)
                 .expect('Content-Type', /^application\/json/)
                 .expect(201)
                 .expect(function (data) {
-                    expect(data.body.sshSettings).to.deep.equal(updatedSshSettings);
-                    expect(waterline.nodes.updateByIdentifier).to.have.been.calledOnce;
-                    expect(waterline.nodes.updateByIdentifier).to.have.been.calledWith(node.id);
-                    expect(waterline.nodes.updateByIdentifier.firstCall.args[1].sshSettings.host)
-                        .to.equal(updatedSshSettings.host);
+                    expect(data.body).to.deep.equal(sendSsh);
+                    expect(waterline.nodes.getNodeById).to.have.been.calledOnce;
                 });
         });
 
         it('should not add a new unsupported ssh settings', function () {
-            waterline.nodes.needByIdentifier.resolves(node);
+            waterline.nodes.getNodeById.resolves(node);
             var invalidSetting = {
                 'host': '5.5.5.5'
             };
 
-            waterline.nodes.needByIdentifier.resolves(node);
+            waterline.nodes.getNodeById.resolves(node);
 
             return helper.request().post('/api/2.0/nodes/1234/ssh')
                 .send(invalidSetting)
                 .expect('Content-Type', /^application\/json/)
-                .expect(400)
-                .expect(function () {
-                    expect(waterline.nodes.updateByIdentifier).to.not.have.been.called;
-                });
+                .expect(400);
         });
 
         it('should return a 404 if the node was not found', function () {
-            waterline.nodes.needByIdentifier.rejects(new Errors.NotFoundError('Not Found'));
+            waterline.nodes.getNodeById.rejects(new Errors.NotFoundError('Not Found'));
 
             return helper.request().post('/api/2.0/nodes/1234/ssh')
-                .send(updatedSshSettings)
+                .send(sendSsh)
                 .expect('Content-Type', /^application\/json/)
                 .expect(404);
         });
     });
-
+    
     describe('GET /nodes/:identifier/catalogs', function() {
         it('should get a list of catalogs', function () {
             var node = {
@@ -907,4 +924,5 @@ describe('2.0 Http.Api.Nodes', function () {
                 });
         });
     });
+  
 });

--- a/spec/lib/serializables/v1/ssh-spec.js
+++ b/spec/lib/serializables/v1/ssh-spec.js
@@ -25,22 +25,26 @@ describe('Ssh Serializable V1', function () {
         it('should redact encrypted password fields', function() {
             return this.subject.serialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    password: encryption.encrypt('fake-password')
+                    config:{
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        password: encryption.encrypt('fake-password')
+                    }
                 }
-            ).should.eventually.have.property('password').that.equals('REDACTED');
+            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('password').and.not.equals('fake-password');
         });
 
         it('should redact encrypted privateKey fields', function() {
             return this.subject.serialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    publicKey: 'fake-public-key',
-                    privateKey: encryption.encrypt('fake-private-key'),
+                    config:{
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        publicKey: 'fake-public-key',
+                        privateKey: encryption.encrypt('fake-private-key')
+                    }
                 }
-            ).should.eventually.have.property('privateKey').that.equals('REDACTED');
+            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('privateKey').and.not.equals('fake-private-key');
         });
     });
 
@@ -52,9 +56,13 @@ describe('Ssh Serializable V1', function () {
         it('should conform to a host/user/password schema', function() {
             return this.subject.deserialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    password: 'fake-password'
+                    service: "test",
+                    config: {
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        password: 'fake-password'
+                    }
+
                 }
             ).should.be.fulfilled;
         });
@@ -62,10 +70,13 @@ describe('Ssh Serializable V1', function () {
         it('should conform to a host/user/publicKey/privateKey schema', function() {
             return this.subject.deserialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    publicKey: 'fake-public-key',
-                    privateKey: 'fake-private-key'
+                    service: "test",
+                    config: {
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        publicKey: 'fake-public-key',
+                        privateKey: 'fake-private-key'
+                    }
                 }
             ).should.be.fulfilled;
         });
@@ -73,21 +84,27 @@ describe('Ssh Serializable V1', function () {
         it('should optionally support both schemas', function() {
             return this.subject.deserialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    password: 'fake-password',
-                    publicKey: 'fake-public-key',
-                    privateKey: 'fake-private-key'
+                    service: "test",
+                    config: {
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        password: 'fake-password',
+                        publicKey: 'fake-public-key',
+                        privateKey: 'fake-private-key'
+                    }
                 }
+
             ).should.be.fulfilled;
         });
 
         it('should fail on a bad host/user/password key schema', function() {
             return this.subject.deserialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    publicKey: 'fake-public-key'
+                    config: {
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        publicKey: 'fake-public-key'
+                    }
                 }
             ).should.be.rejectedWith(/SchemaError/);
         });
@@ -95,9 +112,11 @@ describe('Ssh Serializable V1', function () {
         it('should fail on a bad host/user/public/private key schema', function() {
             return this.subject.deserialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    publicKey: 'fake-public-key'
+                    service: "test",
+                    config: {
+                        host: 'fake-host',
+                        user: 'fake-user'
+                    }
                 }
             ).should.be.rejectedWith(/SchemaError/);
         });
@@ -105,26 +124,28 @@ describe('Ssh Serializable V1', function () {
         it('should encrypt password fields', function() {
             return this.subject.deserialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    password: 'fake-password'
+                    service: "test",
+                    config: {
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        password: 'fake-password'
+                    }
                 }
-            ).should.eventually.have.property(
-                'password'
-            ).and.not.equal('fake-password');
+            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('password').and.not.equals('fake-password');
         });
 
         it('should encrypt privateKey fields', function() {
             return this.subject.deserialize(
                 {
-                    host: 'fake-host',
-                    user: 'fake-user',
-                    publicKey: 'fake-public-key',
-                    privateKey: 'fake-private-key'
+                    service: "test",
+                    config: {
+                        host: 'fake-host',
+                        user: 'fake-user',
+                        publicKey: 'fake-public-key',
+                        privateKey: 'fake-private-key'
+                    }
                 }
-            ).should.eventually.have.property(
-                'privateKey'
-            ).and.not.equal('fake-private-key');
+            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('privateKey').and.not.equals('fake-private-key');
         });
     });
 });

--- a/spec/lib/serializables/v1/ssh-spec.js
+++ b/spec/lib/serializables/v1/ssh-spec.js
@@ -31,7 +31,9 @@ describe('Ssh Serializable V1', function () {
                         password: encryption.encrypt('fake-password')
                     }
                 }
-            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('password').and.not.equals('fake-password');
+            ).should.eventually.have.property('config')
+             .that.is.an('object').and.to.have.property('password')
+             .and.not.equals('fake-password');
         });
 
         it('should redact encrypted privateKey fields', function() {
@@ -44,7 +46,9 @@ describe('Ssh Serializable V1', function () {
                         privateKey: encryption.encrypt('fake-private-key')
                     }
                 }
-            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('privateKey').and.not.equals('fake-private-key');
+            ).should.eventually.have.property('config')
+             .that.is.an('object').and.to.have.property('privateKey')
+             .and.not.equals('fake-private-key');
         });
     });
 
@@ -131,7 +135,9 @@ describe('Ssh Serializable V1', function () {
                         password: 'fake-password'
                     }
                 }
-            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('password').and.not.equals('fake-password');
+            ).should.eventually.have.property('config')
+             .that.is.an('object').and.to.have.property('password')
+             .and.not.equals('fake-password');
         });
 
         it('should encrypt privateKey fields', function() {
@@ -145,7 +151,9 @@ describe('Ssh Serializable V1', function () {
                         privateKey: 'fake-private-key'
                     }
                 }
-            ).should.eventually.have.property('config').that.is.an('object').and.to.have.property('privateKey').and.not.equals('fake-private-key');
+            ).should.eventually.have.property('config')
+             .that.is.an('object').and.to.have.property('privateKey')
+             .and.not.equals('fake-private-key');
         });
     });
 });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -627,25 +627,19 @@ paths:
     x-swagger-router-controller: files
   /ibms:
     get:
-      description: 'Get a list of all In Band Management settings that have been associated
-
-        with nodes. 
-        '
+      description: Get a list of all In Band Management settings that have been associated
+        with nodes.
       operationId: ibmsGet
       responses:
         200:
-          description: 'Successfully retrieved the list of IBMS service instances
-
-            '
+          description: Successfully retrieved the list of IBMS service instances
           schema:
             type: object
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-      summary: 'Get list of all IBM service instances
-
-        '
+      summary: Get list of all IBM service instances
       tags:
       - /api/2.0
       x-authentication-type:
@@ -655,16 +649,11 @@ paths:
       - ibmsRead
       x-view: ibms.2.0.json
     put:
-      description: 'Create or update a single IBM service, and
-
+      description: Create or update a single IBM service, and
         associate it with a node.
-
-        '
       operationId: ibmsPut
       parameters:
-      - description: 'The IBM settings information to create
-
-          '
+      - description: The IBM settings information to create
         in: body
         name: body
         required: true
@@ -672,24 +661,18 @@ paths:
           $ref: '#/definitions/ssh-ibm-service_Ibm'
       responses:
         201:
-          description: 'Successfully put the IBM service
-
-            '
+          description: Successfully put the IBM service
           schema:
             type: object
         500:
-          description: 'IBM service creation failed
-
-            '
+          description: IBM service creation failed
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-      summary: 'Put an IBM service
-
-        '
+      summary: Put an IBM service
       tags:
       - /api/2.0
       x-authentication-type:
@@ -702,26 +685,20 @@ paths:
     x-swagger-router-controller: ibms
   /ibms/definitions:
     get:
-      description: 'Get a list of IBMS schemas, which define the properties
-
+      description:
+        Get a list of IBMS schemas, which define the properties
         required to create IBMS settings.
-
-        '
       operationId: ibmsDefinitionsGetAll
       responses:
         200:
-          description: 'Successfully retrieved a list of IBMS schemas
-
-            '
+          description: Successfully retrieved a list of IBMS schemas
           schema:
             type: object
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-      summary: 'Get list of IBMS services
-
-        '
+      summary: Get list of IBMS services
       tags:
       - /api/2.0
       x-authentication-type:
@@ -732,32 +709,24 @@ paths:
     x-swagger-router-controller: ibms
   /ibms/definitions/{name}:
     get:
-      description: 'Get the contents of the specified IBMS service schema.
-
-        '
+      description: Get the contents of the specified IBMS service schema.
       operationId: ibmsDefinitionsGetByName
       parameters:
-      - description: 'The IBMS service name
-
-          '
+      - description: The IBMS service name
         in: path
         name: name
         required: true
         type: string
       responses:
         200:
-          description: 'Successfully retrieved the specified IBMS shcema
-
-            '
+          description: Successfully retrieved the specified IBMS shcema
           schema:
             type: object
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-      summary: 'Get an IBMS service definition
-
-        '
+      summary: Get an IBMS service definition
       tags:
       - /api/2.0
       x-authentication-type:
@@ -768,38 +737,28 @@ paths:
     x-swagger-router-controller: ibms
   /ibms/{identifier}:
     delete:
-      description: 'Delete the IBMS settings with the specified identifier.
-
-        '
+      description: Delete the IBMS settings with the specified identifier.
       operationId: ibmsDeleteById
       parameters:
-      - description: 'The IBMS service identifier
-
-          '
+      - description: The IBMS service identifier
         in: path
         name: identifier
         required: true
         type: string
       responses:
         204:
-          description: 'Successfully deleted the specified IBMS settings
-
-            '
+          description: Successfully deleted the specified IBMS settings
           schema:
             type: object
         404:
-          description: 'The IBMS service with the specified identifier was not found
-
-            '
+          description: The IBMS service with the specified identifier was not found
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-      summary: 'Delete IBMS settings
-
-        '
+      summary: Delete IBMS settings
       tags:
       - /api/2.0
       x-authentication-type:
@@ -808,32 +767,24 @@ paths:
       - Write
       - ibmsRemove
     get:
-      description: 'Get the IBMS settings associated with the specified identifier
-
-        '
+      description: Get the IBMS settings associated with the specified identifier
       operationId: ibmsGetById
       parameters:
-      - description: 'The IBMS service identifier
-
-          '
+      - description: The IBMS service identifier
         in: path
         name: identifier
         required: true
         type: string
       responses:
         200:
-          description: 'Successfully retrieved the specified IBMS service
-
-            '
+          description: Successfully retrieved the specified IBMS service
           schema:
             type: object
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-      summary: 'Get an IBMS service
-
-        '
+      summary: Get an IBMS service
       tags:
       - /api/2.0
       x-authentication-type:
@@ -843,14 +794,10 @@ paths:
       - ibmsRead
       x-view: ibms.2.0.json
     patch:
-      description: 'Update the properties of the IBMS settings with the specified identifier.
-
-        '
+      description: Update the properties of the IBMS settings with the specified identifier.
       operationId: ibmsPatchById
       parameters:
-      - description: 'The IBMS service identifier
-
-          '
+      - description: The IBMS service identifier
         in: path
         name: identifier
         required: true
@@ -863,24 +810,18 @@ paths:
           $ref: '#/definitions/ssh-ibm-service_Ibm'
       responses:
         200:
-          description: 'Successfully patched the specified IBMS settings
-
-            '
+          description: Successfully patched the specified IBMS settings
           schema:
             type: object
         500:
-          description: 'IBMS patch failed
-
-            '
+          description: IBMS patch failed
           schema:
             $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-      summary: 'Patch IBMS settings
-
-        '
+      summary: Patch IBMS settings
       tags:
       - /api/2.0
       x-authentication-type:

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -205,16 +205,19 @@ definitions:
           $ref: '#/definitions/tag_rule'
         type: array
     type: object
-  ssh_settings:
+  ssh-ibm-service_Ibm:
     description: SSH settings
     properties:
       config:
         properties:
           host:
+            description: IP address
             type: string
           password:
+            description: Password
             type: string
           user:
+            description: Username
             type: string
         type: object
       service:
@@ -666,7 +669,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/ipmi-obm-service_Obm'
+          $ref: '#/definitions/ssh-ibm-service_Ibm'
       responses:
         201:
           description: 'Successfully put the IBM service
@@ -857,7 +860,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/ipmi-obm-service_Obm'
+          $ref: '#/definitions/ssh-ibm-service_Ibm'
       responses:
         200:
           description: 'Successfully patched the specified IBMS settings
@@ -1553,7 +1556,6 @@ paths:
       x-privileges:
       - Read
       - nodesRead
-      x-swagger-serializer: nodes
     post:
       description: Create the ssh settings associated with the specified node.
       operationId: nodesPostSshById
@@ -1568,7 +1570,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/ssh_settings'
+          $ref: '#/definitions/ssh-ibm-service_Ibm'
       responses:
         201:
           description: Successfull created ssh settings
@@ -1588,7 +1590,8 @@ paths:
       x-privileges:
       - Write
       - nodesWrite
-      #x-swagger-deserializer: nodes
+      x-swagger-schema: ibm
+      x-swagger-deserializer: nodes
     x-swagger-router-controller: nodes
   /nodes/{identifier}/tags:
     get:

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -208,15 +208,20 @@ definitions:
   ssh_settings:
     description: SSH settings
     properties:
-      host:
-        type: string
-      password:
-        type: string
-      user:
+      config:
+        properties:
+          host:
+            type: string
+          password:
+            type: string
+          user:
+            type: string
+        type: object
+      service:
         type: string
     required:
-    - host
-    - user
+    - service
+    - config
     type: object
   tag_rule:
     properties:
@@ -617,6 +622,271 @@ paths:
       - filesRead
       x-view: file.2.0.json
     x-swagger-router-controller: files
+  /ibms:
+    get:
+      description: 'Get a list of all In Band Management settings that have been associated
+
+        with nodes. 
+        '
+      operationId: ibmsGet
+      responses:
+        200:
+          description: 'Successfully retrieved the list of IBMS service instances
+
+            '
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: 'Get list of all IBM service instances
+
+        '
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Read
+      - ibmsRead
+      x-view: ibms.2.0.json
+    put:
+      description: 'Create or update a single IBM service, and
+
+        associate it with a node.
+
+        '
+      operationId: ibmsPut
+      parameters:
+      - description: 'The IBM settings information to create
+
+          '
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/ipmi-obm-service_Obm'
+      responses:
+        201:
+          description: 'Successfully put the IBM service
+
+            '
+          schema:
+            type: object
+        500:
+          description: 'IBM service creation failed
+
+            '
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: 'Put an IBM service
+
+        '
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Write
+      - ibmsWrite
+      x-swagger-schema: ibm
+      x-view: ibms.2.0.json
+    x-swagger-router-controller: ibms
+  /ibms/definitions:
+    get:
+      description: 'Get a list of IBMS schemas, which define the properties
+
+        required to create IBMS settings.
+
+        '
+      operationId: ibmsDefinitionsGetAll
+      responses:
+        200:
+          description: 'Successfully retrieved a list of IBMS schemas
+
+            '
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: 'Get list of IBMS services
+
+        '
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Read
+      - ibmsRead
+    x-swagger-router-controller: ibms
+  /ibms/definitions/{name}:
+    get:
+      description: 'Get the contents of the specified IBMS service schema.
+
+        '
+      operationId: ibmsDefinitionsGetByName
+      parameters:
+      - description: 'The IBMS service name
+
+          '
+        in: path
+        name: name
+        required: true
+        type: string
+      responses:
+        200:
+          description: 'Successfully retrieved the specified IBMS shcema
+
+            '
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: 'Get an IBMS service definition
+
+        '
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Read
+      - ibmsRead
+    x-swagger-router-controller: ibms
+  /ibms/{identifier}:
+    delete:
+      description: 'Delete the IBMS settings with the specified identifier.
+
+        '
+      operationId: ibmsDeleteById
+      parameters:
+      - description: 'The IBMS service identifier
+
+          '
+        in: path
+        name: identifier
+        required: true
+        type: string
+      responses:
+        204:
+          description: 'Successfully deleted the specified IBMS settings
+
+            '
+          schema:
+            type: object
+        404:
+          description: 'The IBMS service with the specified identifier was not found
+
+            '
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: 'Delete IBMS settings
+
+        '
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Write
+      - ibmsRemove
+    get:
+      description: 'Get the IBMS settings associated with the specified identifier
+
+        '
+      operationId: ibmsGetById
+      parameters:
+      - description: 'The IBMS service identifier
+
+          '
+        in: path
+        name: identifier
+        required: true
+        type: string
+      responses:
+        200:
+          description: 'Successfully retrieved the specified IBMS service
+
+            '
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: 'Get an IBMS service
+
+        '
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Read
+      - ibmsRead
+      x-view: ibms.2.0.json
+    patch:
+      description: 'Update the properties of the IBMS settings with the specified identifier.
+
+        '
+      operationId: ibmsPatchById
+      parameters:
+      - description: 'The IBMS service identifier
+
+          '
+        in: path
+        name: identifier
+        required: true
+        type: string
+      - description: The IBMS properties to patch
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/ipmi-obm-service_Obm'
+      responses:
+        200:
+          description: 'Successfully patched the specified IBMS settings
+
+            '
+          schema:
+            type: object
+        500:
+          description: 'IBMS patch failed
+
+            '
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: 'Patch IBMS settings
+
+        '
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Write
+      - ibmsModify
+      x-swagger-schema: ibm
+    x-swagger-router-controller: ibms
   /lookups:
     get:
       description:
@@ -1318,7 +1588,7 @@ paths:
       x-privileges:
       - Write
       - nodesWrite
-      x-swagger-deserializer: nodes
+      #x-swagger-deserializer: nodes
     x-swagger-router-controller: nodes
   /nodes/{identifier}/tags:
     get:

--- a/static/schemas/ibms/ssh-ibm-service.json
+++ b/static/schemas/ibms/ssh-ibm-service.json
@@ -1,0 +1,36 @@
+{
+    "title": "ssh-ibm-service",
+    "definitions": {
+        "Ibm": {
+            "description": "IBM settings",
+            "type": "object",
+            "properties": {
+                "nodeId": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "description": "BMC address",
+                            "type": "string"
+                        },
+                        "user": {
+                            "description": "username",
+                            "type": "string"
+                        },
+                        "password": {
+                            "description": "password",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["host", "user", "password"]
+                }
+            },
+            "required": ["service", "config"]
+        }
+    }
+}

--- a/static/schemas/ibms/ssh-ibm-service.json
+++ b/static/schemas/ibms/ssh-ibm-service.json
@@ -15,7 +15,7 @@
                     "type": "object",
                     "properties": {
                         "host": {
-                            "description": "BMC address",
+                            "description": "The IP address to SSH into",
                             "type": "string"
                         },
                         "user": {
@@ -25,9 +25,19 @@
                         "password": {
                             "description": "password",
                             "type": "string"
+                        },
+                        "publicKey": {
+                            "description": "publicKey",
+                            "type": "string"
+                        },
+                        "privateKey": {
+                            "description": "privateKey",
+                            "type": "string"
                         }
                     },
-                    "required": ["host", "user", "password"]
+                    "anyOf": [
+                        { "required": ["host", "user", "password"] },
+                        { "required": [ "host", "user", "privateKey" ] }
                 }
             },
             "required": ["service", "config"]


### PR DESCRIPTION
This PR Jenkins:depends on https://github.com/RackHD/on-core/pull/222 and Jenkins:depends on RackHD/on-tasks#361

In this PR:

```
Move sshSettings from nodes.
Create /ibms and /ibms/{identifier} like the obms .
Backward compatible with 1.1 like obms.
Schema/view for ibms.
unit-test fix
```

@RackHD/corecommitters @dalebremner @brianparry @BillyAbildgaard @geoff-reid
