### PR TITLE
RAC-4558: patch users{name} does not accept password changes

### DIFF
--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -63,6 +63,12 @@ definitions:
         type: string
       username:
         type: string
+  patch_user_obj:
+    properties:
+      role:
+        type: string
+      password:
+        type: string
   hooks.2.0_HookBase:
     description: Hook base schema
     type: object
@@ -4117,7 +4123,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/get_user_obj'
+          $ref: '#/definitions/patch_user_obj'
       responses:
         200:
           description: Successfully modified the specified user.


### PR DESCRIPTION
the swagger-ui shows { "role": "string", "username": "string"} instead of { "role": "string", "password": "string"} for input. the username is already a required field.

underneath, the get_user_obj does not provide a password for modifyUser() in lib/api/2.0/user.js. 

fix: created a patch_user_obj with role and password data.