### PR TITLE
Mount host dev in the micro container

### DIFF
--- a/data/templates/cloud-config.yaml
+++ b/data/templates/cloud-config.yaml
@@ -14,7 +14,7 @@ write_files:
           -e SERVER='<%= server %>' \
           -e PORT='<%= port %>' \
           -e MAC='<%= macaddress %>' \
-          --privileged --net=host rackhd/micro
+          --privileged --net=host -v=/dev:/dev rackhd/micro
 
       mapfile -t containerlist < <(docker ps)
       container=(${containerlist[1]//$'\n'/ })


### PR DESCRIPTION
- Required for task driveId
- Adding  -v=dev:/dev to the docker run command