### PR TITLE
Add Deprecation Warning Header to 1.1 northbound/southbound router

### DIFF
--- a/lib/api/1.1/northbound/router.js
+++ b/lib/api/1.1/northbound/router.js
@@ -20,6 +20,10 @@ function northApiFactory (injector) {
 
         // Un-mount existing routes when mounting.
         this.unMountAllRouters();
+        router.all("*", function (req, res, next) {
+        res.setHeader('X-Warning', 'Deprecated API');
+        return next();
+        });
 
         router.use(injector.get(require('./catalogs')));
         router.use(injector.get(require('./config')));

--- a/lib/api/1.1/southbound/router.js
+++ b/lib/api/1.1/southbound/router.js
@@ -21,6 +21,10 @@ function internalApiFactory (injector) {
         // Un-mount existing routes when mounting.
         this.unMountAllRouters();
 
+        router.all("*", function (req, res, next) {
+        res.setHeader('X-Warning', 'Deprecated API');
+        return next();
+        });
         router.use(injector.get(require('./profiles')));
         router.use(injector.get(require('./files')));
         router.use(injector.get(require('./tasks')));


### PR DESCRIPTION
Add a Deprecation warning header to north/south-bound 1.1 API.
@RackHD/corecommitters @RackHD/veyron 