### PR TITLE
Validate url for webhook

### DIFF
--- a/lib/services/hooks-api-service.js
+++ b/lib/services/hooks-api-service.js
@@ -11,14 +11,18 @@ di.annotate(hookApiServiceFactory,
         'Services.Waterline',
         'Logger',
         '_',
-        'Errors'
+        'Errors',
+        'Assert',
+        'Promise'
     )
 );
 function hookApiServiceFactory(
     waterline,
     Logger,
     _,
-    Errors
+    Errors,
+    assert,
+    Promise
 ) {
     var logger = Logger.initialize(hookApiServiceFactory);
     function HooksApiService() {
@@ -45,7 +49,12 @@ function hookApiServiceFactory(
      * @return
      */
     HooksApiService.prototype.createHook = function(body) {
-        return waterline.hooks.findOne({url: body.url})
+        return Promise.try(function(){
+            assert.isURL(body.url, {protocols: ['http', 'https']});
+        })
+        .then(function(){
+            return waterline.hooks.findOne({url: body.url});
+        })
         .then(function(entry){
             if(_.isEmpty(entry)) {
                 return waterline.hooks.create(body);

--- a/spec/lib/services/hooks-api-service-spec.js
+++ b/spec/lib/services/hooks-api-service-spec.js
@@ -6,8 +6,8 @@ describe('Http.Services.Api.Hooks', function () {
     var Errors;
     var hooksApiService;
     var waterline;
-    var body = {url: 'test', filters: [{nodeId: 'nodeId'}]};
-    var hook = {url: 'test', id: 'hookId'};
+    var body = {url: '0.0.0.0', filters: [{nodeId: 'nodeId'}]};
+    var hook = {url: '0.0.0.0', id: 'hookId'};
     var _;
     
     before('Http.Services.Api.Hooks before', function() {
@@ -64,6 +64,17 @@ describe('Http.Services.Api.Hooks', function () {
             expect(waterline.hooks.create).to.be.calledOnce;
             expect(waterline.hooks.create).to.be.calledWith(body);
             expect(result).to.be.deep.equal(hook);
+        });
+    });
+
+    it('should throw error if hook url string is not a url', function (done) {
+        return hooksApiService.createHook({url: 'abcd'})
+        .then(function() {
+            done(new Error('Test should fail'));
+        })
+        .catch(function(err){
+            expect(err.name).equals('AssertionError');
+            done();
         });
     });
 


### PR DESCRIPTION
Schema URL validation doesn't work, add url validation code in hook-api