### PR TITLE
 Fix-notification-progress-data-pre-validation-error

### DIFF
--- a/lib/services/notification-api-service.js
+++ b/lib/services/notification-api-service.js
@@ -49,25 +49,24 @@ function NotificationApiServiceFactory(
     };
 
     NotificationApiService.prototype.publishTaskProgress = function(message) {
-        if(!_.isString(message.taskId)) {
-            throw new Errors.BadRequestError('taskId is required for progress notification');
-        }
-        if(!message.maximum) {
-            throw new Errors.BadRequestError('maximum is required for progress notification');
-        }
-        if(!message.value) {
-            throw new Errors.BadRequestError('value is required for progress notification');
-        }
-
-        if (message.value) {
+        var progressData;
+        return Promise.try(function() {
             message.value = parseInt(message.value);
-        }
-        if (message.maximum) {
             message.maximum = parseInt(message.maximum);
-        }
-        var progressData = _.pick(message, ['maximum', 'value', 'description']);
-
-        return waterline.taskdependencies.findOne({taskId: message.taskId})
+            if(!_.isString(message.taskId)) {
+                throw new Errors.BadRequestError('taskId is required for progress notification');
+            }
+            if(!_.isFinite(message.maximum)) {
+                throw new Errors.BadRequestError('maximum is invalid for progress notification');
+            }
+            if(!_.isFinite(message.value)) {
+                throw new Errors.BadRequestError('value is invalid for progress notification');
+            }
+            progressData = _.pick(message, ['maximum', 'value', 'description']);
+        })
+        .then(function(){
+            return waterline.taskdependencies.findOne({taskId: message.taskId});
+        })
         .then(function(task) {
             if (_.isEmpty(_.get(task, 'graphId'))) {
                 throw new Errors.BadRequestError('Cannot find the task for taskId ' + message.taskId); //jshint ignore: line

--- a/spec/lib/api/2.0/notification-spec.js
+++ b/spec/lib/api/2.0/notification-spec.js
@@ -127,6 +127,20 @@ describe('Http.Api.Notification', function () {
                 .expect(200);
             });
 
+            it('should be success if value is 0 in body', function() {
+                return helper.request()
+                .post('/api/2.0/notification/progress')
+                .send({
+                    taskId: 'test',
+                    value: 0,
+                    maximum: '100',
+                    description: 'foo bar'
+                })
+                .send(body)
+                .set('Content-Type', 'application/json')
+                .expect(200);
+            });
+
             it('should post progress notification via query', function () {
                 return helper.request()
                 .post('/api/2.0/notification/progress?taskId=testid&maximum=5&value=2&description=foo%20bar%20%202') //jshint ignore: line
@@ -198,11 +212,37 @@ describe('Http.Api.Notification', function () {
                 .expect(400);
             });
 
+            it('should return 400 if maximum is invalid in body', function() {
+                return helper.request()
+                .post('/api/2.0/notification/progress')
+                .send({
+                    taskId: 'test',
+                    value: 2,
+                    maximum: 'abc',
+                    description: 'foo bar'
+                })
+                .set('Content-Type', 'application/json')
+                .expect(400);
+            });
+
             it('should return 400 if value is missing in body', function() {
                 return helper.request()
                 .post('/api/2.0/notification/progress')
                 .send({
                     taskId: 'test',
+                    maximum: 5,
+                    description: 'foo bar'
+                })
+                .set('Content-Type', 'application/json')
+                .expect(400);
+            });
+
+            it('should return 400 if maximum is invalid in body', function() {
+                return helper.request()
+                .post('/api/2.0/notification/progress')
+                .send({
+                    taskId: 'test',
+                    value: 'a2',
                     maximum: 5,
                     description: 'foo bar'
                 })

--- a/spec/lib/api/2.0/notification-spec.js
+++ b/spec/lib/api/2.0/notification-spec.js
@@ -237,7 +237,7 @@ describe('Http.Api.Notification', function () {
                 .expect(400);
             });
 
-            it('should return 400 if maximum is invalid in body', function() {
+            it('should return 400 if value is invalid in body', function() {
                 return helper.request()
                 .post('/api/2.0/notification/progress')
                 .send({


### PR DESCRIPTION
Existing progress data pre-validation will reject 0 value, this is not expected.
This PR enhances progress data pre-validation and pack them in a Promise.try.
Also negative and boundary tests are added.