### PR TITLE
RAC-3801 ESXi 6.0 OS installation failure when network interface is s…

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -216,10 +216,10 @@ for retry in $(seq 1 60);
 do
     wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc.local.d/local.sh
     if [ $? -eq 0 ]; then
-        echo "The call back script was downloaded successfully."
+        logger "The call back script was downloaded successfully after $retry attempt(s)."
         break
     else
-        echo "Failed to download call back script, retrying..."
+        logger "Failed to download call back script after $retry attempt(s)."
         sleep 1
     fi
 done;

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -216,10 +216,10 @@ for retry in $(seq 1 60);
 do
     wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc.local.d/local.sh
     if [ $? -eq 0 ]; then
-        logger "The call back script was downloaded successfully after $retry attempt(s)."
+        logger -p user.info "RackHD's call back script was downloaded successfully after $retry attempt(s)."
         break
     else
-        logger "Failed to download call back script after $retry attempt(s)."
+        logger -p user.info "Failed to download RackHD's call back script after $retry attempt(s)."
         sleep 1
     fi
 done;

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -209,7 +209,20 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 #
 # NOTE: this script will execute right away as a result of writing it to local.sh
 # along with executing on every subsequent boot
-wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc.local.d/local.sh
+#
+# Try to download call back script 60 times 1 second
+# sleep in between to allow link to be up after DHCP
+for retry in $(awk 'BEGIN { for ( i=0; i<60; i++ ) { print i; } }');
+do
+    wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc.local.d/local.sh
+    if [ $? -eq 0 ]; then
+        echo "The call back script was downloaded successfully."
+        break
+    else
+        echo "Failed to download call back script, retrying..."
+        sleep 1
+    fi
+done;
 
 #backup ESXi configuration to persist it
 /sbin/auto-backup.sh

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -221,11 +221,12 @@ do
     else
         logger -p user.info "Failed to download RackHD's call back script after $retry attempt(s)."
         sleep 1
-        if [ $retry -eq 60 ]; then
-           logger -p user.err "Failed to download RackHD's call back script."
-        fi
     fi
 done;
+
+if [ $retry -eq 60 ]; then
+   logger -p user.err "RackHD's call back script was not downloaded successfully."
+fi
 
 #backup ESXi configuration to persist it
 /sbin/auto-backup.sh

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -212,7 +212,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 #
 # Try to download call back script 60 times 1 second
 # sleep in between to allow link to be up after DHCP
-for retry in $(awk 'BEGIN { for ( i=0; i<60; i++ ) { print i; } }');
+for retry in $(seq 1 60);
 do
     wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc.local.d/local.sh
     if [ $? -eq 0 ]; then

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -221,6 +221,9 @@ do
     else
         logger -p user.info "Failed to download RackHD's call back script after $retry attempt(s)."
         sleep 1
+        if [ $retry -eq 60 ]; then
+           logger -p user.err "Failed to download RackHD's call back script."
+        fi
     fi
 done;
 


### PR DESCRIPTION
…et to dhcp

This code change is to solve the issue where the network interface is specified in the payload and it is set to dhcp. The payload may look like the following in this case:

{
    "options": {
        "defaults": {
            "version": "6.0",
            "repo": "http://172.31.128.1:9080/esxi/esxi6",
            "networkDevices":[{"device": "vmnic2"}]
        }
    }
}
 It looks like when the host try to download the call back script the link is not ready. So I included a retry option in the kickstart script. 

@RackHD/corecommitters 

@stuart-stanley 

@derrickostertag 

@johren 


