### PR TITLE
add swagger python-client deb build back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_deploy:
    if ! [ "$BEFORE_DEPLOY_RUN" ]; then
      export BEFORE_DEPLOY_RUN=1;
      ./extra/make-docs.sh;
+     ./extra/make-deb.sh;
    fi
 
 deploy:


### PR DESCRIPTION
Oops,  my PR https://github.com/RackHD/on-http/pull/556 has wrongly remove the swagger python deb build .
so this PR added it back ..

@brianparry @geoff-reid 