### PR TITLE
RAC-4700

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -196,6 +196,9 @@ var selTranslator = function(selArray, identifier) {
     return Promise.map(selArray, function(entry) {
         var dates = dateRegex.exec(entry.date);
         var times = timeRegex.exec(entry.time);
+        if(entry.sensorNumber.indexOf('#') !== 0) {
+            entry.sensorNumber = '#'+entry.sensorNumber;
+        }
         return Promise.props({
             logId: entry.logId,
             // Month is zero indexed by moment so we must decrement

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -1053,6 +1053,39 @@ describe('Redfish Systems Root', function () {
             });
     });
 
+    it('should return a valid sel log service entry despite no #', function() {
+        wsman.isDellSystem.withArgs('1234abcd1234abcd1234abcd').resolves({
+            node: node, isDell: false, isRedfishCapable: false
+        });
+
+        waterline.nodes.find.resolves([node]);
+        waterline.workitems.findPollers.resolves([{
+            config: { command: 'sel' }
+        }]);
+
+        taskProtocol.requestPollerCache.resolves([{
+            sel: [{
+                logId: 'abcd',
+                value: 'Assert',
+                sensorType: 'Temperature',
+                event: 'Thermal Event',
+                sensorNumber: '1',
+                date: '01/01/1970',
+                time: '01:01:01'
+            }]
+        }]);
+
+        return helper.request().get('/redfish/v1/Systems/' + node.id +
+                                    '/LogServices/sel/Entries/abcd')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200)
+            .expect(function() {
+                expect(tv4.validate.called).to.be.true;
+                expect(validator.validate.called).to.be.true;
+                expect(redfish.render.called).to.be.true;
+            });
+    });
+
     it('should return a valid iDrac sel log service entry', function() {
         wsman.isDellSystem.withArgs('1234abcd1234abcd1234abcd').resolves({
             node: node, isDell: true, isRedfishCapable: false


### PR DESCRIPTION
* Fixed 500 error due to bad SEL parsing
* Checks entry.sensorNumber to start with '#' and adds it if missing.
This is because the # is expected and popped of in the code