### PR TITLE
Revert "Rac 1984 node/id/workflow returns appropriate response codes"

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -7,6 +7,7 @@ var controller = injector.get('Http.Services.Swagger').controller;
 var addLinks = injector.get('Http.Services.Swagger').addLinksHeader;
 var nodes = injector.get('Http.Services.Api.Nodes');
 var waterline = injector.get('Services.Waterline');
+var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var _ = injector.get('_'); // jshint ignore:line
 var constants = injector.get('Constants');
 var Errors = injector.get('Errors');
@@ -17,7 +18,7 @@ var nodesGetAll = controller(function(req, res) {
         limit: req.swagger.query.$top
     };
     return nodes.getAllNodes(req.query, options)
-    .tap(function() {
+    .tap(function(nodes) {
         return addLinks(req, res, 'nodes', req.query);
     });
 });
@@ -77,10 +78,9 @@ var nodesGetWorkflowById = controller(function(req) {
         newQuery = req.query;
     }
 
-    return waterline.nodes.needByIdentifier(req.swagger.params.identifier.value)
-    .then(function() {
-        return nodes.getNodeWorkflowById(req.swagger.params.identifier.value, newQuery);
-    });
+    return workflowApiService.getWorkflowsByNodeId(req.swagger.params.identifier.value,
+                                                   newQuery);
+
 });
 
 var nodesPostWorkflowById = controller({success: 201}, function(req) {

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -273,6 +273,12 @@ function workflowApiServiceFactory(
         });
     };
 
+    WorkflowApiService.prototype.getWorkflowsByNodeId = function(id, query) {
+        var nodeId = ({node: id});
+        var mergedQuery = _.merge({}, nodeId, query);
+        return waterline.graphobjects.find(mergedQuery);
+    };
+
     WorkflowApiService.prototype.getAllWorkflows = function(query, options) {
         options = options || {};
 

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -622,7 +622,6 @@ describe('2.0 Http.Api.Nodes', function () {
                     }]
             };
 
-            waterline.nodes.needByIdentifier.resolves(node);
             waterline.graphobjects.find.resolves(node.workflows);
 
             return helper.request().get('/api/2.0/nodes/123/workflows')


### PR DESCRIPTION
Reverts RackHD/on-http#551 
CI Test failure http://rackhdci.lss.emc.com/job/ContinuousFunctionTest/192/

@lacarb you could resubmit another PR and also include related test cases fix. 

@RackHD/corecommitters 