### PR TITLE
Fix exit code handling in bootstrap.js

### DIFF
--- a/data/templates/bootstrap.js
+++ b/data/templates/bootstrap.js
@@ -80,7 +80,7 @@ function updateTasks(data, timeout, retry, retries) {
                 }, timeout);
             } else {
                 console.log("Task Execution Complete");
-                process.exit(data.exit.code || 0);
+                process.exit(data.exit.code || data.exit || 0);
             }
         });
     }).on('error', function (err) {


### PR DESCRIPTION
When we ask bootstrap.js to exit we pass the value as the `exit` member of the tasks structure. Problem is that bootstrap.js seems to expect it to be `exit.code`. I've fixed this defensively as I'm not sure if there are prior installations that expect the `exit.code` value.