### PR TITLE
Refine get profile log

### DIFF
--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -313,13 +313,13 @@ function profileApiServiceFactory(
                     };
                 })
                 .catch(function (e) {
-                    logger.warning("Unable to retrieve workflow properties", {
+                    logger.warning("Unable to retrieve workflow properties or profiles", {
                         error: e,
                         id: node.id,
-                        taskgraphInstance: taskgraphInstance
+                        taskgraphInstanceId: taskgraphInstance.instanceId
                     });
                     return self._handleProfileRenderError(
-                        'Unable to retrieve workflow properties', node.type, 503);
+                        'Unable to retrieve workflow properties or profiles', node.type, 503);
                 });
             } else {
                 if (_.has(node, 'bootSettings')) {

--- a/spec/lib/api/2.0/profiles-spec.js
+++ b/spec/lib/api/2.0/profiles-spec.js
@@ -254,7 +254,8 @@ describe('Http.Api.Profiles', function () {
                 .query({ macs: '00:00:de:ad:be:ef', ips: '172.31.128.5' })
                 .expect(503)
                 .then(function(resp) {
-                    expect(resp.body.message).to.equal('Error: Unable to retrieve workflow properties');
+                    expect(resp.body.message).to.equal(
+                        'Error: Unable to retrieve workflow properties or profiles');
                 });
         });
 
@@ -334,7 +335,8 @@ describe('Http.Api.Profiles', function () {
             return helper.request().get('/api/2.0/profiles/switch/testswitchvendor')
                 .expect(503)
                 .then(function(resp) {
-                    expect(resp.body.message).to.equal('Error: Unable to retrieve workflow properties');
+                    expect(resp.body.message).to.equal(
+                        'Error: Unable to retrieve workflow properties or profiles');
                 });
         });
 

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -347,7 +347,8 @@ describe("Http.Services.Api.Profiles", function () {
 
             var promise = profileApiService.getProfileFromTaskOrNode(node);
 
-            return expect(promise).to.be.rejectedWith('Unable to retrieve workflow properties')
+            return expect(promise).to.be.rejectedWith(
+                'Unable to retrieve workflow properties or profiles')
             .then(function() {
                 expect(workflowApiService.findActiveGraphForTarget).to.have.been.calledOnce;
                 expect(taskProtocol.requestProfile).to.have.been.calledOnce;


### PR DESCRIPTION
there's many long and duplicated taskgraphInstance log when analysis  masterci log. only show graph instanceId that it could match with previous full graph log http://rackhdci.lss.emc.com/job/MasterCI/67/artifact/Install-ESXI-6.0/vagrant.log   

@RackHD/corecommitters @iceiilin @yyscamper @changev 