### PR TITLE
Allow backdoor process, to create Administrator user

### DIFF
--- a/lib/api/2.0/users.js
+++ b/lib/api/2.0/users.js
@@ -23,9 +23,10 @@ var addUser = controller({success: 201}, function(req, res) {
         return accountService.listUsers();
     })
     .then(function(users) {
-        if(!users.length && localUserException && res.locals.ipAddress === '127.0.0.1') {
+        if((!users.length && localUserException && res.locals.ipAddress === '127.0.0.1') || _.isEmpty(_.filter(users, {role: 'Administrator'}))) {
             // Only when there are no users, and the remote is a local connection, and we 
             // permit it, then let them add the first user.
+            // Added backdoor process to add an Administrator, in case there are none.
             return accountService.createUser(userObj)
             .then(function(user) {
                 return _.pick(user, ['username', 'role']);


### PR DESCRIPTION
Extend the Localhost Exception, to allow backdoor access to create an Administrator account, when there are no "Adminstrator" in the collection.
@RackHD/corecommitters