### PR TITLE
Create SoftwareInventory route, tweak existing Firmware code/view, unit-test fixes

### DIFF
--- a/data/views/redfish-1.0/redfish.1.0.0.softwareinventorycollection.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.softwareinventorycollection.json
@@ -8,7 +8,7 @@
     "Members": [
         <% fwItems.forEach(function(fwItem, i, arr) { %>
 {
-    "@odata.id": "<%= basepath %>/UpdateService/FirmwareInventory/<%=fwItem %>"
+    "@odata.id": "<%=url%>/<%=fwItem %>"
 }
 <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
 <% }); %>

--- a/lib/api/redfish-1.0/update-service.js
+++ b/lib/api/redfish-1.0/update-service.js
@@ -214,7 +214,6 @@ var getInventoryById = controller({success: 201}, function (req, res) {
 function getVersions(url) {
     var nodesProcessed = {};
     var allFwCollections = {};
-    var updatedCollections = {};
     var matchComponent = '';
     url.indexOf("FirmwareInventory")!== -1 ? matchComponent="FIRMWARE":matchComponent="APPLICATION";
     return new Promise.resolve()
@@ -229,7 +228,7 @@ function getVersions(url) {
             _.mapKeys(fwCollections, function (value, key) {
                 //NOTE:Ternary operatory is to include "BIOS" componentType under FIRMWARE. Also, checking if value has componentType key before updating the entry.
                 if ((matchComponent==="APPLICATION"?_.filter(value, _.matches({componentType: "APPLICATION"})).length === 0 : _.filter(value, _.matches({componentType: "APPLICATION"})).length !== 0 )
-                    && _.findIndex(value, 'componentType')!=-1) {
+                    && _.findIndex(value, 'componentType')!==-1) {
                     delete updatedCollections[key];
                 }
             });

--- a/lib/api/redfish-1.0/update-service.js
+++ b/lib/api/redfish-1.0/update-service.js
@@ -86,10 +86,10 @@ var updateFirmware = controller({success: 201}, function (req, res) {
         });
 });
 
-var getFirmwareInventoryList = controller({success: 201}, function (req, res) {
+var getInventoryList = controller({success: 201}, function (req, res) {
     var options = redfish.makeOptions(req, res);
 
-    return getFirmwareVersions()
+    return getVersions(options.url)
         .then(function (allFwCollections) {
             options.fwItems = Object.keys(allFwCollections);
             return redfish.render('redfish.1.0.0.softwareinventorycollection.json',
@@ -101,7 +101,7 @@ var getFirmwareInventoryList = controller({success: 201}, function (req, res) {
         });
 });
 
-var getFirmwareInventoryById = controller({success: 201}, function (req, res) {
+var getInventoryById = controller({success: 201}, function (req, res) {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res);
     var pathsLookups = {
@@ -192,7 +192,7 @@ var getFirmwareInventoryById = controller({success: 201}, function (req, res) {
     };
     options.elementInfo= pathsLookups[identifier.split('-')[0]];
 
-    return getFirmwareVersions()
+    return getVersions(options.url)
         .then(function (allFwCollections) {
             var relatedItems = allFwCollections[identifier];
             if (options.elementInfo["base"]=== "/Chassis/"){
@@ -211,10 +211,12 @@ var getFirmwareInventoryById = controller({success: 201}, function (req, res) {
         });
 });
 
-function getFirmwareVersions() {
+function getVersions(url) {
     var nodesProcessed = {};
     var allFwCollections = {};
-
+    var updatedCollections = {};
+    var matchComponent = '';
+    url.indexOf("FirmwareInventory")!== -1 ? matchComponent="FIRMWARE":matchComponent="APPLICATION";
     return new Promise.resolve()
         .then(function () {
             return getLatestCatalogs(nodesProcessed, ["racadm-firmware-list-catalog"]);
@@ -223,7 +225,15 @@ function getFirmwareVersions() {
             return getFwCollections(fwTypeKeywords, catalogs);
         })
         .then(function (fwCollections) {
-            _.merge(allFwCollections, fwCollections);
+            var updatedCollections = fwCollections;
+            _.mapKeys(fwCollections, function (value, key) {
+                //NOTE:Ternary operatory is to include "BIOS" componentType under FIRMWARE. Also, checking if value has componentType key before updating the entry.
+                if ((matchComponent==="APPLICATION"?_.filter(value, _.matches({componentType: "APPLICATION"})).length === 0 : _.filter(value, _.matches({componentType: "APPLICATION"})).length !== 0 )
+                    && _.findIndex(value, 'componentType')!=-1) {
+                    delete updatedCollections[key];
+                }
+            });
+            _.merge(allFwCollections, updatedCollections);
             return getLatestCatalogs(nodesProcessed, ["dmi", "ipmi-mc-info", "smart"]);
         })
         .then(function (catalogs) {
@@ -287,7 +297,8 @@ function getFwCollections(fwTypeKeywords, catalogs) {
                             FWType = prefix + '-' + element["currentVersion"];
                             entry = {
                                 "FQDD": element["FQDD"],
-                                "node": source["node"]
+                                "node": source["node"],
+                                "componentType": element.componentType
                             };
                             if (fwTypes[FWType] === undefined) {
                                 fwTypes[FWType] = [entry];
@@ -367,6 +378,6 @@ function updateChassisIds(elements) {
 
 module.exports = {
     updateFirmware: updateFirmware,
-    getFirmwareInventoryList: getFirmwareInventoryList,
-    getFirmwareInventoryById: getFirmwareInventoryById
+    getInventoryList: getInventoryList,
+    getInventoryById: getInventoryById
 };

--- a/spec/lib/api/redfish-1.0/update-service-spec.js
+++ b/spec/lib/api/redfish-1.0/update-service-spec.js
@@ -33,7 +33,8 @@ describe('Redfish Update Service', function () {
                 "installationDate": "2016-08-31T04:18:55Z",
                 "currentVersion": "00.24.7A",
                 "rollbackVersion": "",
-                "availableVersion": ""
+                "availableVersion": "",
+                "componentType": "FIRMWARE"
             },
             "PSU2": {
                 "elementName": "Power Supply.Slot.2",
@@ -41,7 +42,8 @@ describe('Redfish Update Service', function () {
                 "installationDate": "2017-03-10T08:24:14Z",
                 "currentVersion": "00.24.7A",
                 "rollbackVersion": "",
-                "availableVersion": ""
+                "availableVersion": "",
+                "componentType": "FIRMWARE"
             },
             "iDRAC": {
                 "elementName": "Integrated Remote Access Controller",
@@ -49,17 +51,20 @@ describe('Redfish Update Service', function () {
                 "installationDate": "2017-03-30T09:10:51Z",
                 "currentVersion": "2.40.40.40",
                 "rollbackVersion": "2.30.30.30",
-                "availableVersion": ""
+                "availableVersion": "",
+                "componentType": "FIRMWARE"
             },
             "NIC1": {
                 "elementName": "Intel(R) Gigabit 4P X520/I350 rNDC - 24:6E:96:1F:51:8D",
                 "currentVersion": "21.1",
-                "FQDD": "NIC.Integrated.1-4-1"
+                "FQDD": "NIC.Integrated.1-4-1",
+                "componentType": "APPLICATION"
             },
             "NIC2": {
                 "elementName": "Intel(R) Gigabit 4P X520/I350 rNDC - 24:6E:96:1F:51:8c",
                 "currentVersion": "21.1",
-                "FQDD": "NIC.Integrated.1-4-2"
+                "FQDD": "NIC.Integrated.1-4-2",
+                "componentType": "APPLICATION"
             }
         }
     };
@@ -253,6 +258,7 @@ describe('Redfish Update Service', function () {
             });
     });
 
+
     it('should return a valid list of Firmware Inventory from RACADM catalog', function () {
         waterline.catalogs.find.resolves([mockCatalogRACADM]);
         waterline.catalogs.findMostRecent.resolves(mockCatalogRACADM);
@@ -261,13 +267,11 @@ describe('Redfish Update Service', function () {
             .expect('Content-Type', /^application\/json/)
             .expect(201)
             .expect(function(res) {
-                expect(res.body['Members@odata.count']).to.equal(3);
+                expect(res.body['Members@odata.count']).to.equal(2);
                 expect(res.body.Members[0]['@odata.id'])
                     .to.equal("/redfish/v1/UpdateService/FirmwareInventory/PSU-00.24.7A");
                 expect(res.body.Members[1]['@odata.id'])
                     .to.equal("/redfish/v1/UpdateService/FirmwareInventory/iDRAC-2.40.40.40");
-                expect(res.body.Members[2]['@odata.id'])
-                    .to.equal("/redfish/v1/UpdateService/FirmwareInventory/NIC-21.1");
             });
     });
 
@@ -328,23 +332,6 @@ describe('Redfish Update Service', function () {
                     .to.equal("/redfish/v1/Chassis/593accd15a45b5dd76e24adf/Power#/PowerSupplies/1");
             });
     });
-
-    it('should return a valid root to RACADM Firmware Inventory by Id (enumeratable Entity)', function () {
-        waterline.catalogs.find.resolves([mockCatalogRACADM]);
-        waterline.catalogs.findMostRecent.resolves(mockCatalogRACADM);
-        waterline.nodes.findByIdentifier.resolves(node1);
-        return helper.request().get('/redfish/v1/UpdateService/FirmwareInventory/NIC-21.1')
-            .expect('Content-Type', /^application\/json/)
-            .expect(201)
-            .expect(function(res) {
-                expect(res.body.RelatedItem.length).to.equal(2);
-                expect(res.body.RelatedItem[0]['@odata.id'])
-                    .to.equal("/redfish/v1/Systems/593acc7e5aa5beed6f1f3082/EthernetInterfaces/NIC.Integrated.1-4-1");
-                expect(res.body.RelatedItem[1]['@odata.id'])
-                    .to.equal("/redfish/v1/Systems/593acc7e5aa5beed6f1f3082/EthernetInterfaces/NIC.Integrated.1-4-2");
-            });
-    });
-
     it('should return a valid root to RACADM Firmware Inventory by Id (Non enumeratable Entity)', function () {
         waterline.catalogs.find.resolves([mockCatalogRACADM]);
         waterline.catalogs.findMostRecent.resolves(mockCatalogRACADM);
@@ -398,6 +385,49 @@ describe('Redfish Update Service', function () {
                 expect(res.body.RelatedItem.length).to.equal(1);
                 expect(res.body.RelatedItem[0]['@odata.id'])
                     .to.equal("/redfish/v1/Systems/5947d2cfe6b9b3e113d81984/SimpleStorage/");
+            });
+    });
+
+    it('should return a valid list of Software Inventory from RACADM catalog', function () {
+        waterline.catalogs.find.resolves([mockCatalogRACADM]);
+        waterline.catalogs.findMostRecent.resolves(mockCatalogRACADM);
+        waterline.nodes.findByIdentifier.resolves(node1);
+        return helper.request().get('/redfish/v1/UpdateService/SoftwareInventory')
+            .expect('Content-Type', /^application\/json/)
+            .expect(201)
+            .expect(function(res) {
+                expect(res.body['Members@odata.count']).to.equal(1);
+                expect(res.body.Members[0]['@odata.id'])
+                    .to.equal("/redfish/v1/UpdateService/SoftwareInventory/NIC-21.1");
+            });
+    });
+
+
+    it('should return a valid list of Software Inventory from DMI catalog', function () {
+        waterline.catalogs.find.resolves([mockCatalogDMI]);
+        waterline.catalogs.findMostRecent.resolves(mockCatalogDMI);
+        waterline.nodes.findByIdentifier.resolves(node2);
+        return helper.request().get('/redfish/v1/UpdateService/SoftwareInventory')
+            .expect('Content-Type', /^application\/json/)
+            .expect(201)
+            .expect(function(res) {
+                expect(res.body['Members@odata.count']).to.equal(1);
+                expect(res.body.Members[0]['@odata.id'])
+                    .to.equal("/redfish/v1/UpdateService/SoftwareInventory/BIOS-S2S_3A14");
+            });
+    });
+
+    it('should return a valid root to RACADM Software Inventory by Id (Non enumeratable Entity)', function () {
+        waterline.catalogs.find.resolves([mockCatalogRACADM]);
+        waterline.catalogs.findMostRecent.resolves(mockCatalogRACADM);
+        waterline.nodes.findByIdentifier.resolves(node1);
+        return helper.request().get('/redfish/v1/UpdateService/SoftwareInventory/NIC-21.1')
+            .expect('Content-Type', /^application\/json/)
+            .expect(201)
+            .expect(function(res) {
+                expect(res.body.RelatedItem.length).to.equal(2);
+                expect(res.body.RelatedItem[0]['@odata.id'])
+                    .to.equal("/redfish/v1/Systems/593acc7e5aa5beed6f1f3082/EthernetInterfaces/NIC.Integrated.1-4-1");
             });
     });
 

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -2343,7 +2343,7 @@ paths:
       x-privileges: [ 'Login' ]
       x-authentication-type: [ 'redfish', 'basic' ]
       summary: get a list of firmware installed on all nodes managed by this instance of RackHD
-      operationId: getFirmwareInventoryList
+      operationId: getInventoryList
       tags: [ "/redfish/v1" ]
       parameters:
         - name: payload
@@ -2373,7 +2373,67 @@ paths:
       x-privileges: [ 'Login' ]
       x-authentication-type: [ 'redfish', 'basic' ]
       summary: retrieve information about a specific firmware
-      operationId: getFirmwareInventoryById
+      operationId: getInventoryById
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          type: string
+          description: node identifier
+      responses:
+        201:
+          description: Success
+          $ref: "#/responses/status_201"
+        400:
+          $ref: "#/responses/status_400"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        404:
+          $ref: "#/responses/status_404"
+        500:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /UpdateService/SoftwareInventory:
+    x-swagger-router-controller: update-service
+    get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: get a list of firmware installed on all nodes managed by this instance of RackHD
+      operationId: getInventoryList
+      tags: [ "/redfish/v1" ]
+      parameters:
+        - name: payload
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/UpdateService.1.0.0_UpdateService"
+      responses:
+        201:
+          description: Success
+          $ref: "#/responses/status_201"
+        400:
+          $ref: "#/responses/status_400"
+        401:
+          $ref: "#/responses/status_401"
+        403:
+          $ref: "#/responses/status_403"
+        404:
+          $ref: "#/responses/status_404"
+        500:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"
+  /UpdateService/SoftwareInventory/{identifier}:
+    x-swagger-router-controller: update-service
+    get:
+      x-privileges: [ 'Login' ]
+      x-authentication-type: [ 'redfish', 'basic' ]
+      summary: retrieve information about a specific firmware
+      operationId: getInventoryById
       tags: [ "/redfish/v1" ]
       parameters:
         - name: identifier


### PR DESCRIPTION
Add UpdateService/SoftwareInventory route, and tweaked existing code to make it common for both Firmware/Software, and RACADM catalog has both "FIRMWARE" and "APPLICATION" type of components.

@dalebremner @RackHD/corecommitters 