### PR TITLE
Fix bug  introduced by hook-schema that breaks swagger-ui

### DIFF
--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -80,7 +80,15 @@ definitions:
     description: Hook post schema 
     type: object
     properties:
-      $ref: "#/definitions/hooks.2.0_HookBase/properties"
+      url:
+        type: string
+        format: uri
+      name:
+        type: string
+      filters:
+        type: array
+        items:
+          type: object
     required:
       - url
   ipmi-obm-service_Obm:


### PR DESCRIPTION
The $ref under HooksPost was causing the swagger-ui crash.

@RackHD/corecommitters @RackHD/veyron 