### PR TITLE
added redactions to workflows GET by :id

### DIFF
--- a/lib/api/1.1/northbound/workflows.js
+++ b/lib/api/1.1/northbound/workflows.js
@@ -14,7 +14,8 @@ di.annotate(workflowsRouterFactory,
         'Http.Services.Api.Workflows',
         'Services.Waterline',
         'Errors',
-        '_'
+        '_',
+        'Sanitizer'
     )
 );
 
@@ -23,7 +24,8 @@ function workflowsRouterFactory (
     workflowApiService,
     waterline,
     Errors,
-    _
+    _,
+    sanitizer
 ) {
     var router = express.Router();
 
@@ -144,7 +146,12 @@ function workflowsRouterFactory (
      */
 
     router.get('/workflows/:instanceId', rest(function (req) {
-        return waterline.graphobjects.needOne({ instanceId: req.params.instanceId });
+        
+        return  waterline.graphobjects.needOne({ instanceId: req.params.instanceId })
+        .then(function(graph) {
+            sanitizer.scrub(graph);
+            return graph;
+        });
     }));
 
     return router;

--- a/lib/api/2.0/workflows.js
+++ b/lib/api/2.0/workflows.js
@@ -9,6 +9,7 @@ var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var Errors = injector.get('Errors');
 var Constants = injector.get('Constants');
 var _ = injector.get('_');    // jshint ignore:line
+var sanitizer = injector.get('Sanitizer');
 
 /**
 * @api {get} /api/2.0/workflows GET /workflows
@@ -65,7 +66,11 @@ var workflowsPost = controller({success: 201}, function(req) {
 */
 
 var workflowsGetByInstanceId = controller(function(req) {
-    return workflowApiService.getWorkflowByInstanceId(req.swagger.params.identifier.value);
+    return workflowApiService.getWorkflowByInstanceId(req.swagger.params.identifier.value)
+    .then(function(graph) {
+        sanitizer.scrub(graph);
+        return graph;
+    });
 });
 
 /**


### PR DESCRIPTION
@RackHD/corecommitters 

New way to resolve: https://github.com/RackHD/RackHD/issues/241
This PR depends on: https://github.com/RackHD/on-core/pull/228
both PRs resolve: https://github.com/RackHD/RackHD/issues/417

this is the final PR to revert old (complex and overlapping) encryption of passwords to simply redact secret fields prior to the object being passed to the client.