### PR TITLE
RAC-5235

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -224,9 +224,8 @@ var getSystem = controller(function(req, res) {
     var options = redfish.makeOptions(req, res, identifier);
     options.systemType = 'Physical';
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
-//        if(/^[0-9|A-Z]{7}$/.test(node.name)){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
             if(/^[0-9|A-Z]{7}$/.test(node.identifiers[i])){
@@ -281,6 +280,8 @@ var getSystem = controller(function(req, res) {
                 return redfish.handleError(error, res);
             });
         }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -293,9 +294,8 @@ var listSystemProcessors = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
-//        if(/^[0-9|A-Z]{7}$/.test(node.name)){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
             if(/^[0-9|A-Z]{7}$/.test(node.identifiers[i])){
@@ -340,9 +340,8 @@ var getSystemProcessor = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
-//        if(/^[0-9|A-Z]{7}$/.test(node.name)){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
             if(/^[0-9|A-Z]{7}$/.test(node.identifiers[i])){
@@ -379,6 +378,8 @@ var getSystemProcessor = controller(function(req, res)  {
                 return redfish.handleError(error, res);
             });
         }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -391,9 +392,8 @@ var listSimpleStorage = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
-//        if(/^[0-9|A-Z]{7}$/.test(node.name)){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
             if(/^[0-9|A-Z]{7}$/.test(node.identifiers[i])){
@@ -430,26 +430,28 @@ var listSimpleStorage = controller(function(req, res)  {
                 .spread(function(dmi, smart) {
                     options.dmi = dmi;
 
-            var controllers = {};
-            _.forEach(smart.data, function(ele) {
-                var id = ele.Controller.controller_PCI_BDF.replace(/[:.]/g, '_');  // jshint ignore: line
-                if(!(id in controllers)) {
-                    controllers[id] = [];
-                }
-                controllers[id].push(ele);
-            });
+                var controllers = {};
+                _.forEach(smart.data, function(ele) {
+                    var id = ele.Controller.controller_PCI_BDF.replace(/[:.]/g, '_');  // jshint ignore: line
+                    if(!(id in controllers)) {
+                        controllers[id] = [];
+                    }
+                    controllers[id].push(ele);
+                });
 
-            var ids = [];
-            _.forOwn(controllers, function(val, key) { ids.push(key); });
-            options.controllers = ids;
+                var ids = [];
+                _.forOwn(controllers, function(val, key) { ids.push(key); });
+                options.controllers = ids;
 
-            return redfish.render('redfish.1.0.0.simplestoragecollection.json',
+               return redfish.render('redfish.1.0.0.simplestoragecollection.json',
                             'SimpleStorageCollection.json#/definitions/SimpleStorageCollection',
                             options);
-		    }).catch(function(error) {
-		        return redfish.handleError(error, res);
-		    });
-		}
+           }).catch(function(error) {
+               return redfish.handleError(error, res);
+           });
+        }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -465,9 +467,8 @@ var getSimpleStorage = controller(function(req, res)  {
 
     options.index = index;
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
-//        if(/^[0-9|A-Z]{7}$/.test(node.name)){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
             if(/^[0-9|A-Z]{7}$/.test(node.identifiers[i])){
@@ -526,13 +527,15 @@ var getSimpleStorage = controller(function(req, res)  {
                         }
                     });
 
-            return redfish.render('redfish.1.0.0.simplestorage.1.0.0.json',
+                return redfish.render('redfish.1.0.0.simplestorage.1.0.0.json',
                             'SimpleStorage.v1_1_1.json#/definitions/SimpleStorage',
                             options);
-		    }).catch(function(error) {
-		        return redfish.handleError(error, res);
-		    });
-	    }
+            }).catch(function(error) {
+                return redfish.handleError(error, res);
+            });
+        }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -545,7 +548,7 @@ var listStorage = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -580,6 +583,8 @@ var listStorage = controller(function(req, res)  {
        // } else {
          //  throw "Not implemented for non-Dell hardware."
        // }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -595,7 +600,7 @@ var getStorage = controller(function(req, res)  {
 
     options.index = index;
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -651,6 +656,8 @@ var getStorage = controller(function(req, res)  {
             });
        // } else { 
        // }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -669,7 +676,7 @@ var getDrive = controller(function(req, res)  {
     options.identifier = identifier;
     options.index = index;
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -698,6 +705,8 @@ var getDrive = controller(function(req, res)  {
             });
       //  } else {
       //  }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -708,7 +717,7 @@ var listVolume = controller(function(req, res)  {
     
     options.identifier = identifier;
     options.index = index;
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -733,6 +742,8 @@ var listVolume = controller(function(req, res)  {
             });
        // } else {
        // }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -751,7 +762,7 @@ var getVolume = controller(function(req, res)  {
     options.identifier = identifier;
     options.index = index;
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -783,6 +794,8 @@ var getVolume = controller(function(req, res)  {
             });
        // } else {
        // }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -796,10 +809,12 @@ var listLogService = controller(function(req, res)  {
     var options = redfish.makeOptions(req, res, identifier);
 
     options.logSource = ['sel'];
-    return redfish.render('redfish.1.0.0.logservicecollection.json',
+    return nodeApi.getNodeById(identifier)
+    .then(function(){
+        return redfish.render('redfish.1.0.0.logservicecollection.json',
                  'LogServiceCollection.json#/definitions/LogServiceCollection',
                   options)
-    .catch(function(error) {
+    }).catch(function(error) {
         return redfish.handleError(error, res);
     });
 });
@@ -818,7 +833,9 @@ var getSelLogService = controller(function(req, res)  {
     options.name = 'ipmi-sel-information';
     options.log = {};
 
-    return dataFactory(identifier, 'selInfoData')
+    return nodeApi.getNodeById(identifier)
+    .then(function(){
+        return dataFactory(identifier, 'selInfoData')
         .then(function(sel) {
             options.log.size = sel['# of Alloc Units'] || 0;
             options.log.policy = sel.Overflow && sel.Overflow === 'false' ?
@@ -828,6 +845,7 @@ var getSelLogService = controller(function(req, res)  {
             return redfish.render('redfish.1.0.0.logservice.1.0.0.json',
                             'LogService.v1_0_3.json#/definitions/LogService',
                             options);
+        });
     }).catch(function(error) {
         return redfish.handleError(error, res);
     });
@@ -838,24 +856,27 @@ var getSelLogService = controller(function(req, res)  {
  * @param  {Object}     req
  * @param  {Object}     res
  */
-var listSelLogServiceEntries = controller(function(req, res)  {
+var listSelLogServiceEntries = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
     options.type = 'SEL';
 
-    return dataFactory(identifier, 'selData')
-    .then(function(selData) {
-        if(selData) {
-            return selTranslator(selData, identifier);
-        }
-        return [];
-    })
-    .then(function(selData) {
-        options.logEntries = selData;
-        return redfish.render('redfish.1.0.0.logentrycollection.json',
-                        'LogEntryCollection.json#/definitions/LogEntryCollection',
-                        options);
+    return nodeApi.getNodeById(identifier)
+    .then(function(){
+        return dataFactory(identifier, 'selData')
+        .then(function(selData) {
+            if(selData) {
+                return selTranslator(selData, identifier);
+            }
+            return [];
+        })
+        .then(function(selData) {
+            options.logEntries = selData;
+            return redfish.render('redfish.1.0.0.logentrycollection.json',
+                            'LogEntryCollection.json#/definitions/LogEntryCollection',
+                           options);
+        });
     }).catch(function(error) {
         return redfish.handleError(error, res);
     });
@@ -876,22 +897,25 @@ var getSelLogServiceEntry = controller(function(req, res)  {
     options.name = 'ipmi-sel-information';
     options.log = {};
 
-    return dataFactory(identifier, 'selData')
-    .then(function(selData) {
-        options.entries = _.filter(selData, function(entry) {
-            return entry.logId === entryId;
+    return nodeApi.getNodeById(identifier)
+    .then(function(){
+        return dataFactory(identifier, 'selData')
+        .then(function(selData) {
+            options.entries = _.filter(selData, function(entry) {
+                return entry.logId === entryId;
+            });
+            if(!options.entries.length) {
+                throw new Errors.NotFoundError('sel entry ' + entryId + ' was not found');
+            }
+            return selTranslator(options.entries, identifier);
+        })
+        .then(function(selData) {
+            options.entries = selData;
+            options.entry = options.entries[0];
+            return redfish.render('redfish.1.0.0.logentry.1.0.0.json',
+                            'LogEntry.v1_1_1.json#/definitions/LogEntry',
+                            options);
         });
-        if(!options.entries.length) {
-            throw new Errors.NotFoundError('sel entry ' + entryId + ' was not found');
-        }
-        return selTranslator(options.entries, identifier);
-    })
-    .then(function(selData) {
-        options.entries = selData;
-        options.entry = options.entries[0];
-        return redfish.render('redfish.1.0.0.logentry.1.0.0.json',
-                        'LogEntry.v1_1_1.json#/definitions/LogEntry',
-                        options);
     }).catch(function(error) {
         return redfish.handleError(error, res);
     });
@@ -1053,7 +1077,7 @@ var deleteVolume = controller(function(req,res) {
     var graphOptions = {
         defaults: payload
     };
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -1101,7 +1125,7 @@ var addVolume = controller(function(req,res) {
         }
     };
 
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -1205,7 +1229,7 @@ var addHotspare = controller(function(req,res) {
     var graphOptions = {
         defaults: payload
     };
-    return waterline.nodes.getNodeById(identifier)
+    return nodeApi.getNodeById(identifier)
     .then(function(node){
         var dellFound = false;
         for(var i=0; i<node.identifiers.length; i++)
@@ -1249,26 +1273,28 @@ var getSecureBoot = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return getObmSettings(identifier)
-        .then(function(obmSettings) {
-            return racadm.runCommand (
-                obmSettings.host,
-                obmSettings.user,
-                obmSettings.password,
-                'get bios.SysSecurity.SecureBoot'
-            );
-        })
-        .then(function(secureBoot) {
-            var secureBootSetting = _.words(secureBoot, /SecureBoot=[a-zA-Z]*/);
-            var statusArray = secureBootSetting[0].split('=');
-            options.SecureBoot = (statusArray[1]);
-            return redfish.render('redfish.1.0.0.secureboot.1.0.1.json',
-                'SecureBoot.v1_0_1.json#/definitions/SecureBoot',
-                options);
-        })
-        .catch(function(error) {
-            return redfish.handleError(error, res);
-        });
+    return nodeApi.getNodeById(identifier)
+    .then(function(){
+        return getObmSettings(identifier)
+            .then(function(obmSettings) {
+                return racadm.runCommand (
+                    obmSettings.host,
+                    obmSettings.user,
+                    obmSettings.password,
+                    'get bios.SysSecurity.SecureBoot'
+                );
+            })
+            .then(function(secureBoot) {
+                var secureBootSetting = _.words(secureBoot, /SecureBoot=[a-zA-Z]*/);
+                var statusArray = secureBootSetting[0].split('=');
+                options.SecureBoot = (statusArray[1]);
+                return redfish.render('redfish.1.0.0.secureboot.1.0.1.json',
+                    'SecureBoot.v1_0_1.json#/definitions/SecureBoot',
+                    options);
+            });
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
+    });
 });
 
 /**

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -28,7 +28,7 @@ describe('Redfish Systems Root', function () {
     }
 
     before('start HTTP server', function () {
-        this.timeout(5000);
+        this.timeout(10000);
         return helper.startServer([]).then(function () {
             view = helper.injector.get('Views');
             sinon.stub(view, "get", redirectGet);
@@ -55,7 +55,7 @@ describe('Redfish Systems Root', function () {
             nodeApi = helper.injector.get('Http.Services.Api.Nodes');
             sinon.stub(nodeApi, "setNodeWorkflowById");
             sinon.stub(nodeApi, "getAllNodes");
-            sinon.stub(nodeApi, "getNodeById");
+            // sinon.stub(nodeApi, "getNodeById");
 
             racadm = helper.injector.get('JobUtils.RacadmTool');
             sinon.stub(racadm, "runCommand");
@@ -102,6 +102,7 @@ describe('Redfish Systems Root', function () {
             name: '1234abcd1234abcd1234abcd',
             identifiers: ['1234']
         }));
+        waterline.nodes.getNodeById.withArgs('bad' + '1234abcd1234abcd1234abcd').resolves();
         waterline.nodes.needByIdentifier.rejects(new Errors.NotFoundError('Not Found'));
         waterline.nodes.getNodeById.resolves({
 	    identifiers: ['1234']
@@ -325,7 +326,7 @@ describe('Redfish Systems Root', function () {
         taskProtocol.requestPollerCache.resolves([{
             chassis: { power: "Unknown", uid: "Reserved"}
         }]);
-        nodeApi.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(rawNode);
+        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(rawNode);
 
         return helper.request().get('/redfish/v1/Systems/' + node.id)
             .expect('Content-Type', /^application\/json/)
@@ -359,7 +360,7 @@ describe('Redfish Systems Root', function () {
             chassis: { power: "Unknown", uid: "Reserved"}
         }]);
 
-        nodeApi.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(rawNode);
+        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(rawNode);
 
         return helper.request().get('/redfish/v1/Systems/' + node.id)
             .expect('Content-Type', /^application\/json/)
@@ -372,7 +373,6 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should 404 an invalid system', function() {
-        nodeApi.getNodeById.withArgs('bad'+node.id).resolves([]);
         return helper.request().get('/redfish/v1/Systems/bad' + node.id)
             .expect('Content-Type', /^application\/json/)
             .expect(404);
@@ -641,7 +641,7 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should 404 a reset type list on an invalid node', function() {
-        nodeApi.getNodeById.resolves();
+        waterline.nodes.getNodeById.resolves();
         return helper.request().get('/redfish/v1/Systems/' + node.id +
                                     'invalid/Actions/ComputerSystem.Reset')
             .expect(404);
@@ -661,7 +661,7 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should 404 a reset on an invalid node', function() {
-        nodeApi.getNodeById.resolves();
+        waterline.nodes.getNodeById.resolves();
         return helper.request().post('/redfish/v1/Systems/' + node.id +
                                     'invalid/Actions/ComputerSystem.Reset')
             .send({ reset_type: "ForceRestart"})


### PR DESCRIPTION
- Replaced usages of waterline.nodes.getNodeById(identifier) with
  nodeApi.getNodeById(identifier)

- Fixed some tabbing/spacing issues

- All system.js get methods that use {identifier} are now properly
  returning 404.

Fixed system spec tests

- nodeApi.getNodeById should not be stubbed out.  waterline.nodes.getNodeById
  should be instead.  This will allow nodeApi.getNodeById to throw any
  exceptions it needs to throw (which are needed in systems.js)