### PR TITLE
remove rackhd callback script after esxi installation

### DIFF
--- a/data/templates/esx.rackhdcallback
+++ b/data/templates/esx.rackhdcallback
@@ -18,6 +18,14 @@ do
         echo "Failed to connect to RackHD API callback, retrying"
         sleep 1
     else
+        if [ -e /vmfs/volumes/datastore1/rackhd_callback ]
+        then
+            echo "Remove RackHD callback script"
+            rm /vmfs/volumes/datastore1/rackhd_callback
+            rm /etc/rc.local.d/local.sh
+        else
+            touch /vmfs/volumes/datastore1/rackhd_callback
+        fi
         exit 0
     fi
 done;


### PR DESCRIPTION
Remove RackHD callback script after ESXi installation. 

Otherwise ESXi will try sending API to RackHD every time it boots, causing much longer boot time if disconnected from RackHD.

This script is called two times in ESXi installation workflow. Firstly in firstboot, and then in the final reboot for ssh validation, thus a tmp file (rackhd_callback) is created as a flag to signal it is called before so that this script could be deleted the second time it is called.

Putting this flag in /vmfs is because ESXi uses in-memory file system, and there is no method to persist user specific files in other directory of the OS. refer http://www.virtuallyghetto.com/2011/08/how-to-persist-configuration-changes-in.html 

@lanchongyizu 