### PR TITLE
Add skipPollerOption to determine creating or skipping 

### DIFF
--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -143,6 +143,7 @@ function profileApiServiceFactory(
             configuration = self.getSwitchDiscoveryConfiguration(node, options.switchVendor);
         } else {
             var setObm = configFile.get('autoCreateObm', 'false');
+            var skipPollers = configFile.get('skipPollersCreation', 'false');
             configuration = {
                 name: configFile.get('discoveryGraph', 'Graph.SKU.Discovery'),
                 options: {
@@ -154,6 +155,9 @@ function profileApiServiceFactory(
                             }
                         },
                         nodeId: node.id
+                    },
+                    'skip-pollers': {
+                        skipPollersCreation: skipPollers
                     }
                 }
             };

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -213,10 +213,11 @@ describe("Http.Services.Api.Profiles", function () {
                     defaults: {
                         graphOptions: {
                             target: node.id,
-                            'obm-option': { autoCreateObm: "false" }
+                            'obm-option': { autoCreateObm: 'false' }
                         },
                         nodeId: node.id
-                    }
+                    },
+                    'skip-pollers': { skipPollersCreation: 'false' }
                 }
             });
             expect(profileApiService.waitForDiscoveryStart).to.have.been.calledOnce;
@@ -232,6 +233,7 @@ describe("Http.Services.Api.Profiles", function () {
         this.sandbox.stub(configuration, 'get').withArgs('discoveryGraph')
             .returns('from.config.graph');
         configuration.get.withArgs('autoCreateObm').returns('false');
+        configuration.get.withArgs('skipPollersCreation').returns('false');
         return profileApiService.runDiscovery(node)
         .then(function(_node) {
             expect(_node).to.equal(node);
@@ -245,7 +247,8 @@ describe("Http.Services.Api.Profiles", function () {
                             'obm-option': { autoCreateObm: "false" }
                         },
                         nodeId: node.id
-                    }
+                    },
+                    'skip-pollers': { skipPollersCreation: 'false' }
                 }
             });
             expect(profileApiService.waitForDiscoveryStart).to.have.been.calledOnce;


### PR DESCRIPTION
Add a new option in the config file to allow user to skip the generation of pollers on a compute node