### PR TITLE
Cisco Version Header string contains extra escape characters

### DIFF
--- a/data/templates/cisco-catalog-version.py
+++ b/data/templates/cisco-catalog-version.py
@@ -8,7 +8,10 @@ def main():
     data = {}
 
     try:
-        data = json.loads(clid('show version'))
+        # The "as is" will cause dumps from taskrunner.py to produce an invalid jason string
+        dataString = clid('show version')
+        dataString = dataString.replace("\\\"as is,\\\"", "as is")
+        data = json.loads(dataString)
     except:
         pass
 

--- a/data/templates/cisco-catalog-version.py
+++ b/data/templates/cisco-catalog-version.py
@@ -8,8 +8,11 @@ def main():
     data = {}
 
     try:
-        # The "as is" will cause dumps from taskrunner.py to produce an invalid jason string
+        # get the version in json form in a temporary string so we can manipulate it
         dataString = clid('show version')
+        # The "as is" in the license header string from 'show version'
+        # will cause json.dumps within taskrunner.py to produce an invalid json string
+        # This is resolved by replacing the additional escapes (\) with a raw string
         dataString = dataString.replace("\\\"as is,\\\"", "as is")
         data = json.loads(dataString)
     except:


### PR DESCRIPTION
that json encoding escapes on and renders incorrectly.
This removes those characters and allows correct encoding.

Signed-off-by: Ethan Kaley <ethan.kaley@emc.com>