### PR TITLE
Add options to allow console redirect in ESXi bootstrap

### DIFF
--- a/data/templates/esx-boot-cfg
+++ b/data/templates/esx-boot-cfg
@@ -2,7 +2,7 @@ bootstate=0
 title=Loading ESXi installer
 prefix=<%=repo%>
 kernel=<%=tbootFile%>
-kernelopt=runweasel formatwithmbr com1_baud=115200 com1_Port=<%=comportaddress%> tty2Port=<%=comport%> debugLogToSerial=1 logPort=<%=comport%> ks=<%=installScriptUri%>
+kernelopt=runweasel formatwithmbr com1_baud=115200 com1_Port=<%=comportaddress%> tty2Port=<%=comport%> gdbPort=<%=gdbPort%> debugLogToSerial=<%=debugLogToSerial%> logPort=<%=logPort%> ks=<%=installScriptUri%>
 modules=<%=moduleFiles%> <%=kargs%>
 build=
 updated=0

--- a/data/templates/esx-ks
+++ b/data/templates/esx-ks
@@ -51,6 +51,12 @@ esxcli system settings advanced set -o /UserVars/SuppressShellWarning -i 1
 #Set the ESXi Shell Interactive idle time logout
 esxcli system settings advanced set -o /UserVars/ESXiShellInteractiveTimeout -i 3600
 
+#Set Console port redirect
+esxcli system settings kernel set -s="gdbPort" -v=<%=gdbPort%>
+esxcli system settings kernel set -s="logPort" -v=<%=logPort%>
+esxcli system settings kernel set -s="tty2Port" -v=<%=comport%>
+esxcli system settings kernel set -s="debugLogToSerial" -v=<%=debugLogToSerial%>
+
 # disable firewall
 esxcli network firewall set --default-action false --enabled no
 


### PR DESCRIPTION
In many rack mount servers or customized servers, there is no monitor connected, UART port are usually used as console. VMware ESXi use VGA card as console. User need pass VM kernel To support this use, I add three options: "gdbPort","logPort","debugLogToSerial".
[VMware ESXi referrence](https://pubs.vmware.com/vsphere-50/index.jsp?topic=%2Fcom.vmware.vsphere.install.doc_50%2FGUID-C65306C0-DA37-4F45-8A50-31F8D109BB1D.html])

To support this , 'on-http/data/templates/esx-boot-cfg', 'on-http/data/templates/esx-ks'(This PR) and 'on-tasks/lib/task-data/tasks/install-esx.js'(in another PR for on-tasks) are changed.
The default value of those options keep console in VGA as it does before. User can customize the console redirect setting in the OS bootstrapping payload.
Jenkins depends on https://github.com/RackHD/on-tasks/pull/443
