### PR TITLE
creating script to make client libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Note: requires MongoDB and RabbitMQ to be running to start correctly.
  * http://rackhd.readthedocs.io/en/latest/rackhd/index.html
  * https://bintray.com/rackhd/docs/apidoc#files
 
-The readthedocs shows API usage for 1.1 by default. Unless otherwise specified
-you can use `/api/2.0/` in place of `/api/1.1/` to leverage the 2.0 API. Any functional
-differences will be listed below the 1.1 API examples.
+The readthedocs shows API usage for 2.0 by default. Using `api/current/` will
+use the 2.0 API by default. Functional differences between the 1.1 API and the 2.0
+API are listed in readthedocs, however, the 1.1 API is officially deprecated.
 
 ## Config
 
@@ -65,6 +65,11 @@ To run tests and get coverage for CI:
     ./node_modules/.bin/istanbul report cobertura
     # if you want HTML reports locally
     ./node_modules/.bin/istanbul report html
+
+## Client Libraries
+
+Instructions for how to generate client libraries (python, java, go) can be seen on the readthedocs
+* http://rackhd.readthedocs.io/en/latest/rackhd/rackhd_api.html?highlight=swagger#rackhd-client-libraries
 
 ## Building
 

--- a/extra/make-client.sh
+++ b/extra/make-client.sh
@@ -10,7 +10,7 @@
 
 #changing directory to on-http
 SCRIPT_DIR=$(cd $(dirname $0) && pwd)
-cd $SCRIPT_DIR/..
+pushd $SCRIPT_DIR/..
 
 # help function to show usage of this script
 # 1>&2 redirects stdout to stderr
@@ -69,31 +69,29 @@ fi
 if [ $CLIENT_LIB == "go" ]; then
 
 #2.0 API Client Library
-    mkdir on-http-api2.0 && cd on-http-api2.0
+    mkdir on-http-api2.0 && pushd on-http-api2.0
     apt-get install jq
     LATESTV=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/latest | jq -r .tag_name)
     if [ -d swagger_linux_amd64 ]; then
         rm -rf swagger_linux_amd64
-    else
-        wget https://github.com/go-swagger/go-swagger/releases/download/$LATESTV/swagger_linux_amd64
     fi
+    wget https://github.com/go-swagger/go-swagger/releases/download/$LATESTV/swagger_linux_amd64
     chmod +x swagger_linux_amd64
     cp ../static/monorail-2.0.yaml .
     swagger generate client -f ./monorail-2.0.yaml -A on-http-api2.0
-    cd $SCRIPT_DIR/..
+    popd
 
 #Redfish API Client Library
-    mkdir on-http-redfish-1.0 && cd on-http-redfish-1.0
+    mkdir on-http-redfish-1.0 && pushd on-http-redfish-1.0
     LATESTV=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/latest | jq -r .tag_name)
     if [ -d swagger_linux_amd64 ]; then
         rm -rf swagger_linux_amd64
-    else
-        wget https://github.com/go-swagger/go-swagger/releases/download/$LATESTV/swagger_linux_amd64
     fi
+    wget https://github.com/go-swagger/go-swagger/releases/download/$LATESTV/swagger_linux_amd64
     chmod +x swagger_linux_amd64
     cp ../static/redfish.yaml .
     swagger generate client -f ./redfish.yaml -A on-http-redfish-1.0
-    cd $SCRIPT_DIR/..
+    popd
 
 #if not go, use swagger-codegen to generate client libraries
 else
@@ -116,3 +114,5 @@ else
         -l $CLIENT_LIB \
         --additional-properties packageName=on_http_redfish_1_0,packageVersion=${VERSION}
 fi
+
+popd

--- a/extra/make-client.sh
+++ b/extra/make-client.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# DESCRIPTION: This script is used to create a client library
+#              of choice by the user and generate documentation.
+
+# enable to fail on errors in script or failure to run any command
+#set -e
+# enable to see script debug output
+#set -x
+
+#changing directory to on-http
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+cd $SCRIPT_DIR/..
+
+# help function to show usage of this script
+# 1>&2 redirects stdout to stderr
+help() { echo "Usage: $0 [-l <python | go | java>]" 1>&2; exit 0; }
+
+# ensuring "-l" matches a client library to generate
+# only takes "-l" as an arg
+# requires language of choice after invoking "-l"
+while getopts ":l:" opts; do
+    case "${opts}" in
+        l)
+            CLIENT_LIB=${OPTARG}
+            if [ "$CLIENT_LIB" == "python" ] || [ "$CLIENT_LIB" == "go" ] ||
+               [ "$CLIENT_LIB" == "java" ] ; then
+               echo "creating client library for $CLIENT_LIB"
+            else
+                help
+            fi
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG"
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument"
+            help
+            exit 1
+            ;;
+    esac
+done
+
+#checking if $CLIENT_LIB string is empty
+if [ -z $CLIENT_LIB ]; then
+    help
+fi
+
+#removing existing on-http-api2.0 directory if it exists
+if [ -d on-http-api2.0 ]; then
+    echo "removing existing 2.0 api client library"
+    rm -rf on-http-api2.0/;
+fi
+
+#removing existing on-http-redfish-1.0 directory if it exists
+if [ -d on-http-redfish-1.0 ]; then
+    echo "removing existing redfish client library"
+    rm -rf on-http-redfish-1.0/;
+fi
+
+#removing existing swagger-codegen directory if it exists
+if [ -d swagger-codegen ]; then
+    echo "removing existing swagger-codegen directory"
+    rm -rf swagger-codegen/;
+fi
+
+#if language chosen is go, use go-swagger to generate client library
+if [ $CLIENT_LIB == "go" ]; then
+
+#2.0 API Client Library
+    mkdir on-http-api2.0 && cd on-http-api2.0
+    apt-get install jq
+    LATESTV=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/latest | jq -r .tag_name)
+    if [ -d swagger_linux_amd64 ]; then
+        rm -rf swagger_linux_amd64
+    else
+        wget https://github.com/go-swagger/go-swagger/releases/download/$LATESTV/swagger_linux_amd64
+    fi
+    chmod +x swagger_linux_amd64
+    cp ../static/monorail-2.0.yaml .
+    swagger generate client -f ./monorail-2.0.yaml -A on-http-api2.0
+    cd $SCRIPT_DIR/..
+
+#Redfish API Client Library
+    mkdir on-http-redfish-1.0 && cd on-http-redfish-1.0
+    LATESTV=$(curl -s https://api.github.com/repos/go-swagger/go-swagger/releases/latest | jq -r .tag_name)
+    if [ -d swagger_linux_amd64 ]; then
+        rm -rf swagger_linux_amd64
+    else
+        wget https://github.com/go-swagger/go-swagger/releases/download/$LATESTV/swagger_linux_amd64
+    fi
+    chmod +x swagger_linux_amd64
+    cp ../static/redfish.yaml .
+    swagger generate client -f ./redfish.yaml -A on-http-redfish-1.0
+    cd $SCRIPT_DIR/..
+
+#if not go, use swagger-codegen to generate client libraries
+else
+    git clone https://github.com/swagger-api/swagger-codegen
+    pushd ./swagger-codegen && mvn package && popd
+
+    echo "creating client library based on 2.0 api"
+    VERSION=$(awk -F \" '/version: +"[0-9]+.[0-9]+.[0-9]+"/{print $2;exit}' static/monorail-2.0.yaml)
+    java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
+        -i static/monorail-2.0.yaml \
+        -o on-http-api2.0 \
+        -l $CLIENT_LIB \
+        --additional-properties packageName=on_http_api2_0,packageVersion=${VERSION}
+
+    echo "creating client library based on redfish api"
+    VERSION=$(awk -F \" '/version: +"[0-9]+.[0-9]+.[0-9]+"/{print $2;exit}' static/redfish.yaml)
+    java -jar ./swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar generate \
+        -i static/redfish.yaml \
+        -o on-http-redfish-1.0 \
+        -l $CLIENT_LIB \
+        --additional-properties packageName=on_http_redfish_1_0,packageVersion=${VERSION}
+fi

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "doc": "./node_modules/.bin/jsdoc lib/api/1.1/northbound -r -d docs",
     "test": "./node_modules/.bin/mocha $(find spec -name '*-spec.js') -R spec --require spec/helper.js",
     "install": "./install-web-ui.sh && ./install-swagger-ui.sh",
-    "apidoc": "./node_modules/.bin/apidoc -i lib/api/1.1/northbound -f '.*\\.js$' -o build/apidoc",
+    "apidoc": "node extra/swagger-doc.js",
     "taskdoc": "./install-task-doc.sh",
-    "swaggerdoc": "node extra/swagger-doc.js"
+    "client": "./extra/make-client.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- creating a script to generate client libraries for go, java, and python
- updating on-http readme to remove 1.1 API references
- updating package.json to remove 1.1 documentation generation. added new client command used to generate client libraries

@RackHD/veyron 