### PR TITLE
prevent render error if networkDevices is not defined

### DIFF
--- a/data/templates/unattend_server2012.xml
+++ b/data/templates/unattend_server2012.xml
@@ -147,7 +147,7 @@
             <ComputerName><%=hostname%></ComputerName>
         </component>
         <component name="Microsoft-Windows-TCPIP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <% if( undefined !== networkDevices ) { %>
+            <% if( typeof networkDevices !== 'undefined' ) { %>
             <% networkDevices.forEach(function(n) { %>
             <% cidr_bits = 0 %>
             <% dhcp_ipv4 = false %>


### PR DESCRIPTION
This is to fix the failure with windows OS install, https://rackhd.atlassian.net/browse/RAC-4035

@RackHD/corecommitters @tannoa2 @keedya @uppalk1 