### PR TITLE
SUSE OS installation was failing when the node has too many Ethernet …

### DIFF
--- a/data/profiles/install-suse.ipxe
+++ b/data/profiles/install-suse.ipxe
@@ -1,6 +1,6 @@
 echo Starting SUSE <%=version%> installer >
 set base-url <%=repo%>
-set params linux install=${base-url} autoyast=<%=installScriptUri%>
+set params linux install=${base-url} autoyast=<%=installScriptUri%> <%=kargs%>
 kernel ${base-url}/boot/x86_64/loader/linux
 initrd ${base-url}/boot/x86_64/loader/initrd
 imgargs linux ${params}


### PR DESCRIPTION
…ports.

We added a wait statement to give a chance for the ports to initialize