### PR TITLE
Rac 1984 redo - node/id/workflow fix after revert

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -7,7 +7,6 @@ var controller = injector.get('Http.Services.Swagger').controller;
 var addLinks = injector.get('Http.Services.Swagger').addLinksHeader;
 var nodes = injector.get('Http.Services.Api.Nodes');
 var waterline = injector.get('Services.Waterline');
-var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var _ = injector.get('_'); // jshint ignore:line
 var constants = injector.get('Constants');
 var Errors = injector.get('Errors');
@@ -18,7 +17,7 @@ var nodesGetAll = controller(function(req, res) {
         limit: req.swagger.query.$top
     };
     return nodes.getAllNodes(req.query, options)
-    .tap(function(nodes) {
+    .tap(function() {
         return addLinks(req, res, 'nodes', req.query);
     });
 });
@@ -78,9 +77,7 @@ var nodesGetWorkflowById = controller(function(req) {
         newQuery = req.query;
     }
 
-    return workflowApiService.getWorkflowsByNodeId(req.swagger.params.identifier.value,
-                                                   newQuery);
-
+    return nodes.getNodeWorkflowById(req.swagger.params.identifier.value);
 });
 
 var nodesPostWorkflowById = controller({success: 201}, function(req) {

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -635,6 +635,7 @@ describe('2.0 Http.Api.Nodes', function () {
             });
             mockGrpc.setResponse(JSON.stringify(node.workflows));
 
+            waterline.nodes.needByIdentifier.resolves(node);
             waterline.graphobjects.find.resolves(node.workflows);
 
             return helper.request().get('/api/2.0/nodes/123/workflows')
@@ -652,6 +653,7 @@ describe('2.0 Http.Api.Nodes', function () {
             };
             mockGrpc.setResponse(JSON.stringify(node.workflows));
 
+            waterline.nodes.needByIdentifier.resolves(node);
             waterline.graphobjects.find.resolves(node.workflows);
 
             return helper.request().get('/api/2.0/nodes/123/workflows')


### PR DESCRIPTION
Follow up to this PR which used to be green but broke the pipeline when it was merged a few days later - https://github.com/RackHD/on-http/pull/551

Investigating what went wrong.