### PR TITLE
Compare RoleId value to existing roles and only accepts known roles

### DIFF
--- a/lib/api/redfish-1.0/account-service.js
+++ b/lib/api/redfish-1.0/account-service.js
@@ -64,7 +64,13 @@ var createAccount = controller({success: 201}, function(req, res) {
         assert.string(payload.UserName);
         assert.string(payload.Password);
         assert.string(payload.RoleId);
-        return accountService.listUsers();
+        return accountService.getRoleByName(payload.RoleId)
+        .then(function() {
+            return accountService.listUsers();
+        })
+        .catch(function() {
+            throw new Errors.UnauthorizedError('Unauthorized RoleId value');
+        });
     })
     .then(function(users) {
         if(!users.length && localUserException && res.locals.ipAddress === '127.0.0.1') {


### PR DESCRIPTION
Presently, redfish users can be created with any string given as their RoleId. This change ensures that users can only be made with known role values taken from getRoleByName()