### PR TITLE
RAC-4177, RAC-4909, RAC-4901

### DIFF
--- a/data/views/redfish-1.0/redfish.1.0.0.bios.1.0.0.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.bios.1.0.0.json
@@ -1,0 +1,36 @@
+{
+    "@odata.context" : "<%= basepath %>/$metadata#Systems/<%= identifier %>/Bios",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#Bios.1.0.0.Bios",
+    "Actions": {
+        "Oem": {}
+    },
+    "@Redfish.Settings": {
+        "@odata.type": "#Settings.v1_0_0.Settings",
+        "ETag": "",
+        "Messages": [],
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Systems/<%= identifier %>/Bios/Settings"
+        },
+        "Time": ""
+    },
+    "AttributeRegistry": "",
+    "Attributes": {
+        <% bios.attributes.forEach(function(item, i, arr) { %>
+            "<%= item.attributeName.value %>": %> "<%= item.currentValue[0].value %>"
+            <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
+        <% }); %>
+    },
+    "Description": "BIOS Configuration Current Settings",
+    "Id": "Bios",
+    "Name": "BIOS Configuration Current Settings",
+    "Oem": {},
+    "Actions": {
+        "#Bios.ResetBios": {
+            "target": "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios"
+        },
+        "#Bios.ChangePassword": {
+            "target": "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword"
+        }
+    }
+}

--- a/data/views/redfish-1.0/redfish.1.0.0.bios.1.0.0.settings.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.bios.1.0.0.settings.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context" : "<%= basepath %>/$metadata#Systems/<%= identifier %>/Bios/Settings",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#Bios.1.0.0.Bios",
+    "AttributeRegistry": "",
+    "Attributes": {
+        <% bios.attributes.forEach(function(item, i, arr) { %>
+            "<%= item.attributeName.value %>": %> "<%= item.currentValue[0].value %>"
+            <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
+        <% }); %>
+    },
+    "Description": "BIOS Configuration Current Settings",
+    "Id": "Bios",
+    "Name": "BIOS Configuration Current Settings",
+    "Oem": {}
+}

--- a/data/views/redfish-1.0/redfish.1.0.0.computersystem.1.0.0.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.computersystem.1.0.0.json
@@ -17,6 +17,7 @@
     "HostName": "",
     "IndicatorLED": "<%= chassisData.uid %>",
     "PowerState": "<%= chassisData.power==='Unknown' ? 'On' : chassisData.power %>",
+    "Bios": {},
     "Boot": {},
     "BiosVersion": "<%= ohai.data.dmi.bios.version.trim() %> <%= ohai.data.dmi.bios.bios_revision.trim() %> <%= ohai.data.dmi.bios.release_date.trim() %>",
     "ProcessorSummary": {

--- a/data/views/redfish-1.0/wsman.1.0.0.computersystem.1.0.0.json
+++ b/data/views/redfish-1.0/wsman.1.0.0.computersystem.1.0.0.json
@@ -17,6 +17,9 @@
     "HostName": "<% hardware.data.system.hostName %>",
     "IndicatorLED": "<%= hardware.data.leds[0] || 'Unknown' %>",
     "PowerState": "<%= hardware.data.system.powerState == 2 ? 'On' : 'Off' %>",
+    "Bios": {
+        "@odata.id": "<%= basepath %>/Systems/<%= identifier %>/Bios"
+    },
     "Boot": {},
     "BiosVersion": "<%= hardware.data.system.biosVersionString.trim() %> <%= hardware.data.system.biosReleaseDate.trim() %> ",
     "ProcessorSummary": {

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -13,6 +13,7 @@ var controller = injector.get('Http.Services.Swagger').controller;
 var Errors = injector.get('Errors');
 var moment = require('moment');
 var racadm = injector.get('JobUtils.RacadmTool');
+var configuration = injector.get('Services.Configuration');
 
 var dataFactory = function(identifier, dataName) {
     switch(dataName)  {
@@ -21,6 +22,8 @@ var dataFactory = function(identifier, dataName) {
         case 'smart':
         case 'hardware':
         case 'boot':
+        case 'bios':
+        case 'DeviceSummary':
             return nodeApi.getNodeCatalogSourceById(identifier, dataName);
 
         case 'chassis':
@@ -280,6 +283,173 @@ var getSystem = controller(function(req, res) {
                 return redfish.handleError(error, res);
             });
         }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+/**
+ * Generate information about the bios of a specific system
+ * @param  {Object}     req
+ * @param  {Object}     res
+ */
+var listSystemBios = controller(function(req, res) {
+    var identifier = req.swagger.params.identifier.value;
+    var options = redfish.makeOptions(req, res, identifier);
+
+    return nodeApi.getNodeById(identifier)
+    .then(function(node){
+        // look for Dell service tag in identifiers list
+        var dellFound = false;
+        node.identifiers.forEach(function(ident) {
+            if(/^[0-9|A-Z]{7}$/.test(ident)){
+                dellFound=true;
+            }
+        });
+        if (dellFound) {
+            return dataFactory(identifier, 'bios').then(function(bios) {
+                options.bios = bios;
+                bios.attributes = [];
+                var key;
+                // create a single bios attribute list (not organized by type)
+                for(key in bios.data) {
+                    if (bios.data.hasOwnProperty(key)) {
+                        bios.attributes = bios.attributes.concat(bios.data[key]);
+                    }
+                }
+                // normalize the currentValue field (some need value fields)
+                for(key in bios.attributes) {
+                    if (bios.attributes[key].currentValue[0] === null) {
+                        bios.attributes[key].currentValue[0] = {"value": null};
+                    }
+                }
+                return options;
+            });
+        } else {
+            throw new Errors.NotFoundError('No BIOS found for node ' + identifier);
+        }
+    }).then(function(options) {
+        return redfish.render('redfish.1.0.0.bios.1.0.0.json',
+            'Bios.v1_0_1.json#/definitions/Bios',
+            options);
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+/**
+ * Generate information about the bios settings data of a specific system
+ * @param  {Object}     req
+ * @param  {Object}     res
+ */
+var listSystemBiosSettings = controller(function(req, res)  {
+    var identifier = req.swagger.params.identifier.value;
+    var options = redfish.makeOptions(req, res, identifier);
+
+    return nodeApi.getNodeById(identifier).then(function(node){
+        var dellFound = false;
+        node.identifiers.forEach(function(ident) {
+            if(/^[0-9|A-Z]{7}$/.test(ident)){
+                dellFound = true;
+            }
+        });
+
+        if (dellFound) {
+            return dataFactory(identifier, 'bios').then(function(bios) {
+                options.bios = bios;
+                bios.attributes = [];
+                var key;
+                // create a single bios attribute list (not organized by type)
+                for(key in bios.data) {
+                    if (bios.data.hasOwnProperty(key)) {
+                        bios.attributes = bios.attributes.concat(bios.data[key]);
+                    }
+                }
+                for (key = bios.attributes.length - 1; key >= 0; key -= 1) {
+                    // remove entries that are readOnly
+                    if (bios.attributes[key].isReadOnly.value === "true") {
+                        bios.attributes.splice(key, 1);
+                        continue;
+                    }
+                    // normalize the currentValue field (some need value fields)
+                    if (bios.attributes[key].currentValue[0] === null) {
+                        bios.attributes[key].currentValue[0] = {"value": null};
+                    }
+                }
+                return options;
+            });
+        } else {
+            /* TODO: Not implemented? */
+               throw new Errors.NotFoundError(
+                    'No BIOS found for node ' + identifier
+            );
+        }
+    }).then(function(options) {
+        return redfish.render('redfish.1.0.0.bios.1.0.0.settings.json',
+                              'Bios.v1_0_1.json#/definitions/Bios',
+                              options);
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+/**
+ * Patch information about the bios settings data of a specific system
+ * @param  {Object}     req
+ * @param  {Object}     res
+ */
+var patchSystemBiosSettings = controller({success: 202}, function(req, res)  {
+
+    var identifier = req.swagger.params.identifier.value;
+    redfish.makeOptions(req, res, identifier);
+    var payload = req.swagger.params.payload.value;
+
+    var southboundApiRouter = _.filter(configuration.get('httpEndpoints', []),
+                                       _.matches({routers:'southbound-api-router'}))[0];
+
+    return nodeApi.getNodeById(identifier)
+    .then(function(node){
+        var dellFound = false;
+        node.identifiers.forEach(function(ident) {
+            if(/^[0-9|A-Z]{7}$/.test(ident)){
+                dellFound = true;
+            }
+        });
+        if(dellFound){
+            var results = { name: "Graph.Dell.Wsman.UpdateSystemComponents", options: {} };
+
+            return dataFactory(identifier, 'DeviceSummary').then(function(summary) {
+
+                results.options = {
+                    defaults: {
+                        serverIP: summary.data.id,
+                        fileName: "",
+                        shareType: 0,
+                        shareAddress: southboundApiRouter.address,
+                        shareName: "/nfs",
+                        shutdownType: 0,
+                        serverUsername: "",
+                        serverPassword: "",
+                        serverComponents: [{fqdd: "BIOS.Setup.1-1", attributes: []}]
+                    }
+                };
+
+                for (var key in payload.Attributes) {
+                    if (payload.Attributes.hasOwnProperty(key)) {
+                        results.options.defaults.serverComponents[0].attributes.push(
+                            {name: key, value: payload.Attributes[key]});
+                    }
+                }
+                return results;
+            });
+        } else {
+            /* TODO: Not implemented? */
+             throw new Errors.NotFoundError(
+                'Update Bios is not implemented for node ' + identifier
+            );
+        }
+    }).then(function(results) {
+        return nodeApi.setNodeWorkflowById(results, identifier);
     }).catch(function(error) {
         return redfish.handleError(error, res);
     });
@@ -1331,6 +1501,9 @@ var setSecureBoot = controller(function(req, res)  {
 module.exports = {
     listSystems: listSystems,
     getSystem: getSystem,
+    listSystemBios: listSystemBios,
+    listSystemBiosSettings: listSystemBiosSettings,
+    patchSystemBiosSettings: patchSystemBiosSettings,
     listSystemProcessors: listSystemProcessors,
     getSystemProcessor: getSystemProcessor,
     listSimpleStorage: listSimpleStorage,

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -227,6 +227,107 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /Systems/{identifier}/Bios:
+    x-swagger-router-controller: systems
+    get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: retrieve the current bios settings for a specified identifier
+      description: >
+        defines a set of bios resources
+      operationId: listSystemBios
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          type: string
+          x-param-handler: sku
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/Bios.v1_0_1.Bios"
+        400:
+          $ref: "#/responses/status_400"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        404:
+          $ref: "#/responses/status_404"
+        500:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /Systems/{identifier}/Bios/Settings:
+    x-swagger-router-controller: systems
+    get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: retrieve the pending bios settings for a specified identifier
+      description: >
+        defines a set of bios resources that are pending
+      operationId: listSystemBiosSettings
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          type: string
+          x-param-handler: sku
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/Bios.v1_0_1.Bios"
+        400:
+          $ref: "#/responses/status_400"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        404:
+          $ref: "#/responses/status_404"
+        500:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+    patch:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: patch the pending bios settings for a specified identifier
+      description: >
+        patch a set of bios resources
+      operationId: patchSystemBiosSettings
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          type: string
+          x-param-handler: sku
+        - name: payload
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/Bios.v1_0_1.Bios"
+      responses:
+        202:
+          description: Success
+          $ref: "#/responses/status_202"
+        400:
+          $ref: "#/responses/status_400"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        404:
+          $ref: "#/responses/status_404"
+        500:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
   /Systems/{identifier}/Processors:
     x-swagger-router-controller: systems
     get:
@@ -2258,6 +2359,74 @@ definitions:
       Status:
         $ref: '#/definitions/Resource_Status'
     type: object
+#  Bios.ChangePassword:
+#    description: This action is used to change the BIOS passwords.
+#    properties:
+#      target: {}
+#      title: {}
+#    type: object
+#  Bios.ResetBios:
+#    description: This action is used to reset the BIOS attributes to default.
+#    properties:
+#      target: {}
+#      title: {}
+#    type: object
+  Bios.v1_0_0.Actions:
+    properties:
+      Oem:
+        $ref: '#/definitions/Bios.v1_0_0.OemActions'
+    type: object
+  Bios.v1_0_0.Attributes:
+    properties: {}
+    type: object
+  Bios.v1_0_0.OemActions:
+    properties: {}
+    type: object
+  Bios.v1_0_1.Bios:
+    description: Bios contains properties surrounding a BIOS Attribute Registry (where
+      the system-specific BIOS attributes are described) and the Actions needed to
+      perform changes to BIOS settings, which typically require a system reset to
+      apply.
+    properties:
+      '@odata.context':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.id':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.type':
+        readOnly: true
+        type: string
+      Actions:
+        $ref: '#/definitions/Bios.v1_0_0.Actions'
+        description: The available actions for this resource.
+      AttributeRegistry:
+        description: The Resource ID of the Attribute Registry for the BIOS Attributes
+          resource.
+        readOnly: true
+        type: string
+      Attributes:
+        $ref: '#/definitions/Bios.v1_0_0.Attributes'
+        description: This is the manufacturer/provider specific list of BIOS attributes.
+      Description:
+        readOnly: true
+        type: string
+      Id:
+        readOnly: true
+        type: string
+      Name:
+        readOnly: true
+        type: string
+      Oem:
+        $ref: '#/definitions/Resource_Oem'
+        description: This is the manufacturer/provider specific extension moniker
+          used to divide the Oem object into sections.
+    required:
+    - Id
+    - Name
+    type: object
   Chassis.1.0.0_Chassis:
     description: This is the schema definition for the Chassis resource.  It represents
       the properties for physical components for any system.  This one object is intended
@@ -2568,6 +2737,10 @@ definitions:
           system for inventory or other client purposes
         readOnly: false
         type: string
+      Bios:
+        $ref: "#/definitions/Bios.v1_0_1.Bios"
+        description: A reference to the BIOS settings associated with this system.
+        readOnly: true
       BiosVersion:
         description: The version of the system BIOS or primary system firmware.
         type: string


### PR DESCRIPTION
Added the following endpoints:

  GET /redfish/v1/Systems/{identifier}/Bios
  GET /redfish/v1/Systems/{identifier}/Bios/Settings
  PATCH /redfish/v1/Systems/{identifier}/Bios/Settings

- This implements redfish systems bios settings for Dell
  nodes only.

- Fix patch to return 202 http status on success.

- Added system/bios tests for Dell and non-Dell systems.