### PR TITLE
keep data consistency in enclosure update

### DIFF
--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -142,6 +142,63 @@ function nodeApiServiceFactory(
     };
 
     /**
+     * Get the targets to be removed in node. If the node is invalid
+     * or doesn't have required targets, this function doesn't need to return the
+     * node relation info and ignore silently with Promise.resolve().
+     * @param  {Object}     node node whose relation needs to be updated
+     * @param  {String}     type relation type that needs to be updated
+     * @param  {String[] | Object[]}    targets - nodes or ids in the relation
+     * that needs to be deleted
+     * @return {Object}    {indexPath: [tagsToBeRemoved]}
+     */
+    NodeApiService.prototype._getTargetsToBeRemoved = 
+        function getTargetsToBeRemoved(node, type, targets){
+        if (!node || !type || !_.has(node, 'relations')) {
+            return;
+        }
+
+        var index = _.findIndex(node.relations, { relationType: type });
+        if (index === -1 || !_.has(node.relations[index], 'targets')) {
+            return;
+        }
+
+        targets = [].concat(targets).map(function(node) {return node.id || node;});
+        var indexPath = ["relations.", String(index),".targets"].join("");
+        var values = {};
+        values[indexPath] = [].concat(targets);
+        return values;
+    };
+
+    /**
+     * Get the relations to be removed in node. Relations with [targets] shoud be removed.
+     * If the node is invalid or doesn't have required relation, this function doesn't need to 
+     * return the node relation info and ignore silently with Promise.resolve().
+     * @param  {Object}     node node whose relation needs to be updated
+     * @param  {String}     type relation type that needs to be updated
+     * @param  {String[] | Object[]}    targets - nodes or ids in the relation
+     * that needs to be deleted
+     * @return {Object}    {indexPath: [tagsToBeRemoved]}
+     */
+    NodeApiService.prototype._getRelationsToBeRemoved = 
+        function getRelationsToBeRemoved(node, type){
+        if (!node || !type || !_.has(node, 'relations')) {
+            return;
+        }
+
+        var index = _.findIndex(node.relations, { relationType: type });
+        if (index === -1 || !_.has(node.relations[index], 'targets')) {
+            return;
+        }
+
+        if (node.relations[index].targets.length !== 0) {
+            return;
+        }
+
+        var values = {"relations": [node.relations[index]]};
+        return values;
+    };
+
+    /**
      * Check whether a node is valid to be deleted
      * @param  {String}     nodeId
      * @return {Promise}
@@ -201,17 +258,28 @@ function nodeApiServiceFactory(
                         });
                     } else {
                         return Promise.map(targetNodes, function(targetNode) {
-                            var updatedNode = self._removeRelation(
+                            var targets = self._getTargetsToBeRemoved(
                                 targetNode,
                                 Constants.NodeRelations[type].mapping,
                                 node.id
                             );
-                            if (!updatedNode) {
+                            if (!targets) {
                                 return;
                             }
-                            return waterline.nodes.updateByIdentifier(
-                                updatedNode.id, {relations: updatedNode.relations}
-                            );
+                            return waterline.nodes
+                            .removeListItemsByIdentifier(targetNode.id, targets)
+                            .then(function(modifiedTargetNode){
+                                var relations = self._getRelationsToBeRemoved(
+                                    modifiedTargetNode,
+                                    Constants.NodeRelations[type].mapping,
+                                    node.id
+                                );
+                                if (!relations) {
+                                    return;
+                                }
+                                return waterline.nodes
+                                .removeListItemsByIdentifier(targetNode.id, relations);
+                            });
                         });
                     }
                 });


### PR DESCRIPTION
Fix https://rackhd.atlassian.net/browse/RAC-4805

jenkins: depends on https://github.com/RackHD/on-core/pull/278

Enclosure node will be updated when deleting compute node.
Find enclosure -> modify -> write

Used:
* find enclosure, delete the compute id in targets and get a new  enclosure [object], then ```update``` enclosure with this [object].
* this is not atomic

Now:
* find enclosure, use ```findAndModify``` to delete compute id in its target. If target = [], use ```findAndModify``` to delete the relation too
* this is atomic