### PR TITLE
RAC-4172 GET Systems/EthernetInterfaces

### DIFF
--- a/data/views/redfish-1.0/redfish.1.0.0.ethernetinterface.1.0.0.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.ethernetinterface.1.0.0.json
@@ -1,38 +1,103 @@
 {
-    "@odata.context" : "<%= basepath %>/$metadata#Systems/Members/$entity",
-    "@odata.id": "<%= url %>",
-    "@odata.type": "#EthernetInterface.1.0.0.EthernetInterface",
-    "Oem" : {},
-    "Id": "<%= index %>",
-    "Description": "",
-    "Name": "Manager Ethernet Interface",
-    "Status": {},
-    "InterfaceEnabled": true,
-    <% if(typeof hostMAC !== 'undefined') { %>
-    "PermanentMACAddress": "<%= hostMAC %>",
-    "MACAddress": "<%= hostMAC %>",
+    "@odata.context" : "<%= basepath %>/$metadata#<%= baseprofile %>/Members/$entity"
+    ,"@odata.id": "<%= url %>"
+    ,"@odata.type": "#EthernetInterface.1.2.0.EthernetInterface"
+    <% if (typeof autoneg !== 'undefined') { %>
+        ,"AutoNeg": <%= autoneg %>
+    <% } %>
+    <% if (typeof description !== 'undefined') { %>
+        ,"Description": "<%= description %>"
+    <% } %>
+    <% if (typeof fqdn !== 'undefined') { %>
+        ,"FQDN": "<%= fqdn %>"
+    <% } %>
+    <% if (typeof fullduplex !== 'undefined') { %>
+        ,"FullDuplex": <%= fullduplex %>
+    <% } %>
+    <% if (typeof hostname !== 'undefined') { %>
+        ,"HostName": "<%= hostname %>"
+    <% } %>
+    <% if (typeof ipv4 !== 'undefined') { %>
+        ,"IPv4Addresses" : [
+        <% ipv4.forEach(function(ipv4, i, arr) { %>
+            {
+                "Address": "<%= ipv4.ipaddr %>"
+                <% if(typeof ipv4.ipsubnet !== 'undefined') { %>
+                ,"SubnetMask": "<%= ipv4.ipsubnet %>"
+                <% } %>
+                <% if(typeof ipv4.ipsrc !== 'undefined') { %>
+                ,"AddressOrigin": "<%= ipv4.ipsrc %>"
+                <% } %>
+                <% if(typeof ipv4.ipgateway !== 'undefined') { %>
+                ,"Gateway": "<%= ipv4.ipgateway %>"
+                <% } %>
+            }
+            <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
+        <% }); %>
+        ]
+    <% } %>
+    <% if (typeof ipv6addresspolicytable !== 'undefined') { %>
+        ,"IPv6AddressPolicyTable": []
+    <% } %>
+    <% if (typeof ipv6addresses !== 'undefined') { %>
+        ,"IPv6Addresses": []
+    <% } %>
+    <% if (typeof ipv6defaultgateway !== 'undefined') { %>
+        ,"IPv6DefaultGateway": null
+    <% } %>
+    <% if (typeof ipv6staticaddresses !== 'undefined') { %>
+        ,"IPv6StaticAddresses" : []
+    <% } %>
+    ,"Id": "<%= index %>"
+    <% if(typeof interfaceenabled !== 'undefined') { %>
+        ,"InterfaceEnabled": <%= interfaceenable %>
+    <% } %>
+    <% if(typeof linkstatus !== 'undefined') { %>
+        <% if(typeof linkstatus === 'string') { %>
+            ,"LinkStatus": "<%= linkstatus %>"
+        <% } else { %>
+            ,"LinkStatus": null
+        <% } %>
+    <% } %>
+    <% if(typeof links !== 'undefined') { %>
+        ,"Links": <%= links %>
+    <% } %>
+    <% if(typeof permanentmacaddress !== 'undefined') { %>
+        ,"PermanentMACAddress": "<%= permanentmacaddress %>"
+    <% } %>
+    <% if(typeof macaddress !== 'undefined') { %>
+        ,"MACAddress": "<%= macaddress %>"
+    <% } %>
+    <% if(typeof mtusize !== 'undefined') { %>
+        ,"MTUSize": <%= mtusize %>
+    <% } %>
+    <% if(typeof maxipv6staticadresses !== 'undefined') { %>
+        ,"MaxIPv6StaticAddresses": <%= maxipv6staticadresses %>
+    <% } %>
+    ,"Name": "<%= name %>"
+    <% if(typeof nameservers !== 'undefined') { %>
+        ,"NameServers": []
+    <% } %>
+    <% if(typeof oem !== 'undefined') { %>
+        ,"Oem": {}
+    <% } %>
+    <% if(typeof speedmbps !== 'undefined') { %>
+        ,"SpeedMbps": <%= speedmbps %>
+    <% } %>
+    <% if(typeof status !== 'undefined') { %>
+        ,"Status": {}
+    <% } %>
+    <% if(typeof uefidevicepath !== 'undefined') { %>
+        ,"UefiDevicePath": "<%= uefidevicepath %>"
     <% } %>
     <% if (typeof vlan !== 'undefined') { %>
-    "VLAN": {
-        "VLANEnable": true,
-        "VLANId": <%= vlan %>
-    },
-    <% } %>
-    "IPv4Addresses" : [
-    <% ipv4.forEach(function(ipv4, i, arr) { %>
-        {
-            "Address": "<%= ipv4.ipaddr %>"
-            <% if(typeof ipv4.ipsubnet !== 'undefined') { %>
-            ,"SubnetMask": "<%= ipv4.ipsubnet %>"
-            <% } %>
-            <% if(typeof ipv4.ipsrc !== 'undefined') { %>
-            ,"AddressOrigin": "<%= ipv4.ipsrc %>"
-            <% } %>
-            <% if(typeof ipv4.ipgateway !== 'undefined') { %>
-            ,"Gateway": "<%= ipv4.ipgateway %>"
-            <% } %>
+        ,"VLAN": {
+            "VLANEnable": true,
+            "VLANId": <%= vlan %>
         }
-        <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
-    <% }); %>
-    ]
+    <% } %>
+    <% if (typeof vlans !== 'undefined') { %>
+        ,"VLANs": {}
+    <% } %>
 }
+

--- a/data/views/redfish-1.0/redfish.1.0.0.ethernetinterfacecollection.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.ethernetinterfacecollection.json
@@ -1,9 +1,9 @@
 {
-    "@odata.context" : "<%= basepath %>/$metadata#Systems/Links/Members/<%= identifier %>/EthernetInterfaces/$entity",
+    "@odata.context" : "<%= basepath %>/$metadata#<%= baseprofile %>/Links/Members/<%= identifier %>/EthernetInterfaces/$entity",
     "@odata.id": "<%= url %>",
     "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
     "Oem" : {},
-    "Name": "Ethernet Interface Collection",
+    "Name": "<%= name %>",
     "Members@odata.count": <%= net.length %>,
     "Members": [
         <% net.forEach(function(n, i, arr) { %>

--- a/lib/api/redfish-1.0/managers.js
+++ b/lib/api/redfish-1.0/managers.js
@@ -199,7 +199,9 @@ var listManagerEthernetInterfaces = controller(function(req, res) {
     .then(function(node) {
         assert.ok(_.isArray(node.obms), 'invalid obmSettings');
         assert.ok(node.obms.length === parseInt(parts[1]) + 1, 'invalid obmSetting');
+        options.name = "Manager Ethernet Interface Collection";
         options.net = [ '0' ];  // there is only one host per obmsetting
+        options.baseprofile = 'Managers';
         return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
                             'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
                             options);
@@ -233,8 +235,11 @@ var getManagerEthernetInterface = controller(function(req, res) {
         return nodeApi.getNodeCatalogSourceById(node.id, 'bmc');
     })
     .then(function(data) {
+        options.name = "Manager Ethernet Interface";
+        options.baseprofile = 'Managers';
         options.index = index;
-        options.hostMAC = data.data['MAC Address'];
+        options.permanentmacaddress = data.data['MAC Address'];
+        options.macaddress = data.data['MAC Address'];
         if(data.data['802_1q VLAN ID'] !== 'Disabled') {
             options.vlan = data.data['802_1q VLAN ID'];
         }
@@ -268,6 +273,9 @@ var listLocalEthernetInterfaces = controller(function(req, res) {
         });
         return arr;
     }, []);
+    options.name = "Manager Ethernet Interface Collection";
+    options.baseprofile = 'Managers';
+    options.identifier = reservedId;
     return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
                           'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
                           options)
@@ -286,6 +294,8 @@ var getLocalEthernetInterface = controller(function(req, res) {
             throw new Errors.NotFoundError('invalid resource');
         }
 
+        options.name = "Manager Ethernet Interface";
+        options.baseprofile = 'Managers';
         options.index = index;
         options.ipv4 = _.reduce(net, function(arr, val) {
             if(!val.internal && val.family === 'IPv4') {
@@ -296,7 +306,8 @@ var getLocalEthernetInterface = controller(function(req, res) {
                     obj.ipsubnet = val.netmask;
                 }
                 if(val.mac) { // not available in node 0.10
-                    options.hostMAC = val.mac;
+                    options.permanentmacaddress = val.mac;
+                    options.macaddress = val.mac;
                 }
                 arr.push(obj);
             }

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -1205,7 +1205,7 @@ var listSystemEthernetInterfaces = controller(function(req, res)  {
 
                 _.forEach(nics.data, (function(data) {
                     options.net.push(data.fqdd);
-                }))
+                }));
                 return options;
             });
         } else {
@@ -1244,19 +1244,19 @@ var listSystemEthernetInterfacesById = controller(function(req, res)  {
             return dataFactory(identifier, 'nics').then(function(nics) {
                 options.baseprofile = 'Systems';
                 options.net = [];
-                _.forEach(nics.data, (function(data) {
+                _.forEach(nics.data, function(data) {
                     if(data.fqdd === index) {
                         options.nic = data;
                     }
-                }));
-                if(typeof options.nic == 'undefined') {
+                });
+                if(typeof options.nic === 'undefined') {
                     // raise an exception
                     throw new Errors.NotFoundError('No Ethernet index found for node ' + index);
                 }
                 options.name = "Systems Ethernet Interface";
                 options.index = index;
                 options.autoneg = autoNeg[options.nic.autoNegotiation];
-                options.description = options.nic.deviceDescription.;
+                options.description = options.nic.deviceDescription;
                 options.fullduplex = fullDuplex[options.nic.linkDuplex];
                 options.linkstatus = options.nic.linkStatus;
                 options.macaddress = options.nic.currentMACAddress;

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -1255,18 +1255,18 @@ var listSystemEthernetInterfacesById = controller(function(req, res)  {
                 }
                 options.name = "Systems Ethernet Interface";
                 options.index = index;
-                options.autoneg = autoNeg[options.nic['autoNegotiation']];
-                options.description = options.nic['deviceDescription'];
-                options.fullduplex = fullDuplex[options.nic['linkDuplex']];
-                options.linkstatus = options.nic['linkStatus'];
-                options.macaddress = options.nic['currentMACAddress'];
-                options.permanentmacaddress = options.nic['permanentMacAddress'];
-                options.speedmbps = linkSpeed[options.nic['linkSpeed']];
+                options.autoneg = autoNeg[options.nic.autoNegotiation];
+                options.description = options.nic.deviceDescription.;
+                options.fullduplex = fullDuplex[options.nic.linkDuplex];
+                options.linkstatus = options.nic.linkStatus;
+                options.macaddress = options.nic.currentMACAddress;
+                options.permanentmacaddress = options.nic.permanentMacAddress;
+                options.speedmbps = linkSpeed[options.nic.linkSpeed];
 
                 return redfish.render('redfish.1.0.0.ethernetinterface.1.0.0.json',
-                                      'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
-                                      options);
-            })
+                    'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
+                    options);
+            });
         } else {
             throw new Errors.NotFoundError('No Ethernet found for node ' + identifier);
         }

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -23,6 +23,7 @@ var dataFactory = function(identifier, dataName) {
         case 'hardware':
         case 'boot':
         case 'bios':
+        case 'nics':
         case 'DeviceSummary':
             return nodeApi.getNodeCatalogSourceById(identifier, dataName);
 
@@ -74,6 +75,17 @@ var dataFactory = function(identifier, dataName) {
             });
     }
 };
+
+//DCIM_View mappings to redfish equivalents
+var autoNeg = {
+    "0": null, "2": true, "3": false };
+
+var fullDuplex = {
+    "0": null, "1": true, "2": false };
+
+var linkSpeed = {
+    "0": null, "1": 10, "2": 100, "3": 1000, "4": 2500, "5": 10000,
+    "6": 20000, "7": 40000, "8": 100000, "9": 25000, "10":50000 };
 
 var selTranslator = function(selArray, identifier) {
     var dateRegex = /(\d{1,2})\/(\d{1,2})\/(\d{4})/;
@@ -1166,6 +1178,104 @@ var doReset = controller(function(req,res) {
     });
 });
 
+
+/**
+ * List the ethernet interfaces for specified system
+ * @param  {Object}     req
+ * @param  {Object}     res
+ */
+var listSystemEthernetInterfaces = controller(function(req, res)  {
+    var identifier = req.swagger.params.identifier.value;
+    var options = redfish.makeOptions(req, res, identifier);
+
+    return nodeApi.getNodeById(identifier)
+    .then(function(node) {
+        // look for Dell service tag in identifiers list
+        var dellFound = false;
+        node.identifiers.forEach(function(ident) {
+            if(/^[0-9|A-Z]{7}$/.test(ident)){
+                dellFound=true;
+            }
+        });
+        options.name = "Systems Ethernet Interface Collection";
+        if(dellFound){
+            return dataFactory(identifier, 'nics').then(function(nics) {
+                options.baseprofile = 'Systems';
+                options.net = [];
+
+                _.forEach(nics.data, (function(data) {
+                    options.net.push(data.fqdd);
+                }))
+                return options;
+            });
+        } else {
+            throw new Errors.NotFoundError('No Ethernet found for node ' + identifier);
+        }
+    }).then(function(options) {
+        return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
+                              'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
+                              options);
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+
+/**
+ * List an ethernet interface by system and id
+ * @param  {Object}     req
+ * @param  {Object}     res
+ */
+var listSystemEthernetInterfacesById = controller(function(req, res)  {
+    var identifier = req.swagger.params.identifier.value;
+    var options = redfish.makeOptions(req, res, identifier);
+    var index = req.swagger.params.index.value;
+
+    return nodeApi.getNodeById(identifier)
+    .then(function(node) {
+        // look for Dell service tag in identifiers list
+        var dellFound = false;
+        node.identifiers.forEach(function(ident) {
+            if(/^[0-9|A-Z]{7}$/.test(ident)){
+                dellFound=true;
+            }
+        });
+        if(dellFound){
+            return dataFactory(identifier, 'nics').then(function(nics) {
+                options.baseprofile = 'Systems';
+                options.net = [];
+                _.forEach(nics.data, (function(data) {
+                    if(data.fqdd === index) {
+                        options.nic = data;
+                    }
+                }));
+                if(typeof options.nic == 'undefined') {
+                    // raise an exception
+                    throw new Errors.NotFoundError('No Ethernet index found for node ' + index);
+                }
+                options.name = "Systems Ethernet Interface";
+                options.index = index;
+                options.autoneg = autoNeg[options.nic['autoNegotiation']];
+                options.description = options.nic['deviceDescription'];
+                options.fullduplex = fullDuplex[options.nic['linkDuplex']];
+                options.linkstatus = options.nic['linkStatus'];
+                options.macaddress = options.nic['currentMACAddress'];
+                options.permanentmacaddress = options.nic['permanentMacAddress'];
+                options.speedmbps = linkSpeed[options.nic['linkSpeed']];
+
+                return redfish.render('redfish.1.0.0.ethernetinterface.1.0.0.json',
+                                      'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
+                                      options);
+            })
+        } else {
+            throw new Errors.NotFoundError('No Ethernet found for node ' + identifier);
+        }
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
+    });
+});
+
+
 /**
  * Generate information about the available boot images for the system
  * @param  {Object}     req
@@ -1525,5 +1635,7 @@ module.exports = {
     addVolume: addVolume,
     addHotspare: addHotspare,
     getSecureBoot: getSecureBoot,
-    setSecureBoot: setSecureBoot
+    setSecureBoot: setSecureBoot,
+    listSystemEthernetInterfaces: listSystemEthernetInterfaces,
+    listSystemEthernetInterfacesById: listSystemEthernetInterfacesById
 };

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -122,17 +122,17 @@ describe('Redfish Systems Root', function () {
             }
         });
 
-        waterline.nodes.getNodeById.withArgs(dellNode.id)
+        waterline.nodes.getNodeById.withArgs('DELLabcd1234abcd1234abcd')
         .resolves(Promise.resolve({
-            id: dellNode.id,
-            name: dellNode.id,
+            id: 'DELLabcd1234abcd1234abcd',
+            name: 'DELLabcd1234abcd1234abcd',
             identifiers: [ "ABCDEFG" ]
         }));
 
-        waterline.nodes.needByIdentifier.withArgs(dellNode.id)
+        waterline.nodes.needByIdentifier.withArgs('DELLabcd1234abcd1234abcd')
         .resolves(Promise.resolve({
-            id: dellNode.id,
-            name: dellNode.id
+            id: 'DELLabcd1234abcd1234abcd',
+            name: 'DELLabcd1234abcd1234abcd' 
         }));
     });
 

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -122,17 +122,17 @@ describe('Redfish Systems Root', function () {
             }
         });
 
-        waterline.nodes.getNodeById.withArgs('DELLabcd1234abcd1234abcd')
+        waterline.nodes.getNodeById.withArgs(dellNode.id)
         .resolves(Promise.resolve({
-            id: 'DELLabcd1234abcd1234abcd',
-            name: 'DELLabcd1234abcd1234abcd',
+            id: dellNode.id,
+            name: dellNode.id,
             identifiers: [ "ABCDEFG" ]
         }));
 
-        waterline.nodes.needByIdentifier.withArgs('DELLabcd1234abcd1234abcd')
+        waterline.nodes.needByIdentifier.withArgs(dellNode.id)
         .resolves(Promise.resolve({
-            id: 'DELLabcd1234abcd1234abcd',
-            name: 'DELLabcd1234abcd1234abcd'
+            id: dellNode.id,
+            name: dellNode.id
         }));
     });
 
@@ -177,6 +177,22 @@ describe('Redfish Systems Root', function () {
         autoDiscover: false,
         id: '1234abcd1234abcd1234abcd',
         name: 'name',
+        identifiers: [],
+        tags: [],
+        obms: [{ obm: '/api/2.0/obms/574dcd5794ab6e2506fd107a'}],
+        type: 'compute',
+        relations: [
+            {
+                relationType: 'enclosedBy',
+                targets: [ '4567efgh4567efgh4567efgh' ]
+            }
+        ]
+    };
+    // Node new mock data with OBM model change
+    var dellNode = {
+        autoDiscover: false,
+        id: 'DELLabcd1234abcd1234abcd',
+        name: 'dell node',
         identifiers: [],
         tags: [],
         obms: [{ obm: '/api/2.0/obms/574dcd5794ab6e2506fd107a'}],
@@ -560,12 +576,12 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should return a valid bios block for Dell-based catalog', function() {
-        waterline.catalogs.findLatestCatalogOfSource.withArgs('DELLabcd1234abcd1234abcd', 'bios').resolves(Promise.resolve({
-            node: 'DELLabcd1234abcd1234abcd',
+        waterline.catalogs.findLatestCatalogOfSource.withArgs(dellNode.id, 'bios').resolves(Promise.resolve({
+            node: dellNode.id,
             source: 'bios',
             data: dellCatalogData.bios
         }));
-        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/Bios')
+        return helper.request().get('/redfish/v1/Systems/' + dellNode.id + '/Bios')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
             .expect(function() {
@@ -588,12 +604,12 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should return a valid bios settings block for Dell-based catalog', function() {
-        waterline.catalogs.findLatestCatalogOfSource.withArgs('DELLabcd1234abcd1234abcd', 'bios').resolves(Promise.resolve({
-            node: 'DELLabcd1234abcd1234abcd',
+        waterline.catalogs.findLatestCatalogOfSource.withArgs(dellNode.id, 'bios').resolves(Promise.resolve({
+            node: dellNode.id,
             source: 'bios',
             data: dellCatalogData.bios
         }));
-        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/Bios/Settings')
+        return helper.request().get('/redfish/v1/Systems/' + dellNode.id + '/Bios/Settings')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
             .expect(function() {
@@ -620,12 +636,12 @@ describe('Redfish Systems Root', function () {
     it('should return a 202 for a Dell-based bios settings patch', function() {
         // Force a southbound interface through httpEndpoints
         configuration.set('httpEndpoints', httpEndpoints);
-        waterline.catalogs.findLatestCatalogOfSource.withArgs('DELLabcd1234abcd1234abcd', 'DeviceSummary').resolves(Promise.resolve({
-            node: 'DELLabcd1234abcd1234abcd',
+        waterline.catalogs.findLatestCatalogOfSource.withArgs(dellNode.id, 'DeviceSummary').resolves(Promise.resolve({
+            node: dellNode.id,
             source: 'DeviceSummary',
             data: dellCatalogData.DeviceSummary
         }));
-        return helper.request().patch('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/Bios/Settings')
+        return helper.request().patch('/redfish/v1/Systems/' + dellNode.id + '/Bios/Settings')
             .send({ "@odata.context": "string", "@odata.id": "string", "@odata.type": "string", "Actions": { "Oem": {} }, "AttributeRegistry": "string", "Attributes": { "X": "y"}, "Description": "string", "Id": "string", "Name": "string", "Oem": {} })
             .expect('Content-Type', /^application\/json/)
             .expect(202);
@@ -644,12 +660,12 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should return a valid ethernet block for Dell-based catalog', function() {
-        waterline.catalogs.findLatestCatalogOfSource.withArgs('DELLabcd1234abcd1234abcd', 'nics').resolves(Promise.resolve({
-            node: 'DELLabcd1234abcd1234abcd',
+        waterline.catalogs.findLatestCatalogOfSource.withArgs(dellNode.id, 'nics').resolves(Promise.resolve({
+            node: dellNode.id,
             source: 'nics',
             data: dellCatalogData.nics
         }));
-        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/EthernetInterfaces')
+        return helper.request().get('/redfish/v1/Systems/' + dellNode.id + '/EthernetInterfaces')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
             .expect(function() {
@@ -678,7 +694,7 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should 404 a valid identifier for ethernet index query with invalid index', function() {
-        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/EthernetInterfaces/' + "BADNIC.Integrated.1-1-1")
+        return helper.request().get('/redfish/v1/Systems/' + dellNode.id + '/EthernetInterfaces/' + "BADNIC.Integrated.1-1-1")
             .expect('Content-Type', /^application\/json/)
             .expect(404)
             .expect(function(res) {
@@ -687,12 +703,12 @@ describe('Redfish Systems Root', function () {
     });
 
     it('should return a valid ethernet index block for Dell-based catalog with valid index', function() {
-        waterline.catalogs.findLatestCatalogOfSource.withArgs('DELLabcd1234abcd1234abcd', 'nics').resolves(Promise.resolve({
-            node: 'DELLabcd1234abcd1234abcd',
+        waterline.catalogs.findLatestCatalogOfSource.withArgs(dellNode.id, 'nics').resolves(Promise.resolve({
+            node: dellNode.id,
             source: 'nics',
             data: dellCatalogData.nics
         }));
-        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/EthernetInterfaces/' + 'NIC.Integrated.1-1-1')
+        return helper.request().get('/redfish/v1/Systems/' + dellNode.id + '/EthernetInterfaces/' + 'NIC.Integrated.1-1-1')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
             .expect(function() {

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -305,7 +305,117 @@ describe('Redfish Systems Root', function () {
         },
         DeviceSummary: {
             id: "1.2.3.4"
-        }
+        },
+        nics: [
+            {
+                "autoNegotiation": "2",
+                "busNumber": "5",
+                "controllerBiosVersion": null,
+                "currentMACAddress": "F8:BC:12:0B:0B:40",
+                "dataBusWidth": "0002",
+                "deviceDescription": "Integrated NIC 1 Port 1 Partition 1",
+                "deviceNumber": "0",
+                "familyDriverVersion": "16.5.20",
+                "familyVersion": "16.5.20",
+                "fcoEOffloadMode": "3",
+                "fcoEWwnn": null,
+                "fqdd": "NIC.Integrated.1-1-1",
+                "id": 0,
+                "iscsiBootMode": null,
+                "iscsiInitiatorGateway": null,
+                "iscsiInitiatorIpAddress": null,
+                "iscsiInitiatorName": null,
+                "iscsiInitiatorPrimaryDns": null,
+                "iscsiInitiatorSecondryDns": null,
+                "iscsiInitiatorSubnet": null,
+                "iscsiMacAddress": null,
+                "iscsiOffloadMode": "3",
+                "iscsiOffloadSupport": null,
+                "legacyBootProtocol": null,
+                "linkDuplex": "1",
+                "linkSpeed": "3",
+                "linkStatus": null,
+                "macAddress": null,
+                "maxBandwidth": "0",
+                "mediaType": "Base T",
+                "minBandwidth": "0",
+                "nicMode": "3",
+                "osDriverState": null,
+                "pciDeviceID": "1521",
+                "pciSubDeviceID": "1028",
+                "permanentFcoMacAddress": "F8:BC:12:0B:0B:40",
+                "permanentMacAddress": "F8:BC:12:0B:0B:40",
+                "permanentiScsiMacAddress": "",
+                "productName": "Intel(R) Gigabit 4P X710/I350 rNDC - F8:BC:12:0B:0B:40",
+                "receiveFlowControl": "2",
+                "slotLength": "0002",
+                "slotType": "0002",
+                "teaming": "< NIC # > , < NIC # >",
+                "toeSupport": null,
+                "transmitFlowControl": "3",
+                "vendorName": "Intel Corp",
+                "virtWwn": null,
+                "virtWwpn": null,
+                "virtualIscsiMacAddress": null,
+                "virtualMacAddress": null,
+                "wwn": null,
+                "wwpn": null
+            },
+            {
+                "autoNegotiation": "2",
+                "busNumber": "5",
+                "controllerBiosVersion": null,
+                "currentMACAddress": "F8:BC:12:0B:0B:41",
+                "dataBusWidth": "0002",
+                "deviceDescription": "Integrated NIC 1 Port 2 Partition 1",
+                "deviceNumber": "0",
+                "familyDriverVersion": "16.5.20",
+                "familyVersion": "16.5.20",
+                "fcoEOffloadMode": "3",
+                "fcoEWwnn": null,
+                "fqdd": "NIC.Integrated.1-2-1",
+                "id": 0,
+                "iscsiBootMode": null,
+                "iscsiInitiatorGateway": null,
+                "iscsiInitiatorIpAddress": null,
+                "iscsiInitiatorName": null,
+                "iscsiInitiatorPrimaryDns": null,
+                "iscsiInitiatorSecondryDns": null,
+                "iscsiInitiatorSubnet": null,
+                "iscsiMacAddress": null,
+                "iscsiOffloadMode": "3",
+                "iscsiOffloadSupport": null,
+                "legacyBootProtocol": null,
+                "linkDuplex": "1",
+                "linkSpeed": "3",
+                "linkStatus": null,
+                "macAddress": null,
+                "maxBandwidth": "0",
+                "mediaType": "Base T",
+                "minBandwidth": "0",
+                "nicMode": "3",
+                "osDriverState": null,
+                "pciDeviceID": "1521",
+                "pciSubDeviceID": "1028",
+                "permanentFcoMacAddress": "F8:BC:12:0B:0B:41",
+                "permanentMacAddress": "F8:BC:12:0B:0B:41",
+                "permanentiScsiMacAddress": "",
+                "productName": "Intel(R) Gigabit 4P X710/I350 rNDC - F8:BC:12:0B:0B:41",
+                "receiveFlowControl": "2",
+                "slotLength": "0002",
+                "slotType": "0002",
+                "teaming": "< NIC # > , < NIC # >",
+                "toeSupport": null,
+                "transmitFlowControl": "3",
+                "vendorName": "Intel Corp",
+                "virtWwn": null,
+                "virtWwpn": null,
+                "virtualIscsiMacAddress": null,
+                "virtualMacAddress": null,
+                "wwn": null,
+                "wwpn": null
+            }
+        ]
     };
 
     var catalogDataWithBadProcessor = {
@@ -519,6 +629,77 @@ describe('Redfish Systems Root', function () {
             .send({ "@odata.context": "string", "@odata.id": "string", "@odata.type": "string", "Actions": { "Oem": {} }, "AttributeRegistry": "string", "Attributes": { "X": "y"}, "Description": "string", "Id": "string", "Name": "string", "Oem": {} })
             .expect('Content-Type', /^application\/json/)
             .expect(202);
+    });
+
+    it('should 404 an invalid identifier for ethernet query', function() {
+        return helper.request().get('/redfish/v1/Systems/bad' + node.id + '/EthernetInterfaces')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404);
+    });
+
+    it('should 404 a non-Dell identifier for ethernet query', function() {
+        return helper.request().get('/redfish/v1/Systems/' + node.id + '/EthernetInterfaces')
+            .expect('Content-Type', /^application\/json/)
+            .expect(404);
+    });
+
+    it('should return a valid ethernet block for Dell-based catalog', function() {
+        waterline.catalogs.findLatestCatalogOfSource.withArgs('DELLabcd1234abcd1234abcd', 'nics').resolves(Promise.resolve({
+            node: 'DELLabcd1234abcd1234abcd',
+            source: 'nics',
+            data: dellCatalogData.nics
+        }));
+        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/EthernetInterfaces')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200)
+            .expect(function() {
+                expect(tv4.validate.called).to.be.true;
+                expect(validator.validate.called).to.be.true;
+                expect(redfish.render.called).to.be.true;
+            });
+    });
+
+    it('should 404 an invalid identifier for ethernet index query with valid index', function() {
+        return helper.request().get('/redfish/v1/Systems/bad' + node.id + '/EthernetInterfaces/' + "NIC.Integrated.1-1-1")
+            .expect('Content-Type', /^application\/json/)
+            .expect(404)
+            .expect(function(res) {
+                expect(res.text).contains("Node not Found bad1234abcd1234abcd1234abcd");
+            });
+    });
+
+    it('should 404 a non-Dell identifier for ethernet index query with valid index', function() {
+        return helper.request().get('/redfish/v1/Systems/' + node.id + '/EthernetInterfaces/' + "NIC.Integrated.1-1-1")
+            .expect('Content-Type', /^application\/json/)
+            .expect(404)
+            .expect(function(res) {
+                expect(res.text).contains("No Ethernet found for node " + node.id);
+            });
+    });
+
+    it('should 404 a valid identifier for ethernet index query with invalid index', function() {
+        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/EthernetInterfaces/' + "BADNIC.Integrated.1-1-1")
+            .expect('Content-Type', /^application\/json/)
+            .expect(404)
+            .expect(function(res) {
+                expect(res.text).contains("No Ethernet index found for node " + "BADNIC.Integrated.1-1-1");
+            });
+    });
+
+    it('should return a valid ethernet index block for Dell-based catalog with valid index', function() {
+        waterline.catalogs.findLatestCatalogOfSource.withArgs('DELLabcd1234abcd1234abcd', 'nics').resolves(Promise.resolve({
+            node: 'DELLabcd1234abcd1234abcd',
+            source: 'nics',
+            data: dellCatalogData.nics
+        }));
+        return helper.request().get('/redfish/v1/Systems/' + 'DELLabcd1234abcd1234abcd' + '/EthernetInterfaces/' + 'NIC.Integrated.1-1-1')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200)
+            .expect(function() {
+                expect(tv4.validate.called).to.be.true;
+                expect(validator.validate.called).to.be.true;
+                expect(redfish.render.called).to.be.true;
+            });
     });
 
     it('should return a valid processor list', function() {

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -1069,7 +1069,7 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
   /Systems/{identifier}/EthernetInterfaces:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: systems
     get:
       x-privileges: [ 'Login' ]
       x-authentication-type: [ 'redfish', 'basic' ]
@@ -1077,7 +1077,7 @@ paths:
       description: >
         Defines a collection of ethernet interfaces that are
         present on the system described by identifier
-      operationId: unimplemented
+      operationId: listSystemEthernetInterfaces
       tags: [ "/redfish/v1" ]
       parameters:
         - name: identifier
@@ -1089,7 +1089,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/EthernetInterfaceCollection_EthernetInterfaceCollection"
+            $ref: "#/definitions/EthernetInterfaceCollection.EthernetInterfaceCollection"
         400:
           $ref: "#/responses/status_400"
         401:
@@ -1103,14 +1103,14 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
   /Systems/{identifier}/EthernetInterfaces/{index}:
-    x-swagger-router-controller: unimplemented
+    x-swagger-router-controller: systems
     get:
       x-privileges: [ 'Login' ]
       x-authentication-type: [ 'redfish', 'basic' ]
       summary: Retrieve the ethernet interface by device identifier
       description: >
         Defines an ethernet interface present on the system described by identifier
-      operationId: unimplemented
+      operationId: listSystemEthernetInterfacesById
       tags: [ "/redfish/v1" ]
       parameters:
         - name: identifier
@@ -1126,7 +1126,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/EthernetInterface.1.0.0_EthernetInterface"
+            $ref: "#/definitions/EthernetInterface.v1_2_0.EthernetInterface"
         400:
           $ref: "#/responses/status_400"
         401:
@@ -1579,7 +1579,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/EthernetInterfaceCollection_EthernetInterfaceCollection"
+            $ref: "#/definitions/EthernetInterfaceCollection.EthernetInterfaceCollection"
         400:
           $ref: "#/responses/status_400"
         401:
@@ -1609,7 +1609,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/EthernetInterfaceCollection_EthernetInterfaceCollection"
+            $ref: "#/definitions/EthernetInterfaceCollection.EthernetInterfaceCollection"
         400:
           $ref: "#/responses/status_400"
         401:
@@ -1639,7 +1639,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/EthernetInterface.1.0.0_EthernetInterface"
+            $ref: "#/definitions/EthernetInterface.v1_2_0.EthernetInterface"
         400:
           $ref: "#/responses/status_400"
         401:
@@ -1673,7 +1673,7 @@ paths:
         200:
           description: Success
           schema:
-            $ref: "#/definitions/EthernetInterface.1.0.0_EthernetInterface"
+            $ref: "#/definitions/EthernetInterface.v1_2_0.EthernetInterface"
         400:
           $ref: "#/responses/status_400"
         401:
@@ -2753,7 +2753,7 @@ definitions:
         readOnly: true
         type: string
       EthernetInterfaces:
-        $ref: '#/definitions/EthernetInterfaceCollection_EthernetInterfaceCollection'
+        $ref: '#/definitions/EthernetInterfaceCollection.EthernetInterfaceCollection'
         description: A reference to the collection of Ethernet interfaces associated
           with this system
         readOnly: true
@@ -2987,7 +2987,125 @@ definitions:
     type: object
   Drive.1.1.1_Drive: #TODO
     description: This schema defines a single physical disk
-  EthernetInterface.1.0.0_EthernetInterface:
+  Endpoint.Endpoint:
+    description: This is the schema definition for the Endpoint resource.  It represents
+      the properties of an entity that sends or receives protocol defined messages
+      over a transport.
+    properties:
+      '@odata.context':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.id':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.type':
+        readOnly: true
+        type: string
+      Description:
+        description: Provides a description of this resource and is used for commonality  in
+          the schema definitions.
+        readOnly: true
+      Id:
+        description: Uniquely identifies the resource within the collection of like resources.
+        readOnly: true
+        type: string
+      Name:
+        description: The name of the resource or array element.
+        readOnly: true
+        type: string
+      Oem:
+        $ref: '#/definitions/Resource_Oem'
+        description: This is the manufacturer/provider specific extension moniker
+          used to divide the Oem object into sections.
+    required:
+    - Name
+    - Id
+    type: object
+  EthernetInterface.EthernetInterface:
+    description: Contains the properties needed to describe and configure a single,
+      logical Ethernet Interface.
+    properties:
+      '@odata.context':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.id':
+        format: uri
+        readOnly: true
+        type: string
+      '@odata.type':
+        readOnly: true
+        type: string
+      Description:
+        description: Provides a description of this resource and is used for commonality  in
+          the schema definitions.
+        readOnly: true
+        type: string
+      Id:
+        description: Uniquely identifies the resource within the collection of like resources.
+        readOnly: true
+        type: string
+      Name:
+        description: The name of the resource or array element.
+        readOnly: true
+        type: string
+      Oem:
+        $ref: '#/definitions/Resource_Oem'
+        description: This is the manufacturer/provider specific extension moniker
+          used to divide the Oem object into sections.
+    required:
+    - Name
+    - Id
+    type: object
+  EthernetInterface.v1_0_0.IPv6AddressPolicyEntry:
+    properties:
+      Label:
+        description: The IPv6 Label (as defined in RFC 6724 section 2.1).
+        maximum: 100
+        minimum: 0
+        readOnly: false
+        type: number
+      Precedence:
+        description: The IPv6 Precedence (as defined in RFC 6724 section 2.1.
+        maximum: 100
+        minimum: 1
+        readOnly: false
+        type: number
+      Prefix:
+        description: The IPv6 Address Prefix (as defined in RFC 6724 section 2.1).
+        readOnly: false
+        type: string
+    type: object
+  EthernetInterface.v1_0_0.MACAddress:
+    pattern: ^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$
+    type: string
+  EthernetInterface.v1_1_0.LinkStatus:
+    enum:
+    - LinkUp
+    - NoLink
+    - LinkDown
+    type: string
+  EthernetInterface.v1_1_0.Links:
+    properties:
+      Endpoints:
+        description: An array of references to the endpoints that connect to this
+          ethernet interface.
+        items:
+          $ref: '#/definitions/Endpoint.Endpoint'
+        readOnly: true
+        type: array
+      Endpoints@odata.count:
+        readOnly: true
+        type: number
+      Endpoints@odata.navigationLink:
+        $ref: '#/definitions/odata.4.0.0_idRef'
+      Oem:
+        $ref: '#/definitions/Resource_Oem'
+        description: Oem extension object.
+    type: object
+  EthernetInterface.v1_2_0.EthernetInterface:
     description: This schema defines a simple ethernet NIC resource.
     properties:
       '@odata.context':
@@ -3004,39 +3122,41 @@ definitions:
       AutoNeg:
         description: This indicates if the speed and duplex are automatically negotiated
           and configured on this interface.
+        readOnly: false
         type: boolean
       Description:
-        description: Provides a description of this resource and is used for commonality  in
-          the schema definitions.
+        description: Uniquely identifies the resource within the collection of like
+          resources.
         readOnly: true
         type: string
       FQDN:
         description: This is the complete, fully qualified domain name obtained by
           DNS for this interface.
+        readOnly: false
         type: string
       FullDuplex:
         description: This indicates if the interface is in Full Duplex mode or not.
+        readOnly: false
         type: boolean
       HostName:
-        description: The DNS Host Name, without any domain information
+        description: The DNS Host Name, without any domain information.
+        readOnly: false
         type: string
       IPv4Addresses:
-        description: The IPv4 addresses assigned to this interface
+        description: The IPv4 addresses assigned to this interface.
         items:
-          $ref: '#/definitions/IPAddresses.1.0.0_IPv4Address'
-        readOnly: true
+          $ref: '#/definitions/IPAddresses.v1_0_0.IPv4Address'
         type: array
       IPv6AddressPolicyTable:
-        description: An array representing the RFC3484 Address Selection Policy Table.
+        description: An array representing the RFC 6724 Address Selection Policy Table.
         items:
-          $ref: '#/definitions/EthernetInterface.1.0.0_IPv6AddressPolicyEntry'
+          $ref: '#/definitions/EthernetInterface.v1_0_0.IPv6AddressPolicyEntry'
         type: array
       IPv6Addresses:
         description: This array of objects enumerates all of the currently assigned
           IPv6 addresses on this interface.
         items:
-          $ref: '#/definitions/IPAddresses.1.0.0_IPv6Address'
-        readOnly: true
+          $ref: '#/definitions/IPAddresses.v1_0_0.IPv6Address'
         type: array
       IPv6DefaultGateway:
         description: This is the IPv6 default gateway address that is currently in
@@ -3047,8 +3167,7 @@ definitions:
         description: This array of objects represents all of the IPv6 static addresses
           to be assigned on this interface.
         items:
-          $ref: '#/definitions/IPAddresses.1.0.0_IPv6StaticAddress'
-        readOnly: true
+          $ref: '#/definitions/IPAddresses.v1_0_0.IPv6StaticAddress'
         type: array
       Id:
         description: Uniquely identifies the resource within the collection of like
@@ -3057,15 +3176,25 @@ definitions:
         type: string
       InterfaceEnabled:
         description: This indicates whether this interface is enabled.
+        readOnly: false
         type: boolean
+      LinkStatus:
+        $ref: '#/definitions/EthernetInterface.v1_1_0.LinkStatus'
+        description: The link status of this interface (port).
+        readOnly: true
+      Links:
+        $ref: '#/definitions/EthernetInterface.v1_1_0.Links'
+        description: Contains references to other resources that are related to this
+          resource.
       MACAddress:
+        $ref: '#/definitions/EthernetInterface.v1_0_0.MACAddress'
         description: This is the currently configured MAC address of the (logical
           port) interface.
-        pattern: ^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$
-        type: string
+        readOnly: false
       MTUSize:
         description: This is the currently configured Maximum Transmission Unit (MTU)
           in bytes on this interface.
+        readOnly: false
         type: number
       MaxIPv6StaticAddresses:
         description: This indicates the maximum number of Static IPv6 addresses that
@@ -3074,8 +3203,8 @@ definitions:
         type: number
       Name:
         description: The name of the resource or array element.
-        readOnly: true
         type: string
+        readOnly: true
       NameServers:
         description: This represents DNS name servers that are currently in use on
           this interface.
@@ -3088,69 +3217,46 @@ definitions:
         description: This is the manufacturer/provider specific extension moniker
           used to divide the Oem object into sections.
       PermanentMACAddress:
+        $ref: '#/definitions/EthernetInterface.v1_0_0.MACAddress'
         description: This is the permanent MAC address assigned to this interface
-          (port)
-        pattern: ^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$
+          (port).
         readOnly: true
-        type: string
       SpeedMbps:
         description: This is the current speed in Mbps of this interface.
+        readOnly: false
         type: number
       Status:
         $ref: '#/definitions/Resource_Status'
       UefiDevicePath:
-        description: The UEFI device path for this interface
+        description: The UEFI device path for this interface.
         readOnly: true
         type: string
       VLAN:
-        $ref: '#/definitions/VLanNetworkInterface.1.0.0_VLAN'
+        $ref: '#/definitions/VLanNetworkInterface.v1_0_0.VLAN'
         description: If this Network Interface supports more than one VLAN, this property
           will not be present and the client should look for VLANs collection in the
           link section of this resource.
       VLANs:
-        $ref: '#/definitions/VLanNetworkInterfaceCollection_VLanNetworkInterfaceCollection'
+        $ref: '#/definitions/VLanNetworkInterfaceCollection.VLanNetworkInterfaceCollection'
         description: This is a reference to a collection of VLANs and is only used
           if the interface supports more than one VLANs.
         readOnly: true
+    required:
+    - Name
+    - Id
     type: object
-  EthernetInterface.1.0.0_IPv6AddressPolicyEntry:
+  EthernetInterfaceCollection.EthernetInterfaceCollection:
+    description: A Collection of EthernetInterface resource instances.
     properties:
-      Label:
-        description: The IPv6 Label (as defined in RFC 6724 section 2.1)
-        maximum: 100
-        minimum: 0
-        type: number
-      Precedence:
-        description: The IPv6 Precedence (as defined in RFC 6724 section 2.1
-        maximum: 100
-        minimum: 1
-        type: number
-      Prefix:
-        description: The IPv6 Address Prefix (as defined in RFC 3484 section 2.1)
-        type: string
-    type: object
-  EthernetInterfaceCollection_EthernetInterfaceCollection:
-    properties:
-      '@odata.context':
-        format: uri
-        readOnly: true
-        type: string
-      '@odata.id':
-        format: uri
-        readOnly: true
-        type: string
-      '@odata.type':
-        readOnly: true
-        type: string
       Description:
-        description: Provides a description of this resource and is used for commonality  in
-          the schema definitions.
+        description: Uniquely identifies the resource within the collection of like
+          resources.
         readOnly: true
         type: string
       Members:
         description: Contains the members of this collection.
         items:
-          $ref: '#/definitions/odata.4.0.0_idRef'
+          $ref: '#/definitions/EthernetInterface.EthernetInterface'
         readOnly: true
         type: array
       Members@odata.count:
@@ -3160,8 +3266,8 @@ definitions:
         $ref: '#/definitions/odata.4.0.0_idRef'
       Name:
         description: The name of the resource or array element.
-        readOnly: true
         type: string
+        readOnly: true
       Oem:
         $ref: '#/definitions/Resource_Oem'
         description: This is the manufacturer/provider specific extension moniker
@@ -3367,82 +3473,96 @@ definitions:
         description: Friendly action name
         type: string
     type: object
-  IPAddresses.1.0.0_IPv4Address:
+  IPAddresses.v1_0_0.AddressState:
+    enum:
+    - Preferred
+    - Deprecated
+    - Tentative
+    - Failed
+    type: string
+  IPAddresses.v1_0_0.IPv4Address:
     properties:
       Address:
         description: This is the IPv4 Address.
         pattern: ^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$
+        readOnly: false
         type: string
       AddressOrigin:
+        $ref: '#/definitions/IPAddresses.v1_0_0.IPv4AddressOrigin'
         description: This indicates how the address was determined.
-        enum:
-        - Static
-        - DHCP
-        - BOOTP
-        - IPv4LinkLocal
         readOnly: true
-        type: string
       Gateway:
         description: This is the IPv4 gateway for this address.
+        pattern: ^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$
+        readOnly: false
         type: string
       Oem:
         $ref: '#/definitions/Resource_Oem'
       SubnetMask:
+        $ref: '#/definitions/IPAddresses.v1_0_0.SubnetMask'
         description: This is the IPv4 Subnet mask.
-        pattern: ^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$
-        type: string
+        readOnly: false
     type: object
-  IPAddresses.1.0.0_IPv6Address:
+  IPAddresses.v1_0_0.IPv4AddressOrigin:
+    enum:
+    - Static
+    - DHCP
+    - BOOTP
+    - IPv4LinkLocal
+    type: string
+  IPAddresses.v1_0_0.IPv6Address:
     properties:
       Address:
         description: This is the IPv6 Address.
+        readOnly: false
         type: string
       AddressOrigin:
+        $ref: '#/definitions/IPAddresses.v1_0_0.IPv6AddressOrigin'
         description: This indicates how the address was determined.
-        enum:
-        - Static
-        - DHCPv6
-        - LinkLocal
-        - SLAAC
         readOnly: true
-        type: string
       AddressState:
+        $ref: '#/definitions/IPAddresses.v1_0_0.AddressState'
         description: The current state of this address as defined in RFC 4862.
-        enum:
-        - Preferred
-        - Deprecated
-        - Tentative
-        - Failed
         readOnly: true
-        type: string
       Oem:
         $ref: '#/definitions/Resource_Oem'
       PrefixLength:
+        $ref: '#/definitions/IPAddresses.v1_0_0.PrefixLength'
         description: This is the IPv6 Address Prefix Length.
-        maximum: 128
-        minimum: 1
         readOnly: true
-        type: number
     type: object
-  IPAddresses.1.0.0_IPv6StaticAddress:
+  IPAddresses.v1_0_0.IPv6AddressOrigin:
+    enum:
+    - Static
+    - DHCPv6
+    - LinkLocal
+    - SLAAC
+    type: string
+  IPAddresses.v1_0_0.IPv6StaticAddress:
     description: This object represents a single IPv6 static address to be assigned
       on a network interface.
     properties:
       Address:
         description: A valid IPv6 address.
+        readOnly: false
         type: string
       Oem:
         $ref: '#/definitions/Resource_Oem'
       PrefixLength:
+        $ref: '#/definitions/IPAddresses.v1_0_0.PrefixLength'
         description: The Prefix Length of this IPv6 address.
-        maximum: 128
-        minimum: 1
         readOnly: true
-        type: number
     required:
-    - Address
     - PrefixLength
+    - Address
     type: object
+  IPAddresses.v1_0_0.PrefixLength:
+    maximum: 128
+    minimum: 1
+    type: number
+  IPAddresses.v1_0_0.SubnetMask:
+    pattern: ^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$
+    type: string
   JsonSchemaFile.1.0.0_JsonSchemaFile:
     description: This is the schema definition for the Schema File locator resource.
     properties:
@@ -4053,7 +4173,7 @@ definitions:
         readOnly: true
         type: string
       EthernetInterfaces:
-        $ref: '#/definitions/EthernetInterfaceCollection_EthernetInterfaceCollection'
+        $ref: '#/definitions/EthernetInterfaceCollection.EthernetInterfaceCollection'
         description: This is a reference to a collection of NICs that this manager
           uses for network communication.  It is here that clients will find NIC configuration
           options and settings.
@@ -6404,18 +6524,9 @@ definitions:
       Temperatures@odata.navigationLink:
         $ref: '#/definitions/odata.4.0.0_idRef'
     type: object
-  VLanNetworkInterface.1.0.0_VLAN:
-    properties:
-      VLANEnable:
-        description: This indicates if this VLAN is enabled.
-        type: boolean
-      VLANId:
-        description: This indicates the VLAN identifier for this VLAN.
-        maximum: 4095
-        minimum: 0
-        type: number
-    type: object
-  VLanNetworkInterfaceCollection_VLanNetworkInterfaceCollection:
+  VLanNetworkInterface.VLanNetworkInterface:
+    description: This resource contains information for a Virtual LAN (VLAN) network
+      instance available on a manager, system or other device.
     properties:
       '@odata.context':
         format: uri
@@ -6429,14 +6540,54 @@ definitions:
         readOnly: true
         type: string
       Description:
-        description: Provides a description of this resource and is used for commonality  in
-          the schema definitions.
+        description: Uniquely identifies the resource within the collection of like
+          resources.
+        readOnly: true
+        type: string
+      Id:
+        description: Uniquely identifies the resource within the collection of like
+          resources.
+        readOnly: true
+        type: string
+      Name:
+        description: The name of the resource or array element.
+        readOnly: true
+        type: string
+      Oem:
+        $ref: '#/definitions/Resource_Oem'
+        description: This is the manufacturer/provider specific extension moniker
+          used to divide the Oem object into sections.
+    required:
+    - Name
+    - Id
+    type: object
+  VLanNetworkInterface.v1_0_0.VLAN:
+    properties:
+      VLANEnable:
+        description: This indicates if this VLAN is enabled.
+        readOnly: false
+        type: boolean
+      VLANId:
+        $ref: '#/definitions/VLanNetworkInterface.v1_0_0.VLANId'
+        description: This indicates the VLAN identifier for this VLAN.
+        readOnly: false
+    type: object
+  VLanNetworkInterface.v1_0_0.VLANId:
+    maximum: 4094
+    minimum: 0
+    type: number
+  VLanNetworkInterfaceCollection.VLanNetworkInterfaceCollection:
+    description: A Collection of VLanNetworkInterface resource instances.
+    properties:
+      Description:
+        description: Uniquely identifies the resource within the collection of like
+          resources.
         readOnly: true
         type: string
       Members:
         description: Contains the members of this collection.
         items:
-          $ref: '#/definitions/odata.4.0.0_idRef'
+          $ref: '#/definitions/VLanNetworkInterface.VLanNetworkInterface'
         readOnly: true
         type: array
       Members@odata.count:


### PR DESCRIPTION
* Add support for the following API endpoints:

  GET /redfish/v1/Systems/identifier/EthernetInterfaces
  GET /redfish/v1/Systems/identifier/EthernetInterfaces/index

* Add redfish 2016.3 schema into redfish.yaml definition

* npm tests added

* Fix manager.js and systems.js to share ethernet interface
  rendering files.  Pass through necessary context info
  in options block.