### PR TITLE
modify photon ks file to put swap partition as the last item

### DIFF
--- a/data/templates/install-photon/photon-os-ks
+++ b/data/templates/install-photon/photon-os-ks
@@ -29,14 +29,19 @@
                         <%_ numSize = 0; _%>
                     <%_ } _%>
                     <%_ if (par.fsType === "swap") { _%>
-                        <%_ if (i === length ) { _%>
-        {"size": <%=numSize%>, "filesystem": "<%=par.fsType%>"}
-                        <%_ } else { _%>
-        {"size": <%=numSize%>, "filesystem": "<%=par.fsType%>"},
+                        <%# Through experiments, swap partition should always be the last one in %>
+                        <%# "partition" field of ks file, otherwise GUI will display inproperly %>
+                        <%_ swapPar = par; _%>
+                        <%_ swapParSize = numSize; _%>
+                        <%_ if (i === length) { _%>
+                            {"size": <%=swapParSize%>, "filesystem": "<%=swapPar.fsType%>"}
                         <%_ } _%>
                     <%_ } else { _%>
-                        <%_ if (i === length ) { _%>
+                        <%_ if (i === length && typeof swapPar === 'undefined') { _%>
         {"mountpoint": "<%=par.mountPoint%>", "size": <%=numSize%>, "filesystem": "<%=par.fsType%>"}
+                        <%_ } else if (i === length && typeof swapPar !== 'undefined') { _%>
+        {"mountpoint": "<%=par.mountPoint%>", "size": <%=numSize%>, "filesystem": "<%=par.fsType%>"},
+        {"size": <%=swapParSize%>, "filesystem": "<%=swapPar.fsType%>"}
                         <%_ } else { _%>
         {"mountpoint": "<%=par.mountPoint%>", "size": <%=numSize%>, "filesystem": "<%=par.fsType%>"},
                         <%_ } _%>


### PR DESCRIPTION
fix https://rackhd.atlassian.net/browse/RAC-4324, which complains inproper UI display after installing Photon OS using full payload in https://github.com/RackHD/RackHD/blob/master/example/samples/install_photon_os_payload_full.json

From KS file sample provided by Photon, the swap partition is the last item in the "partition" field. This PR modify the rendering rule in ks template to align with it and pass the test.