### PR TITLE
RAC-4626: returning correct resp code for duplicate account

### DIFF
--- a/lib/api/2.0/users.js
+++ b/lib/api/2.0/users.js
@@ -33,15 +33,11 @@ var addUser = controller({success: 201}, function(req, res) {
             });
         }
 
-        if( !_.find(users, function(user) {
-            return user.username === userObj.username;
-        })) {
-            if( req.isAuthenticated && req.isAuthenticated() ) {
-                return accountService.createUser(userObj)
-                .then(function(user) {
-                    return _.pick(user, ['username', 'role']);
-                });
-            }
+        if( req.isAuthenticated && req.isAuthenticated() ) {
+            return accountService.createUser(userObj)
+            .then(function(user) {
+                return _.pick(user, ['username', 'role']);
+            });
         }
 
         throw new Errors.UnauthorizedError('Unauthorized');

--- a/lib/api/redfish-1.0/account-service.js
+++ b/lib/api/redfish-1.0/account-service.js
@@ -76,23 +76,19 @@ var createAccount = controller({success: 201}, function(req, res) {
         if(!users.length && localUserException && res.locals.ipAddress === '127.0.0.1') {
             // Only when there are no users, and the remote is a local connection, and we 
             // permit it, then let them add the first user.
-            return accountService.createUser({ 
+            return accountService.createUser({
                 username: payload.UserName,
                 password: payload.Password,
                 role: payload.RoleId
             });
         }
 
-        if( !_.find(users, function(user) {
-            return user.username === payload.UserName;
-        })) {
-            if( req.isAuthenticated && req.isAuthenticated() ) {
-                return accountService.createUser({ 
-                    username: payload.UserName,
-                    password: payload.Password,
-                    role: payload.RoleId
-                });
-            }
+        if( req.isAuthenticated && req.isAuthenticated() ) {
+            return accountService.createUser({ 
+                username: payload.UserName,
+                password: payload.Password,
+                role: payload.RoleId
+            });
         }
         throw new Errors.UnauthorizedError('Unauthorized');
     })

--- a/spec/lib/api/2.0/users-spec.js
+++ b/spec/lib/api/2.0/users-spec.js
@@ -298,4 +298,5 @@ describe('Http.Api.Users', function () {
                     .expect(401);
             });
     });
+
 });

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -4168,6 +4168,10 @@ paths:
           description: Forbidden
           schema:
             type: object
+        409:
+          description: Conflict
+          schema:
+            type: object
         default:
           description: Unexpected error
           schema:

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -1274,6 +1274,8 @@ paths:
           $ref: "#/responses/status_403"
         404:
           $ref: "#/responses/status_404"
+        409:
+          $ref: "#/responses/status_409"
         500:
           description: Error
           schema:


### PR DESCRIPTION
Currently we are returning 401 Unauthorized responses when attempting to create an account user that already exists. This change returns a 409 'user already exists' message instead for both Redfish and v2.0 APIs.