### PR TITLE
PATCH obms with only service and config as required properties

### DIFF
--- a/lib/fittings/rackhd_validator.js
+++ b/lib/fittings/rackhd_validator.js
@@ -15,7 +15,7 @@ module.exports = function create(fittingDef) {
             var suffix = null;
             var service = null;
             if (schemaName === 'obm') {
-                if (context.request.method == "PATCH")
+                if (context.request.method === "PATCH")
                     suffix = '.json#/definitions/ObmPatch';
                 else
                     suffix = '.json#/definitions/Obm';

--- a/lib/fittings/rackhd_validator.js
+++ b/lib/fittings/rackhd_validator.js
@@ -15,7 +15,10 @@ module.exports = function create(fittingDef) {
             var suffix = null;
             var service = null;
             if (schemaName === 'obm') {
-                suffix = '.json#/definitions/Obm';
+                if (context.request.method == "PATCH")
+                    suffix = '.json#/definitions/ObmPatch';
+                else
+                    suffix = '.json#/definitions/Obm';
                 service = context.request.body.service;
                 if (service) {
                     schemaName = service + suffix;

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -895,6 +895,7 @@ describe('2.0 Http.Api.Nodes', function () {
 
         var obm = {
             service: 'ipmi-obm-service',
+            nodeId: '123',
             config: {
                 host: '1.2.3.4',
                 user: 'myuser',

--- a/spec/lib/api/2.0/obms-spec.js
+++ b/spec/lib/api/2.0/obms-spec.js
@@ -111,9 +111,11 @@ describe('Http.Api.Obms', function () {
                 .expect(function (res) {
                     expect(res.body).to.have.property('title', 'ipmi-obm-service');
                     expect(res.body).to.have.deep.property(
-                        'definitions.Obm.properties.service').that.is.an('object');
+                        'definitions.ObmPatch.properties.service').that.is.an('object');
                     expect(res.body).to.have.deep.property(
-                        'definitions.Obm.properties.config').that.is.an('object');
+                        'definitions.ObmPatch.properties.config').that.is.an('object');
+                    expect(res.body).to.have.deep.property(
+                        'definitions.Obm').that.is.an('object');
                 });
         });
 
@@ -124,9 +126,11 @@ describe('Http.Api.Obms', function () {
                 .expect(function (res) {
                     expect(res.body).to.have.property('title', 'panduit-obm-service');
                     expect(res.body).to.have.deep.property(
-                        'definitions.Obm.properties.service').that.is.an('object');
+                        'definitions.ObmPatch.properties.service').that.is.an('object');
                     expect(res.body).to.have.deep.property(
-                        'definitions.Obm.properties.config').that.is.an('object');
+                        'definitions.ObmPatch.properties.config').that.is.an('object');
+                    expect(res.body).to.have.deep.property(
+                        'definitions.Obm').that.is.an('object');
                 });
 
         });

--- a/spec/lib/api/2.0/obms-spec.js
+++ b/spec/lib/api/2.0/obms-spec.js
@@ -111,9 +111,11 @@ describe('Http.Api.Obms', function () {
                 .expect(function (res) {
                     expect(res.body).to.have.property('title', 'ipmi-obm-service');
                     expect(res.body).to.have.deep.property(
-                        'definitions.ObmPatch.properties.service').that.is.an('object');
+                        'definitions.ObmBase.properties.service').that.is.an('object');
                     expect(res.body).to.have.deep.property(
-                        'definitions.ObmPatch.properties.config').that.is.an('object');
+                        'definitions.ObmBase.properties.config').that.is.an('object');
+                    expect(res.body).to.have.deep.property(
+                        'definitions.ObmPatch').that.is.an('object');
                     expect(res.body).to.have.deep.property(
                         'definitions.Obm').that.is.an('object');
                 });
@@ -126,9 +128,11 @@ describe('Http.Api.Obms', function () {
                 .expect(function (res) {
                     expect(res.body).to.have.property('title', 'panduit-obm-service');
                     expect(res.body).to.have.deep.property(
-                        'definitions.ObmPatch.properties.service').that.is.an('object');
+                        'definitions.ObmBase.properties.service').that.is.an('object');
                     expect(res.body).to.have.deep.property(
-                        'definitions.ObmPatch.properties.config').that.is.an('object');
+                        'definitions.ObmBase.properties.config').that.is.an('object');
+                    expect(res.body).to.have.deep.property(
+                        'definitions.ObmPatch').that.is.an('object');
                     expect(res.body).to.have.deep.property(
                         'definitions.Obm').that.is.an('object');
                 });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -2253,7 +2253,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/ipmi-obm-service_Obm'
+          $ref: '#/definitions/generic_obj'
       responses:
         200:
           description: Successfully patched the specified OBM settings

--- a/static/schemas/obms/amt-obm-service.json
+++ b/static/schemas/obms/amt-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "amt-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "AMT OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -27,6 +28,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/amt-obm-service.json
+++ b/static/schemas/obms/amt-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "amt-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "AMT OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -26,12 +26,18 @@
                     },
                     "required": ["host", "password"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/apc-obm-service.json
+++ b/static/schemas/obms/apc-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "apc-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "APC OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -30,12 +30,18 @@
                     },
                     "required": ["host", "community", "port"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/apc-obm-service.json
+++ b/static/schemas/obms/apc-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "apc-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "APC OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -31,6 +32,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/ipmi-obm-service.json
+++ b/static/schemas/obms/ipmi-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "ipmi-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "IPMI OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -31,6 +32,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/ipmi-obm-service.json
+++ b/static/schemas/obms/ipmi-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "ipmi-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "IPMI OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -30,12 +30,18 @@
                     },
                     "required": ["host", "user", "password"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/noop-obm-service.json
+++ b/static/schemas/obms/noop-obm-service.json
@@ -1,26 +1,34 @@
 {
     "title": "default-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "service": {
+        },
+        "ObmBase": {
             "description": "OBM settings",
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "nodeId": {
+                "service": {
                     "type": "string"
                 },
-                "service": {
+                "nodeId": {
                     "type": "string"
                 },
                 "config": {
                     "type": "object"
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/noop-obm-service.json
+++ b/static/schemas/obms/noop-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "default-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -16,6 +17,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/panduit-obm-service.json
+++ b/static/schemas/obms/panduit-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "panduit-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "Panduit OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -51,12 +51,18 @@
                     },
                     "required": ["host", "community", "cyclePassword", "pduOutlets"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/panduit-obm-service.json
+++ b/static/schemas/obms/panduit-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "panduit-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "Panduit OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -52,6 +53,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/raritan-obm-service.json
+++ b/static/schemas/obms/raritan-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "raritan-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "Raritan OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -34,12 +34,18 @@
                     },
                     "required": ["host", "user", "password", "port"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/raritan-obm-service.json
+++ b/static/schemas/obms/raritan-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "raritan-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "Raritan OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -35,6 +36,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/redfish-obm-service.json
+++ b/static/schemas/obms/redfish-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "redfish-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "Redfish OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -51,12 +51,18 @@
                     },
                     "required": ["host", "user", "password", "root", "uri", "protocol"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/redfish-obm-service.json
+++ b/static/schemas/obms/redfish-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "redfish-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "Redfish OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -52,6 +53,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/servertech-obm-service.json
+++ b/static/schemas/obms/servertech-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "servertech-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "Servertech OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -30,12 +30,18 @@
                     },
                     "required": ["host", "community", "port"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/servertech-obm-service.json
+++ b/static/schemas/obms/servertech-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "servertech-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "Servertech OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -31,6 +32,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/snmp-obm-service.json
+++ b/static/schemas/obms/snmp-obm-service.json
@@ -1,12 +1,11 @@
 {
     "title": "snmp-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "OBM settings",
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "required": [ "service", "config" ],
                 "nodeId": {
                     "type": "string"
                 },
@@ -27,12 +26,18 @@
                         }
                     }
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/snmp-obm-service.json
+++ b/static/schemas/obms/snmp-obm-service.json
@@ -1,9 +1,10 @@
 {
-    "title": "snmp-ibm-service",
+    "title": "snmp-obm-service",
     "definitions": {
-        "Ibm": {
-            "description": "IBM settings",
+        "ObmPatch": {
+            "description": "OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "required": [ "service", "config" ],
                 "nodeId": {
@@ -26,7 +27,14 @@
                         }
                     }
                 }
-            }
+            },
+            "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/vbox-obm-service.json
+++ b/static/schemas/obms/vbox-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "vbox-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "Vbox OBM settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -27,6 +28,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }

--- a/static/schemas/obms/vbox-obm-service.json
+++ b/static/schemas/obms/vbox-obm-service.json
@@ -1,7 +1,7 @@
 {
     "title": "vbox-obm-service",
     "definitions": {
-        "ObmPatch": {
+        "ObmBase": {
             "description": "Vbox OBM settings",
             "type": "object",
             "additionalProperties": false,
@@ -26,12 +26,18 @@
                     },
                     "required": ["alias", "user"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/vmrun-obm-service.json
+++ b/static/schemas/obms/vmrun-obm-service.json
@@ -22,12 +22,18 @@
                     },
                     "required": ["vmxpath"]
                 }
-            },
-            "required": ["service", "config"]
+            }
+        },
+        "ObmPatch": {
+            "type": "object",
+            "allOf": [
+                {"$ref": "#/definitions/ObmBase"}
+            ]
         },
         "Obm": {
+            "type": "object",
             "allOf": [
-                {"$ref": "#/definitions/ObmPatch"},
+                {"$ref": "#/definitions/ObmBase"},
                 {"required": ["nodeId", "service", "config"]}
             ]
         }

--- a/static/schemas/obms/vmrun-obm-service.json
+++ b/static/schemas/obms/vmrun-obm-service.json
@@ -1,9 +1,10 @@
 {
     "title": "default-obm-service",
     "definitions": {
-        "Obm": {
+        "ObmPatch": {
             "description": "Vmrun settings",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "nodeId": {
                     "type": "string"
@@ -23,6 +24,12 @@
                 }
             },
             "required": ["service", "config"]
+        },
+        "Obm": {
+            "allOf": [
+                {"$ref": "#/definitions/ObmPatch"},
+                {"required": ["nodeId", "service", "config"]}
+            ]
         }
     }
 }


### PR DESCRIPTION
Linked to story RAC-4766. Make nodeId optional when doing a PATCH, and set additional properties to false.

@RackHD/corecommitters 