### PR TITLE
Bugfix for set bmc credentials

### DIFF
--- a/data/templates/remove_bmc_credentials.sh
+++ b/data/templates/remove_bmc_credentials.sh
@@ -2,7 +2,26 @@
 
 usernames=(<%= users.join(" ") %>)
 
-mapfile -t userlist < <(ipmitool user list)
+channel=''
+function set_channel()
+{
+    for i in {1..15}; do
+        ipmitool user list $i &>/dev/null
+        status=$?
+        if [ "$status" -eq "0" ] ; then
+            channel=$i
+            break
+        fi
+    done
+}
+set_channel
+echo "channel number is" $channel
+if [ -z "${channel}" ]; then
+ echo "Channel number was not set correctly, exiting script"
+exit 1
+fi
+
+mapfile -t userlist < <(ipmitool user list $channel)
 
 array_len=${#userlist[@]}
 if [ "$array_len" -gt  "1" ]; then
@@ -22,4 +41,6 @@ for user in ${usernames[@]}; do
       fi
    done
 done
+#succesfull
+exit 0
 

--- a/data/templates/set_bmc_credentials.sh
+++ b/data/templates/set_bmc_credentials.sh
@@ -21,9 +21,11 @@ fi
 echo " Getting the user list"
 cmdReturn=$(ipmitool user list $channel)
 myarray=(${cmdReturn//$'\n'/ })
-cmdReturn1=$(ipmitool user summary $channel)
-myarray1=(${cmdReturn1//$'\n'/ })
-userNumber=${myarray1[8]}
+mapfile -t userlist < <(ipmitool user list $channel)
+userNumber=${#userlist[@]}
+if [ "$userNumber" -gt  "1" ]; then
+   userNumber=$(expr $userNumber - 1)
+fi
 user=$(<%=user%>)
 #The check variable is a flag to determine if the user already exists
 #(1:already exist and 0:user does not exist)

--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -150,14 +150,17 @@ function profileApiServiceFactory(
                     defaults: {
                         graphOptions: {
                             target: node.id,
-                            'obm-option' : {
-                                 autoCreateObm: setObm,
+                            'skip-reboot-post-discovery' : {
+                                 skipReboot: setObm,
                             }
                         },
                         nodeId: node.id
                     },
                     'skip-pollers': {
                         skipPollersCreation: skipPollers
+                    },
+                    'obm-option' : {
+                        autoCreateObm: setObm,
                     }
                 }
             };

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -213,11 +213,12 @@ describe("Http.Services.Api.Profiles", function () {
                     defaults: {
                         graphOptions: {
                             target: node.id,
-                            'obm-option': { autoCreateObm: 'false' }
+                            'skip-reboot-post-discovery': { skipReboot: 'false' }
                         },
                         nodeId: node.id
                     },
-                    'skip-pollers': { skipPollersCreation: 'false' }
+                    'skip-pollers': { skipPollersCreation: 'false' },
+                    'obm-option': { autoCreateObm: 'false' }
                 }
             });
             expect(profileApiService.waitForDiscoveryStart).to.have.been.calledOnce;
@@ -244,11 +245,12 @@ describe("Http.Services.Api.Profiles", function () {
                     defaults: {
                         graphOptions: {
                             target: node.id,
-                            'obm-option': { autoCreateObm: "false" }
+                            'skip-reboot-post-discovery': { skipReboot: 'false' }
                         },
                         nodeId: node.id
                     },
-                    'skip-pollers': { skipPollersCreation: 'false' }
+                    'skip-pollers': { skipPollersCreation: 'false' },
+                    'obm-option': { autoCreateObm: "false" }
                 }
             });
             expect(profileApiService.waitForDiscoveryStart).to.have.been.calledOnce;


### PR DESCRIPTION
- Set bmc credentials used to get user count of enabled bmc users
  It should get the toal nb of bmc users
- Remove users fails the user list command; Added logic to get the open channel nb
- Migrate set bms credentials from discovery graph to Discovery-sku-graph
  in discovery graph, group label is set in bootstrap
  and it overides the tasks properties

Fix for https://github.com/RackHD/RackHD/issues/602
depends on: https://github.com/RackHD/on-taskgraph/pull/210