### PR TITLE
Enhance docker build of on-http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ RUN mkdir -p ./node_modules \
   && ln -s /RackHD/on-core ./node_modules/on-core \
   && ln -s /RackHD/on-core/node_modules/di ./node_modules/di \
   && apt-get install -y unzip curl \
-  && npm install --ignore-scripts \
-  && npm install apidoc \
+  && npm config set -g production false \
+  && npm install --unsafe-perm \
   && npm run taskdoc \
-  && /RackHD/on-http/install-web-ui.sh \
-  && /RackHD/on-http/install-swagger-ui.sh \
   && npm prune --production
 
 EXPOSE 9080 9090


### PR DESCRIPTION
On behalf of @PengTian0 , this PR was aim to address  P1     RAC-4784, but it's resolved by @BillyAbildgaard  in other PR which directlly remove apidoc.
**But this PR is still valid.**

-----------

    **Change Summary**
    1. add --unsafe-perm , to enable '''npm install''' run as root
    2. add  "npm config set -g production false"
    3. remove explict step in Dockerfile to run install-web-ui.sh & install-swagger-ui.sh
    4. remove duplicated step of "npm install apidoc"
-----------



    **Rational**
-----------

    (1) why "--unsafe-perm"
    in Docker-Build, the "RUN" shell commands are run as "root"
    But when running npm with "root", NPM tries to downgrade its privileges when it runs scripts(defaults to nobody)
    And it will fail to write in local folder without enough permission, so
    NPM skips the command line ""./install-web-ui.sh && ./install-swagger-ui.sh", which is the "install" steps under "scripts" in package.json
    Warning Message as below:
    ```
     npm WARN cannot run in wd on-http@2.1.0 ./install-web-ui.sh && ./install-swagger-ui.sh
    ```

    Per NPM Usage, "--unsafe-perm" is required if running npm as root or sudo.

    *unsafe-perm*
    Set to true to suppress the UID/GID switching when running package scripts. If set explicitly to false, then installing as a non-root user will fail.

    reference
    http://stackoverflow.com/questions/18136746/npm-install-failed-with-cannot-run-in-wd
    https://til.codes/npm-install-failed-with-cannot-run-in-wd-2/

--------------

    (2) By default, the "npm config get production" will show "true" in base docker image(nodesource/wheezy:4.4.6).
    So whenever run "npm install", it's equal to running "npm install --production".
    So the DevDependency are all missing. which makes the 'npm run apidoc' failed to find html-pdf...etc packages.

------------
    (3) why not explicit "install-web-ui.sh & install-swagger-ui.sh"

    Previouly, when @Roland initialized the Dockerfile, He met the same problem which " npm WARN cannot run in wd on-http@2.1.0 ./install-web-ui.sh && ./install-swagger-ui.sh"
    He brought the *workaround* that split the other npm-install steps with the  web-ui/swagger-ui.sh.
    That's why he run "npm install --ignore-script" to skip the "./install-web-ui.sh && ./install-swagger-ui.sh" at the beginning,
    then explictly run "./install-web-ui.sh && ./install-swagger-ui.sh" after that (out of npm control)

    with the real fix of "--unsafe-perm" , npm-install will cover the step of  "./install-web-ui.sh && ./install-swagger-ui.sh" .

------------
   
 (4) in package.json, "apidoc" is installed with a specific version( "^0.12.1") in package.json(DevDependencies). so no necessary to do it here again.





@yyscamper  @changev  @brianparry  @BillyAbildgaard 