### PR TITLE
Add obm setting while posting a new node

### DIFF
--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -249,18 +249,33 @@ function nodeApiServiceFactory(
         return Promise.try(function() {
             query = waterline.nodes.find(query);
 
-            if (options.skip) query.skip(options.skip);
-            if (options.limit) query.limit(options.limit);
+            if (options.skip) {
+                query.skip(options.skip);
+            }
+            if (options.limit) {
+                query.limit(options.limit);
+            }
 
             return query.populate('obms');
         });
     };
 
     NodeApiService.prototype.postNode = function(body) {
-        return Promise.resolve().then(function() {
-            return waterline.nodes.create(body);
+        //for api-v1.1 back-compatibility, the input obm can be either via obms or obmSettings
+        var nodeBody = _.omit(body, ['obms', 'obmSettings']);
+        var obmBody = body.obms || body.obmSettings || null;
+
+        return Promise.resolve()
+        .then(function() {
+            return waterline.nodes.create(nodeBody);
         }).tap(function(node) {
             return eventsProtocol.publishNodeEvent(node, 'added');
+        }).tap(function(node) {
+            if (obmBody) {
+                return Promise.map(obmBody, function(obm) {
+                    return waterline.obms.upsertByNode(node.id, obm);
+                });
+            }
         }).then(function(node) {
             if(node.type === Constants.NodeTypes.Switch &&
                node.snmpSettings && node.autoDiscover) {
@@ -287,7 +302,7 @@ function nodeApiServiceFactory(
                 );
             }
             else if(node.type === Constants.NodeTypes.Mgmt &&
-                    node.obmSettings && node.autoDiscover) {
+                    obmBody && node.autoDiscover) {
                 var configuration = {
                     name: 'Graph.MgmtSKU.Discovery',
                     options: {
@@ -408,24 +423,6 @@ function nodeApiServiceFactory(
 
     NodeApiService.prototype.getNodeObmById = function(id) {
         return waterline.nodes.needByIdentifier(id);
-    };
-
-    NodeApiService.prototype.postNodeObmById = function(id, body) {
-        return waterline.nodes.needByIdentifier(id)
-            .then(function (node){
-                return ObmService.checkValidService(node, body)
-                    .then(function () {
-                        return node;
-                    });
-            })
-            .then(function (node) {
-                var obmSettings = node.obmSettings || [];
-                obmSettings.push(body);
-                return waterline.nodes.updateByIdentifier(
-                    id,
-                    { obmSettings: obmSettings }
-                );
-            });
     };
 
     NodeApiService.prototype.postNodeObmIdById = function(id, body) {

--- a/lib/services/schema-api-service.js
+++ b/lib/services/schema-api-service.js
@@ -61,7 +61,7 @@ function schemaApiServiceFactory(
                                 logger.warning('no title found in ' + entry);
                             }
                         } catch(err) {
-                            logger.warning('error loading schema:' + entry);
+                            logger.warning('error loading schema:' + entry, { error: err } );
                         }
                     });
             });

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -860,7 +860,7 @@ describe('2.0 Http.Api.Nodes', function () {
     describe('OBM support', function() {
 
         var obm = {
-            service: 'noop-obm-service',
+            service: 'ipmi-obm-service',
             config: {
                 host: '1.2.3.4',
                 user: 'myuser',
@@ -872,10 +872,7 @@ describe('2.0 Http.Api.Nodes', function () {
             id: "57c5e319c466ff9435d27fb3",
             node: "",
             service: "noop-obm-service",
-            config: {
-                host: "1.2.3.4",
-                user: "myuser"
-            }
+            config: {}
         };
 
         after(function() {

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -81,17 +81,23 @@ definitions:
     - config
     type: object
   node.2.0_PartialNode:
-    description: Post a node in RackHD
+    description: Post a node into RackHD
     properties:
       autoDiscover:
         type: string
       name:
         description: Name of the node
         type: string
+      obms:
+        description: The list of obm settings
+        type: array
+        items:
+            $ref: "#/definitions/nodes_post_obm_by_id"
       type:
         description: Type of node
         enum:
         - compute
+        - compute-container
         - switch
         - dae
         - pdu
@@ -101,7 +107,7 @@ definitions:
         type: string
     type: object
   nodes_post_obm_by_id:
-    description: IPMI OBM settings
+    description: OBM settings
     properties:
       config:
         type: object

--- a/static/schemas/2.0/node.2.0.json
+++ b/static/schemas/2.0/node.2.0.json
@@ -16,11 +16,14 @@
                 "type": {
                     "description": "Type of node",
                     "type": "string",
-                    "enum": ["compute", "switch", "dae", "pdu", "mgmt", "enclosure", "rack"]
+                    "enum": ["compute-container", "compute", "switch", "dae", "pdu", "mgmt", "enclosure", "rack"]
                 },
-                "obmSettings": {
+                "obms": {
                     "description": "OBM settings",
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
                 },
                 "snmpSettings": {
                     "description": "SNMP settings",
@@ -51,7 +54,7 @@
         "Node": {
             "allOf": [
                 { "$ref": "#/definitions/PartialNode" },
-                { "required": [ "name" ] }
+                { "required": [ "name", "type" ] }
             ]
         }
     }


### PR DESCRIPTION
This is a part of fix for https://github.com/RackHD/RackHD/issues/483

Root cause: After the obm is moved to a standalone model, we forget to add the obm setting while posting a new node, so some node catalog job will fail.

BTW: the unit-test error due to the node-cache is fixed as well in my PR.

@RackHD/corecommitters @iceiilin @cgx027 @pengz1 @manfrednde 