### PR TITLE
create ssh keys at startup for Esxi

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -92,16 +92,18 @@ esxcli network firewall set --default-action false --enabled no
 <%} %>
 
 #create users
+rm /vmfs/volumes/datastore1/rackhd_create_sshkeys
 <% if( typeof users !== 'undefined' ) { %>
 <% users.forEach(function(user) { %>
     /usr/lib/vmware/auth/bin/adduser -s /bin/sh -G root -h / -D <%=user.name%>
     echo <%=user.plainPassword%> | passwd <%=user.name%> --stdin
     <% if (typeof user.sshKey !== 'undefined') { %>
-        mkdir /etc/ssh/keys-<%=user.name%>
-        echo <%=user.sshKey%> > /etc/ssh/keys-<%=user.name%>/authorized_keys
+        echo "mkdir /etc/ssh/keys-<%=user.name%>" >> /vmfs/volumes/datastore1/rackhd_create_sshkeys
+        echo "echo <%=user.sshKey%> > /etc/ssh/keys-<%=user.name%>/authorized_keys" >> /vmfs/volumes/datastore1/rackhd_create_sshkeys
     <%} %>
 <%}) %>
 <%} %>
+chmod +x /vmfs/volumes/datastore1/rackhd_create_sshkeys
 
 #setup ntp
 cat > /etc/ntp.conf << __NTP_CONFIG__

--- a/data/templates/esx.rackhdcallback
+++ b/data/templates/esx.rackhdcallback
@@ -3,7 +3,7 @@
 # description: calls back to rackhd post installation API hook
 
 echo "Attempting to call back to RackHD ESX installer"
-
+LOCALSH=/etc/rc.local.d/local.sh
 # *sigh*, busybox shell does not support {1..30}. Retry 30 times with 1 second
 # sleep in between.
 for retry in $(awk 'BEGIN { for ( i=0; i<30; i++ ) { print i; } }');
@@ -22,8 +22,11 @@ do
         then
             echo "Remove RackHD callback script"
             rm /vmfs/volumes/datastore1/rackhd_callback
+            echo "Create RackHD SSH keys for non-root users after second reboot and on startup"
             /vmfs/volumes/datastore1/rackhd_create_sshkeys
-            echo $'#!/bin/sh\n/vmfs/volumes/datastore1/rackhd_create_sshkeys\nexit 0' > /etc/rc.local.d/local.sh
+            echo '#!/bin/sh' > $LOCALSH
+            cat /vmfs/volumes/datastore1/rackhd_create_sshkeys >> $LOCALSH
+            echo 'exit 0' >> $LOCALSH
             /sbin/auto-backup.sh
         else
             touch /vmfs/volumes/datastore1/rackhd_callback

--- a/data/templates/esx.rackhdcallback
+++ b/data/templates/esx.rackhdcallback
@@ -22,7 +22,9 @@ do
         then
             echo "Remove RackHD callback script"
             rm /vmfs/volumes/datastore1/rackhd_callback
-            rm /etc/rc.local.d/local.sh
+            /vmfs/volumes/datastore1/rackhd_create_sshkeys
+            echo $'#!/bin/sh\n/vmfs/volumes/datastore1/rackhd_create_sshkeys\nexit 0' > /etc/rc.local.d/local.sh
+            /sbin/auto-backup.sh
         else
             touch /vmfs/volumes/datastore1/rackhd_callback
         fi


### PR DESCRIPTION
It's related with ODR-259.
create ssh keys for Esxi at startup since it can't be persistent.

@RackHD/corecommitters @panpan0000 @iceiilin 