### PR TITLE
Stop TravisCI to upload deb to Bintray on-http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,11 @@ before_deploy:
    if ! [ "$BEFORE_DEPLOY_RUN" ]; then
      export BEFORE_DEPLOY_RUN=1;
      ./extra/make-docs.sh;
-     ./extra/make-deb.sh;
    fi
 
 deploy:
   - provider: bintray
     file: .bintray-doc.json
-    user: $BINTRAY_USER
-    key: $BINTRAY_KEY
-    on:
-      branch: master
-      node: "4"
-  - provider: bintray
-    file: .bintray-deb.json
     user: $BINTRAY_USER
     key: $BINTRAY_KEY
     on:

--- a/extra/make-deb.sh
+++ b/extra/make-deb.sh
@@ -36,6 +36,10 @@ java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-c
 ./build-package.bash python-client "${BRANCH}" "on-http-api1.1"
 ./build-package.bash python-client "${BRANCH}" "on-http-api2.0"
 ./build-package.bash python-client "${BRANCH}" "on-http-redfish-1.0"
-./build-package.bash on-http "${BRANCH}"
+
+##### Peter remove on-http.deb building & upload to bintray ,since Jenkins takes over this work
+#./build-package.bash on-http "${BRANCH}"
+#
+
 if [ -d deb ]; then rm -rf deb/; fi
 mkdir deb && cp -a *.deb deb/


### PR DESCRIPTION
rework of PR https://github.com/RackHD/on-http/pull/549

**Highlight**
the building of swagger python client  package : on-http-api1.1,  on-http-api2.0 ,  on-http-redfish-1.0 still being kept in TravisCI , since Jenkins hasn't covered it yet.
so the ```./extra/make-deb.sh``` & ```.bintray-deb.json``` still there.

**Background**
https://groups.google.com/forum/#!topic/rackhd/MoES4tSsMKk

Jenkins upload package will be like ```1.1-1-20161205UTC-627fbb3  ```
and Travis version will be like ```1.1-1master-20160930100654Z1```, which always newer than Jenkins' publish packages. so we  will have to disable Travis uploading.
moreover, Bintray has stopped Travis CI to upload deb:
```Bintray response: 403 Forbidden. Version 'master' has been published more than 180 days ago and can no longer be deployed to.```



**Test**
https://travis-ci.org/RackHD-Mirror/on-http/builds/189120093

This PR can be merged now .
https://github.com/RackHD/on-http/pull/550 fix swagger-doc build error ( this error previously was hidden , which ```./extra/make-docs.sh``` will fail.)



@brianparry 
