### PR TITLE
Fixed returned value of cli command in catalog config

### DIFF
--- a/data/templates/cisco-catalog-config.py
+++ b/data/templates/cisco-catalog-config.py
@@ -8,8 +8,8 @@ def main():
     data = {}
 
     try:
-        data['startup-config'] = cli('show startup-config')[0]
-        data['running-config'] = cli('show running-config')[0]
+        data['startup-config'] = cli('show startup-config')
+        data['running-config'] = cli('show running-config')
     except:
         pass
 


### PR DESCRIPTION
this command `cli('show startup-config')` returns the output as a string  so using `[0]` will only get the first character.