### PR TITLE
Make skip reboot after discovery optional:

### DIFF
--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -143,6 +143,10 @@ function profileApiServiceFactory(
             configuration = self.getSwitchDiscoveryConfiguration(node, options.switchVendor);
         } else {
             var setObm = configFile.get('autoCreateObm', 'false');
+            var skipReboot = configFile.get('skipResetPostDiscovery', 'false');
+            if (setObm === 'true') {
+                skipReboot = 'true';
+            }
             var skipPollers = configFile.get('skipPollersCreation', 'false');
             configuration = {
                 name: configFile.get('discoveryGraph', 'Graph.SKU.Discovery'),
@@ -151,7 +155,7 @@ function profileApiServiceFactory(
                         graphOptions: {
                             target: node.id,
                             'skip-reboot-post-discovery' : {
-                                 skipReboot: setObm,
+                                 skipReboot: skipReboot,
                             }
                         },
                         nodeId: node.id

--- a/spec/lib/services/profiles-api-service-spec.js
+++ b/spec/lib/services/profiles-api-service-spec.js
@@ -234,6 +234,7 @@ describe("Http.Services.Api.Profiles", function () {
         this.sandbox.stub(profileApiService, 'waitForDiscoveryStart').resolves();
         this.sandbox.stub(configuration, 'get').withArgs('discoveryGraph')
             .returns('from.config.graph');
+        configuration.get.withArgs('skipResetPostDiscovery').returns('false');
         configuration.get.withArgs('autoCreateObm').returns('false');
         configuration.get.withArgs('skipPollersCreation').returns('false');
         return profileApiService.runDiscovery(node)


### PR DESCRIPTION
- Adding a new flag in the config file skipResetPostDiscovery