### PR TITLE
add progress milestones for ESXi/Ubuntu/SUSE/CoreOS/PhotonOS

### DIFF
--- a/data/profiles/install-coreos.ipxe
+++ b/data/profiles/install-coreos.ipxe
@@ -14,8 +14,8 @@ set base-url <%=repo%>
 kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=<%=installScriptUri%>
 initrd ${base-url}/<%=version%>/coreos_production_pxe_image.cpio.gz
 
-<% if( typeof progressMilestones !== 'undefined' && progressMilestones.bootInstallerUri ) { %>
-    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.bootInstallerUri%> ||
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.startInstallerUri%> ||
     imgfree fakedimage ||
 <% } %>
 

--- a/data/profiles/install-coreos.ipxe
+++ b/data/profiles/install-coreos.ipxe
@@ -1,4 +1,10 @@
 echo Starting CoreOS Stable installer
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.enterProfileUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.enterProfileUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 set base-url <%=repo%>
 # coreos.autologin <-- enable as kernel param to autologin for easier debugging
 # reference: https://coreos.com/os/docs/latest/booting-with-ipxe.html
@@ -7,4 +13,10 @@ set base-url <%=repo%>
 #
 kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin cloud-config-url=<%=installScriptUri%>
 initrd ${base-url}/<%=version%>/coreos_production_pxe_image.cpio.gz
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.bootInstallerUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.bootInstallerUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -11,13 +11,13 @@ iseq ${platform} efi && goto is_efi || goto not_efi
 
 :not_efi
 kernel <%=repo%>/<%=mbootFile%> -c <%=esxBootConfigTemplateUri%> BOOTIF=01-${netX/mac}
-goto boot
+goto boot_img
 
 :is_efi
 kernel <%=repo%>/efi/boot/bootx64.efi -c <%=esxBootConfigTemplateUri%>
-goto boot
+goto boot_img
 
-:boot
+:boot_img
 <% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
     imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.startInstallerUri%> ||
     imgfree fakedimage ||

--- a/data/profiles/install-esx.ipxe
+++ b/data/profiles/install-esx.ipxe
@@ -1,10 +1,26 @@
+# The progress notification is just something nice-to-have, so progress notification failure should
+# never impact the normal installation process
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.enterProfileUri ) { %>
+    # since there is no curl like http client in ipxe, so use imgfetch instead
+    # note: the progress milestones uri must be wrapped in unescaped format, otherwise imgfetch will fail
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.enterProfileUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 iseq ${platform} efi && goto is_efi || goto not_efi
 
 :not_efi
 kernel <%=repo%>/<%=mbootFile%> -c <%=esxBootConfigTemplateUri%> BOOTIF=01-${netX/mac}
-boot
+goto boot
 
 :is_efi
 kernel <%=repo%>/efi/boot/bootx64.efi -c <%=esxBootConfigTemplateUri%>
-boot
+goto boot
 
+:boot
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.startInstallerUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
+boot

--- a/data/profiles/install-photon-os.ipxe
+++ b/data/profiles/install-photon-os.ipxe
@@ -1,7 +1,19 @@
 echo Starting Photon OS <%=version%> installer for ${hostidentifier}
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.enterProfileUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.enterProfileUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 set base-url <%=repo%>/isolinux
 set params initrd=initrd.img ks=<%=installScriptUri%> hostname=<%=hostname%> ksdevice=bootif BOOTIF=01-${netX/mac} console=<%=comport%>,115200n8 console=tty0
 kernel ${base-url}/vmlinuz repo=<%=repo%>/RPMS/ ${params}
 initrd ${base-url}/initrd.img
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.startInstallerUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell
 

--- a/data/profiles/install-suse.ipxe
+++ b/data/profiles/install-suse.ipxe
@@ -1,8 +1,24 @@
 echo Starting SUSE <%=version%> installer >
+
+# The progress notification is just something nice-to-have, so progress notification failure should
+# never impact the normal installation process
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.enterProfileUri ) { %>
+    # since there is no curl like http client in ipxe, so use imgfetch instead
+    # note: the progress milestones uri must be wrapped in unescaped format, otherwise imgfetch will fail
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.enterProfileUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 set base-url <%=repo%>
 set params linux install=${base-url} autoyast=<%=installScriptUri%> <%=kargs%>
 kernel ${base-url}/boot/x86_64/loader/linux
 initrd ${base-url}/boot/x86_64/loader/initrd
 imgargs linux ${params}
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.startInstallerUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell
 

--- a/data/profiles/install-ubuntu.ipxe
+++ b/data/profiles/install-ubuntu.ipxe
@@ -1,6 +1,18 @@
 echo Starting Ubuntu x64 installer for ${hostidentifier}
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.enterProfileUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.enterProfileUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 set base-url <%=repo%>/<%=baseUrl%>
 kernel ${base-url}/linux
 initrd ${base-url}/initrd.gz
 imgargs linux auto=true url=<%=installScriptUri%> hostname=<%=hostname%> log_host=<%=server%> BOOTIF=01-<%=macaddress%> interface=<%=interface%> console=<%=comport%>,115200n8 console=tty0 <%=kargs%>
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.startInstallerUri ) { %>
+    imgfetch --name fakedimage http://<%=server%>:<%=port%><%-progressMilestones.startInstallerUri%> ||
+    imgfree fakedimage ||
+<% } %>
+
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -33,6 +33,10 @@ reboot
 
 %firstboot --interpreter=busybox
 
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.firstBootUri ) { %>
+    wget "http://<%=server%>:<%=port%><%-progressMilestones.firstBootUri%>" || true
+<% } %>
+
 # enable VHV (Virtual Hardware Virtualization to run nested 64bit Guests + Hyper-V VM)
 grep -i "vhv.enable" /etc/vmware/config || echo "vhv.enable = \"TRUE\"" >> /etc/vmware/config
 
@@ -234,7 +238,23 @@ fi
 #reboot the system after host configuration
 esxcli system shutdown reboot -d 10 -r "Rebooting after first boot host configuration"
 
+%pre --interpreter=busybox
+
+#notify the current progress
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.preConfigUri ) { %>
+    # the url may contain query, the symbol '&' will mess the command line logic, so the whole url need be wrapped in quotation marks
+    wget "http://<%=server%>:<%=port%><%-progressMilestones.preConfigUri%>" || true
+<% } %>
+
+
 %post --interpreter=busybox
+
+#notify the current progress
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.postConfigUri ) { %>
+    # the url may contain query, the symbol '&' will mess the command line logic, so the whole url need be wrapped in quotation marks
+    wget "http://<%=server%>:<%=port%><%-progressMilestones.postConfigUri%>" || true
+<% } %>
+
 #disable firewall
 localcli network firewall set --enabled no
 #signify ORA the installation completed

--- a/data/templates/install-coreos.sh
+++ b/data/templates/install-coreos.sh
@@ -2,8 +2,8 @@
 set -e
 CLOUD_CONFIG_FILE=pxe-cloud-config.yml
 
-<% if( typeof progressMilestones !== 'undefined' && progressMilestones.executeInstallationUri ) { %>
-    curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%><%-progressMilestones.executeInstallationUri%>' || true
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.installToDiskUri ) { %>
+curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%><%-progressMilestones.installToDiskUri%>' || true
 <% } %>
 
 curl -o $CLOUD_CONFIG_FILE http://<%=server%>:<%=port%>/api/current/templates/$CLOUD_CONFIG_FILE?nodeId=<%=nodeId%>

--- a/data/templates/install-coreos.sh
+++ b/data/templates/install-coreos.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 CLOUD_CONFIG_FILE=pxe-cloud-config.yml
+
+<% if( typeof progressMilestones !== 'undefined' && progressMilestones.executeInstallationUri ) { %>
+    curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%><%-progressMilestones.executeInstallationUri%>' || true
+<% } %>
+
 curl -o $CLOUD_CONFIG_FILE http://<%=server%>:<%=port%>/api/current/templates/$CLOUD_CONFIG_FILE?nodeId=<%=nodeId%>
 sudo coreos-install -d <%=installDisk%> -c $CLOUD_CONFIG_FILE -b <%=repo%>
 

--- a/data/templates/install-photon/photon-os-ks
+++ b/data/templates/install-photon/photon-os-ks
@@ -49,6 +49,11 @@
     "postinstall": [
                     "#!/bin/sh",
 
+                    "# notify the current progress",
+                    <%_ if( typeof progressMilestones !== 'undefined' && progressMilestones.postConfigUri ) { _%>
+                        "curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%><%-progressMilestones.postConfigUri%>' || true",
+                    <%_ } _%>
+
                     "# Set the configuration",
                     "/bin/curl http://<%=server%>:<%=port%>/api/current/templates/post-install-photon.sh?nodeId=<%=nodeId%> > /tmp/post-install-photon.sh",
                     "chmod +x /tmp/post-install-photon.sh",

--- a/data/templates/install-ubuntu/ubuntu-preseed
+++ b/data/templates/install-ubuntu/ubuntu-preseed
@@ -37,9 +37,9 @@ d-i mirror/http/directory string <%=repoDirectory%>
 
 d-i preseed/early_command string \
 <%_ if( typeof progressMilestones !== 'undefined' && progressMilestones.preConfigUri ) { _%>
-    wget 'http://<%=server%>:<%=port%><%-progressMilestones.preConfigUri%>' || true; \
+wget 'http://<%=server%>:<%=port%><%-progressMilestones.preConfigUri%>' || true; \
 <%_ } _%>
-    umount /media || true;
+umount /media || true;
 
 d-i apt-setup/restricted boolean false
 d-i mirror/http/proxy string

--- a/data/templates/install-ubuntu/ubuntu-preseed
+++ b/data/templates/install-ubuntu/ubuntu-preseed
@@ -34,7 +34,13 @@ d-i mirror/http/hostname string <%=repoHostname%>
 # Get directory from repo
 <% var repoDirectory = repo.replace(/^(https?:\/\/)?([a-zA-Z0-9\.:-]+)/g,"") -%>
 d-i mirror/http/directory string <%=repoDirectory%>
-d-i preseed/early_command string umount /media || true
+
+d-i preseed/early_command string \
+<%_ if( typeof progressMilestones !== 'undefined' && progressMilestones.preConfigUri ) { _%>
+    wget 'http://<%=server%>:<%=port%><%-progressMilestones.preConfigUri%>' || true; \
+<%_ } _%>
+    umount /media || true;
+
 d-i apt-setup/restricted boolean false
 d-i mirror/http/proxy string
 d-i apt-setup/universe boolean false
@@ -57,6 +63,11 @@ d-i time/zone string US/Pacific
 d-i clock-setup/ntp boolean true
 
 ### Partitioning
+d-i partman/early_command string \
+<%_ if( typeof progressMilestones !== 'undefined' && progressMilestones.startPartitionUri ) { _%>
+wget 'http://<%=server%>:<%=port%><%-progressMilestones.startPartitionUri%>' || true;
+<%_ } _%>
+
 d-i partman-auto/disk string <%=installDisk%>
 d-i partman-auto/method string lvm
 
@@ -166,7 +177,7 @@ d-i finish-install/reboot_in_progress note
 xserver-xorg xserver-xorg/autodetect_monitor boolean true
 #### Advanced options
 ### Running custom commands during the installation
-# d-i pretemplateing is inherently not secure. Nothing in the installer checks
+# d-i preseeding is inherently not secure. Nothing in the installer checks
 # for attempts at buffer overflows or other exploits of the values of a
 # preconfiguration file like this one. Only use preconfiguration files from
 # trusted locations! To drive that home, and because it's generally useful,
@@ -174,20 +185,24 @@ xserver-xorg xserver-xorg/autodetect_monitor boolean true
 # automatically.
 
 # This first command is run as early as possible, just after
-# pretemplateing is read.
-#d-i pretemplate/early_command string anna-install some-udeb
+# preseed is read.
+#d-i preseed/early_command string anna-install some-udeb
 # This command is run immediately before the partitioner starts. It may be
-# useful to apply dynamic partitioner pretemplateing that depends on the state
-# of the disks (which may not be visible when pretemplate/early_command runs).
+# useful to apply dynamic partitioner preseeding that depends on the state
+# of the disks (which may not be visible when preseed/early_command runs).
 #d-i partman/early_command
 #       string debconf-set partman-auto/disk "$(list-devices disk | head -n1)"
 # This command is run just before the install finishes, but when there is
 # still a usable /target directory. You can chroot to /target and use it
 # directly, or use the apt-install and in-target commands to easily install
 # packages and run commands in the target system.
-#d-i pretemplate/late_command string apt-install zsh; in-target chsh -s /bin/zsh
+#d-i preseed/late_command string apt-install zsh; in-target chsh -s /bin/zsh
 
 d-i preseed/late_command string \
+<%_ if( typeof progressMilestones !== 'undefined' && progressMilestones.postConfigUri ) { _%>
+in-target curl -X POST -H 'Content-Type:application/json' 'http://<%=server%>:<%=port%><%-progressMilestones.postConfigUri%>' || true; \
+<%_ } _%>
+
 #enable root ssh
 in-target sed -i 's/PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config; \
 

--- a/data/templates/suse-autoinst.xml
+++ b/data/templates/suse-autoinst.xml
@@ -151,6 +151,34 @@
   </services-manager>
 
   <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <interpreter>shell</interpreter>
+        <source> <![CDATA[
+          #!/bin/sh
+
+          <% if( typeof progressMilestones !== 'undefined' && progressMilestones.preConfigUri ) { %>
+            curl -X POST -H 'Content-Type:application/json' "http://<%=server%>:<%=port%><%-progressMilestones.preConfigUri%>" || true
+          <% } %>
+          ]]>
+        </source>
+      </script>
+    </pre-scripts>
+
+    <postpartitioning-scripts config:type="list">
+      <script>
+        <interpreter>shell</interpreter>
+        <source> <![CDATA[
+          #!/bin/sh
+
+          <% if( typeof progressMilestones !== 'undefined' && progressMilestones.postPartitioningUri ) { %>
+            curl -X POST -H 'Content-Type:application/json' "http://<%=server%>:<%=port%><%-progressMilestones.postPartitioningUri%>" || true
+          <% } %>
+          ]]>
+        </source>
+      </script>
+    </postpartitioning-scripts>
+
     <chroot-scripts config:type="list">
       <script>
         <chrooted config:type="boolean">true</chrooted>
@@ -158,6 +186,11 @@
         <!-- scripts for workflow completion -->
         <source> <![CDATA[
           #!/bin/sh
+
+          <% if( typeof progressMilestones !== 'undefined' && progressMilestones.chrootUri ) { %>
+            curl -X POST -H 'Content-Type:application/json' "http://<%=server%>:<%=port%><%-progressMilestones.chrootUri%>" || true
+          <% } %>
+
           curl -X POST -H 'Content-Type:application/json' http://<%=server%>:<%=port%>/api/current/notification?nodeId=<%=nodeId%>
           ]]>
         </source>
@@ -172,7 +205,6 @@
           #!/bin/sh
 
           # Make .ssh directory for root and users
-
           # Set root ssh key
           <% if (typeof rootSshKey !== 'undefined') { %>
                 mkdir /root/.ssh
@@ -196,6 +228,7 @@
         </source>
       </script>
     </post-scripts>
+
   </scripts>
 
 </profile>

--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -93,23 +93,13 @@ function NotificationApiServiceFactory(
         return waterline.taskdependencies.findOne({taskId: taskId})
         .then(function(task) {
             if (_.isEmpty(task) || !_.has(task, 'graphId')) {
-                logger.error('notification API fails', {
-                    taskId: taskId,
-                    progress: taskProgress,
-                    error: "Can't find active task for given taskId"
-                });
-                return;
+                throw new Errors.BadRequestError('Cannot find the active task for taskId ' + taskId); //jshint ignore: line
             }
 
             return waterline.graphobjects.findOne({instanceId: task.graphId})
             .then(function(graph) {
                 if (_.isEmpty(graph)) {
-                    logger.error('notification api fails', {
-                        taskid: taskId,
-                        progress: taskProgress,
-                        error: "can't find graphObject for given taskid"
-                    });
-                    return;
+                    throw new Errors.BadRequestError('Cannot find the graphObject for graphId ' + task.graphId); //jshint ignore: line
                 }
                 var progress = GraphProgress.create(graph, taskProgress.description);
                 progress.updateTaskProgress(taskId, taskProgress, false);

--- a/spec/lib/services/notification-api-service-spec.js
+++ b/spec/lib/services/notification-api-service-spec.js
@@ -191,13 +191,12 @@ describe('Http.Api.Notification', function () {
             this.sandbox.stub(waterline.taskdependencies, 'findOne').resolves([]);
             this.sandbox.spy(waterline.graphobjects, 'findOne');
             this.sandbox.spy(eventsProtocol, 'publishProgressEvent');
-            return notificationApiService.postProgressNotification(progressData.taskId,
-                                                                   progressData.progress)
-            .then(function () {
-                expect(waterline.taskdependencies.findOne).to.be.calledOnce;
-                expect(waterline.graphobjects.findOne).to.have.not.been.called;
-                expect(eventsProtocol.publishProgressEvent).to.have.not.been.called;
-            });
+            return expect(
+                notificationApiService.postProgressNotification(
+                    progressData.taskId,
+                    progressData.progress
+                )
+            ).to.be.rejected;
         });
 
         it('should not update graph progress if can not fnd graph object', function () {
@@ -208,12 +207,9 @@ describe('Http.Api.Notification', function () {
             this.sandbox.stub(waterline.taskdependencies, 'findOne').resolves(task);
             this.sandbox.stub(waterline.graphobjects, 'findOne').resolves({});
             this.sandbox.spy(eventsProtocol, 'publishProgressEvent');
-            return notificationApiService.postProgressNotification(progressData.taskId, {})
-            .then(function () {
-                expect(waterline.taskdependencies.findOne).to.be.calledOnce;
-                expect(waterline.graphobjects.findOne).to.have.been.called;
-                expect(eventsProtocol.publishProgressEvent).to.have.not.been.called;
-            });
+            return expect(
+                notificationApiService.postProgressNotification(progressData.taskId, {})
+            ).to.be.rejected;
         });
 
     });


### PR DESCRIPTION
Inject progress milestones for ESXi/Ubuntu/SUSE/CoreOS/PhotonOS.

Different OS exports different injectable point where we can send a http request to notify the current installation stage, so the milestone definition varies on different OS.

I have done at least 3 times testing for each OS for make sure the OS installation has not been broken and the output progress data is correct.

Story links:
- https://rackhd.atlassian.net/browse/RAC-3920
- https://rackhd.atlassian.net/browse/RAC-3919

Thanks @lanchongyizu to help implement the progress for Windows OS ( see PRs https://github.com/RackHD/on-http/pull/593 and https://github.com/RackHD/on-tasks/pull/409 )

jenkins: depends on https://github.com/RackHD/on-tasks/pull/410

@pengz1 @lanchongyizu @anhou @iceiilin 

