### PR TITLE
Revert "Ztip esx kickstart update"

### DIFF
--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -7,35 +7,31 @@ accepteula
   install --disk=<%=installDisk%> --overwritevmfs
 <% } %>
 rootpw <%=rootPlainPassword%>
+
+# Search the networkDevices and set the first device (if defined) up.
+# If no device is specified in the networkDevices, then we fallback
+# to setting 'vmnic0' up as DHCP. The device can be specified with a
+# MAC address or device name ('vmnic0' for example)
+<% if( typeof networkDevices !== 'undefined' ) { %>
+  <% need_default = networkDevices.every(function(n) { %>
+    <% if(typeof n.ipv4 !== 'undefined') { %>
+      <% ipopts = '--ip=' + n.ipv4.ipAddr + ' --gateway=' + n.ipv4.gateway + ' --netmask=' + n.ipv4.netmask %>
+      <% if (typeof n.ipv4.vlanIds !== 'undefined' ) { %>
+        <% ipopts += ' --vlandid=' + n.ipv4.vlanIds[0] %>
+      <% } %>
+      network --bootproto=static --device=<%=n.device%> <%=ipopts%>
+    <% } else { %>
+      network --bootproto=dhcp --device=<%=n.device%>
+    <% } %>
+    <% return false; %>
+  <% }); %>
+  <% if (need_default) { %>
+    network --bootproto=dhcp --device=vmnic0
+  <% } %>
+<% } %>
 reboot
 
 %firstboot --interpreter=busybox
-
-postLookup () {
-  echo "Attempting postLookup operation on $1" >> /vmfs/volumes/datastore1/firstboot.log
-  mac=`esxcli --debug --formatter=csv network ip interface list | grep $1 | awk -F, '{print $3}'`
-  if [ "<%=version%>" == "5.5" ]; then
-    mac=`esxcli --debug --formatter=csv network ip interface list | grep $1 | awk -F, '{print $2}'`
-  fi
-  BODY="{"
-  BODY=$BODY"\"macAddress\": \"$mac\","
-  BODY=$BODY"\"node\": \"<%=nodeId%>\""
-  BODY=$BODY"}"
-  BODYLEN=$(echo -n ${BODY} | wc -c )
-  echo ${BODY} >> /vmfs/volumes/datastore1/firstboot.log
-  result=`echo -ne "POST /api/current/lookups HTTP/1.0\r\nHost: $2\r\nContent-Type: application/json\r\nContent-Length: ${BODYLEN}\r\n\r\n${BODY}" | nc -i 3  <%=server%> <%=port%> | grep -oE 'HTTP/1.1 [0-9]{3}' | awk '{print $2}'`
-  if [ "$result" -ge "400" ]; then
-    # Make an attempt to PATCH if we can find the node id.  This is to handle the case where the
-    # ARP poller added the lookup entry when we tried to POST above causing a collision.
-    id=`wget http://<%=server%>:<%=port%>/api/current/lookups?q=$mac -qO - | grep -oE '\"id\":\"(.)*\"'`
-    if [ "$?" -eq "0" ]; then
-      id=`echo $id | awk -F: '{gsub(/"/,"",$2); print $2}'`
-      result=`echo -ne "PATCH /api/current/lookups/$id HTTP/1.0\r\nHost: $2\r\nContent-Type: application/json\r\nContent-Length: ${BODYLEN}\r\n\r\n${BODY}" | nc -i 3 <%=server%> <%=port%> | grep -oE 'HTTP/1.1 [0-9]{3}' | awk '{print $2}'`
-      echo "Patch result: $result to id: $id" >> /vmfs/volumes/datastore1/firstboot.log
-    fi
-  fi
-  wget http://<%=server%>:<%=port%>/api/current/lookups?q=$mac -qO - >> /vmfs/volumes/datastore1/firstboot.log
-}
 
 # enable VHV (Virtual Hardware Virtualization to run nested 64bit Guests + Hyper-V VM)
 grep -i "vhv.enable" /etc/vmware/config || echo "vhv.enable = \"TRUE\"" >> /etc/vmware/config
@@ -120,7 +116,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
       <% n.uplinks.forEach(function(s) { %>
         currdev=<%=s%>
         <% if (s.substring(0,5) !== 'vmnic') { %>
-          currdev=`esxcli network nic list | grep -i <%=s%> | cut -d ' ' -f 1`
+          currdev=`esxcli network nic list | grep <%=s%> | cut -d ' ' -f 1`
         <% } %>
         currsw=`esxcli --debug --formatter=csv network vswitch standard list | grep $currdev | awk -F, '{print $9}'`
         if [ "$currsw" != "" ]; then
@@ -137,7 +133,7 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
   <% networkDevices.forEach(function(n) { %>
     currdev=<%=n.device%>
     <% if (n.device.substring(0,5) != 'vmnic') { %>
-       currdev=`esxcli network nic list | grep -i <%=n.device%> | cut -d ' ' -f 1`
+       currdev=`esxcli network nic list | grep <%=n.device%> | cut -d ' ' -f 1`
     <% } %>
     <% if( undefined !== n.ipv4 ) { %>
       <% if( undefined !== n.ipv4.vlanIds ) { %>
@@ -183,7 +179,6 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
       esxcli network ip interface remove -i <%=vmkname%>
       esxcli network ip interface add -i <%=vmkname%> -p $currdev
       esxcli network ip interface ipv4 set -i <%=vmkname%> -t dhcp
-      postLookup <%=vmkname%>
     <% } %>
   <% }); %>
 <% } %>
@@ -214,26 +209,12 @@ cp /var/log/esxi_install.log "/vmfs/volumes/datastore1/firstboot-esxi_install.lo
 #
 # NOTE: this script will execute right away as a result of writing it to local.sh
 # along with executing on every subsequent boot
-# rackhdCallbackScript is no longer in context once "Task.Os.Install.ESXi" is marked as completed
-
-mv /vmfs/volumes/datastore1/<%=rackhdCallbackScript%> /etc/rc.local.d/local.sh
-
-#backup ESXi configuration to persist it
-/sbin/auto-backup.sh
-
-#reboot the system after host configuration
-esxcli system shutdown reboot -d 10 -r "Rebooting after first boot host configuration"
-
-%post --interpreter=busybox
-#disable firewall
-localcli network firewall set --enabled no
-#signify ORA the installation completed
 #
 # Try to download call back script 60 times 1 second
 # sleep in between to allow link to be up after DHCP
 for retry in $(seq 1 60);
 do
-    wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /vmfs/volumes/datastore1/<%=rackhdCallbackScript%>
+    wget http://<%=server%>:<%=port%>/api/current/templates/<%=rackhdCallbackScript%>?nodeId=<%=nodeId%> -O /etc/rc.local.d/local.sh
     if [ $? -eq 0 ]; then
         logger -p user.info "RackHD's call back script was downloaded successfully after $retry attempt(s)."
         break
@@ -246,5 +227,19 @@ done;
 if [ $retry -eq 60 ]; then
    logger -p user.err "RackHD's call back script was not downloaded successfully."
 fi
-chmod +x /vmfs/volumes/datastore1/<%=rackhdCallbackScript%>
-/vmfs/volumes/datastore1/<%=rackhdCallbackScript%>
+
+#backup ESXi configuration to persist it
+/sbin/auto-backup.sh
+
+#reboot the system after host configuration
+esxcli system shutdown reboot -d 10 -r "Rebooting after first boot host configuration"
+
+%post --interpreter=busybox
+#disable firewall
+localcli network firewall set --enabled no
+#signify ORA the installation completed
+BODY="{"
+BODY=$BODY"\"nodeId\": \"<%=nodeId%>\""
+BODY=$BODY"}"
+BODYLEN=$(echo -n ${BODY} | wc -c)
+echo -ne "POST /api/current/notification HTTP/1.0\r\nHost: <%=server%>\r\nContent-Type: application/json\r\nContent-Length: ${BODYLEN}\r\n\r\n${BODY}" | nc -i 3 <%=server%> <%=port%>


### PR DESCRIPTION
Reverts RackHD/on-http#497

Some problems for this PR, and it caused regression test failure http://rackhdci.lss.emc.com/job/Continuous-Test/job/OS-Install-Jobs/job/ESXi-6.0/321/, I confirmed with @lanchongyizu about these problems

1. call /notifications URL is essential, cannot be removed.
2. postlookup() is out of date, currently, we don't need this function, don't need to add it back to previous status
3. rackhdCallbackScript will be rendered once esx-ks is downloaded.

@nucklehead Because this PR will cause OS installation regression test failure, I'll revert this PR, when you have more time, you could address these problems above and submit another PR, If you don't have more time, we could help pick useful things in this PR and submit another PR.

@RackHD/corecommitters because this PR have several problems, I prefer to revert rather than submit fixes to let regression test pass.