### PR TITLE
RAC-4625: adding username complexity checking on account create

### DIFF
--- a/spec/lib/api/2.0/users-spec.js
+++ b/spec/lib/api/2.0/users-spec.js
@@ -298,4 +298,36 @@ describe('Http.Api.Users', function () {
                     .expect(401);
             });
     });
+
+    it('should 400 a bad username with spaces post without access', function() {
+        accountService.listUsers.resolves([ userObj ]);
+        return helper.request().post('/login')
+            .send({username: "read only", password: "read123"})
+            .expect(201)
+            .then(function(res) {
+                return res.body.token;
+            }).then(function(token) {
+                return helper.request().post('/api/2.0/users')
+                    .set("authorization", 'JWT ' + token)
+                    .send(readOnlyObj)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(400);
+            });
+    });
+
+    it('should 400 a bad username starting with digit post without access', function() {
+        accountService.listUsers.resolves([ userObj ]);
+        return helper.request().post('/login')
+            .send({username: "1readonly", password: "read123"})
+            .expect(201)
+            .then(function(res) {
+                return res.body.token;
+            }).then(function(token) {
+                return helper.request().post('/api/2.0/users')
+                    .set("authorization", 'JWT ' + token)
+                    .send(readOnlyObj)
+                    .expect('Content-Type', /^application\/json/)
+                    .expect(400);
+            });
+    });
 });

--- a/spec/lib/api/2.0/users-spec.js
+++ b/spec/lib/api/2.0/users-spec.js
@@ -302,14 +302,14 @@ describe('Http.Api.Users', function () {
     it('should 400 a bad username with spaces post without access', function() {
         accountService.listUsers.resolves([ userObj ]);
         return helper.request().post('/login')
-            .send({username: "read only", password: "read123"})
-            .expect(201)
+            .send({username: "admin", password: "admin123"})
+            .expect(200)
             .then(function(res) {
                 return res.body.token;
             }).then(function(token) {
                 return helper.request().post('/api/2.0/users')
                     .set("authorization", 'JWT ' + token)
-                    .send(readOnlyObj)
+                    .send({username: "read only", password: "read123"})
                     .expect('Content-Type', /^application\/json/)
                     .expect(400);
             });
@@ -318,14 +318,14 @@ describe('Http.Api.Users', function () {
     it('should 400 a bad username starting with digit post without access', function() {
         accountService.listUsers.resolves([ userObj ]);
         return helper.request().post('/login')
-            .send({username: "1readonly", password: "read123"})
-            .expect(201)
+            .send({username: "admin", password: "admin123"})
+            .expect(200)
             .then(function(res) {
                 return res.body.token;
             }).then(function(token) {
                 return helper.request().post('/api/2.0/users')
                     .set("authorization", 'JWT ' + token)
-                    .send(readOnlyObj)
+                    .send({username: "1readonly", password: "read123"})
                     .expect('Content-Type', /^application\/json/)
                     .expect(400);
             });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -398,6 +398,7 @@ definitions:
         type: string
       username:
         type: string
+        pattern: ^[A-Za-z][0-9A-Za-z._-]+$
   workflow_graph:
     properties:
       friendlyName:

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -4415,6 +4415,7 @@ definitions:
       UserName:
         description: This property contains the user name for the account.
         type: string
+        pattern: '^[A-Za-z][A-Za-z0-9._-]+$'
     type: object
   ManagerAccount.1.0.0_ManagerAccount.post:
     allOf:


### PR DESCRIPTION
Adding bare minimum account username complexity checking on account creation for both APIs.
As it stands now, accounts can be created with a single space, for example.
Change necessitates that usernames begin with a letter, followed by any number of letters, numbers, hyphens, periods, and underscores.