### PR TITLE
RAC-5241 Can't perform node rediscovery using post /workflows O

### DIFF
--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -110,6 +110,7 @@ function workflowApiServiceFactory(
             }
         })
         .then(function(graphs) {
+
             return _.first(graphs);
         });
     };

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -110,7 +110,6 @@ function workflowApiServiceFactory(
             }
         })
         .then(function(graphs) {
-
             return _.first(graphs);
         });
     };

--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -110,7 +110,6 @@ function workflowApiServiceFactory(
             }
         })
         .then(function(graphs) {
-            assert.ok(graphs.length === 0 || graphs.length === 1);
             return _.first(graphs);
         });
     };


### PR DESCRIPTION
This PR is to remove the graph length( 0 or 1) check( so that we have able to execute a graph that have a graph within it. 
The rediscovery graph length is 2 and it will fail with the check is place. 
