### PR TITLE
RAC-2044/ODR-952 Removed 204 response code to make congruent with swagger definition file

### DIFF
--- a/lib/api/2.0/tasks.js
+++ b/lib/api/2.0/tasks.js
@@ -13,14 +13,9 @@ var getBootstrap = controller( function (req, res) {
     return tasksApiService.getBootstrap(req, res, req.swagger.params.macAddress.value);
 });
 
-var getTasksById = controller( {send204OnEmpty:true}, function (req){
+var getTasksById = controller( function (req){
     return tasksApiService.getTasks(req.swagger.params.identifier.value)
     .catch(function (err) {
-        if (err.name === 'NoActiveTaskError') {
-            //Return with no data, this will cause a 204 to be sent
-            return;
-        }
-        // throw a NotFoundError
         throw new Errors.NotFoundError('Not Found');
     });
 });

--- a/spec/lib/api/2.0/tasks-spec.js
+++ b/spec/lib/api/2.0/tasks-spec.js
@@ -72,13 +72,13 @@ describe('Http.Api.Tasks', function () {
             });
         });
 
-        it("should return 204 if no active task exists", function() {
+        it("should return 404 if no active task exists", function() {
             var tasksApiService = helper.injector.get('Http.Services.Api.Tasks');
             taskProtocol.activeTaskExists.rejects(new tasksApiService.NoActiveTaskError());
             return helper.request().get('/api/2.0/tasks/testnodeid')
-            .expect(204)
+            .expect(404)
             .expect(function (res) {
-                expect(res.body).to.be.empty;
+                expect(res.body.message).to.deep.equal('Not Found');
             });
         });
 


### PR DESCRIPTION
/tasks/{identifier} was returning 204 whenever a task for searched for and not found or when a bad task was provided. By design, this should be returning 404 as specified in monorail-2.0.yaml. What has been removed resolves this.