### PR TITLE
Fix redfish/manager/id to return data, when no nodes are discovered

### DIFF
--- a/lib/api/redfish-1.0/managers.js
+++ b/lib/api/redfish-1.0/managers.js
@@ -70,7 +70,7 @@ var getManager = controller(function(req, res) {
     })
     .then(function(nodes) {
         if(_.isEmpty(nodes)) {
-            throw new Errors.NotFoundError('invalid resource');
+            return [];
         }
         return Promise.map(nodes, function(node) {
             return waterline.nodes.getNodeById(node.id);


### PR DESCRIPTION
Fix for RAC-72. Now return data, even when no nodes are discovered instead of throwing an error.

@RackHD/corecommitters @RackHD/veyron 