### PR TITLE
removing apidoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN mkdir -p ./node_modules \
   && apt-get install -y unzip curl \
   && npm install --ignore-scripts \
   && npm install apidoc \
-  && npm run apidoc \
   && npm run taskdoc \
   && /RackHD/on-http/install-web-ui.sh \
   && /RackHD/on-http/install-swagger-ui.sh \


### PR DESCRIPTION
removing apidoc command.  This was used to generate 1.1 documentation and since we have swagger-ui it seems to add no additional value by also generating this documentation.

@RackHD/veyron 