### PR TITLE
Fix error where InternalServerError is called with a Error object

### DIFF
--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -381,7 +381,7 @@ function profileApiServiceFactory(
             })
             .catch(function (err) {
                 if (!err.status) {
-                    throw new Errors.InternalServerError(err);
+                    throw new Errors.InternalServerError(err.message);
                 } else {
                     throw err;
                 }


### PR DESCRIPTION
Jenkins depends on: https://github.com/RackHD/on-core/pull/230 

## Background
on-core PR #230 fixed a typo on errors.js where InternalServerError should be a subclass of BaseError, thus InternalServerError should be called with a string parameter. 

## The problem
In lib/services/profiles-api-service.js Lin 384, InternalServerError is mistakenly with an Error object. On-http unit test fails because of this. Here is the Jenkins log: http://rackhdci.lss.emc.com/job/on-http/2881/

## The Fix: 
Change parameter from Object to string. 