### PR TITLE
Added PUT to config

### DIFF
--- a/lib/api/2.0/config.js
+++ b/lib/api/2.0/config.js
@@ -16,6 +16,7 @@ var configPatch = controller(function(req) {
 
 module.exports = {
     configGet: configGet,
+    configPut: configPatch,
     configPatch: configPatch
 };
 

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -125,7 +125,7 @@ definitions:
     description: Post a node into RackHD
     properties:
       autoDiscover:
-        type: string
+        type: boolean
       bootSettings:
         type: object
       identifiers:

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -530,6 +530,14 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+      summary: Patch server configuration
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Write
+      - configModify
     put:
       consumes:
       - application/json

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -125,7 +125,7 @@ definitions:
     description: Post a node into RackHD
     properties:
       autoDiscover:
-        type: boolean
+        type: string
       bootSettings:
         type: object
       identifiers:
@@ -514,6 +514,27 @@ paths:
       - application/json
       description: Modify the RackHD server configuration.
       operationId: configPatch
+      parameters:
+      - description: The configuration properties to be modified
+        in: body
+        name: config
+        required: true
+        schema:
+          $ref: '#/definitions/generic_obj'
+      responses:
+        200:
+          description: Successfully modified the configuration
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      consumes:
+      - application/json
+      description: Modify the RackHD server configuration.
+      operationId: configPut
       parameters:
       - description: The configuration properties to be modified
         in: body


### PR DESCRIPTION
@danbmckay and I added PUT rest call which essentially behaves as a PATCH. We are using swagger codegen and it doesnt support PATCH unless we have a POST call which /config doesn't have.
 
Shown below is the generated code from swagger codegen:
```
if ("GET".equals(method)) {
      response = invocationBuilder.get();
    } else if ("POST".equals(method)) {
      response = invocationBuilder.post(entity);
    } else if ("PUT".equals(method)) {
      response = invocationBuilder.put(entity);
    } else if ("DELETE".equals(method)) {
      response = invocationBuilder.delete();
    } else if ("PATCH".equals(method)) {
      response = invocationBuilder.header("X-HTTP-Method-Override", "PATCH").post(entity);
    } else {
      throw new ApiException(500, "unknown method type " + method);
    }
```