### PR TITLE
 Add IP address information to notification events

### DIFF
--- a/lib/api/2.0/notification.js
+++ b/lib/api/2.0/notification.js
@@ -9,8 +9,9 @@ var _ = injector.get('_');    // jshint ignore:line
 var parser = require('body-parser');
 var Promise = injector.get('Promise');
 
-var notificationPost = controller({success: 201}, function(req) {
+var notificationPost = controller({success: 201}, function(req, res) {
     var message = _.defaults(req.swagger.query || {}, req.query || {}, req.body || {});
+    message.nodeIp = res.locals.ipAddress;
     return notificationApiService.postNotification(message);
 });
 

--- a/spec/lib/api/2.0/notification-spec.js
+++ b/spec/lib/api/2.0/notification-spec.js
@@ -44,6 +44,8 @@ describe('Http.Api.Notification', function () {
 
     describe('POST /notification', function () {
         it('should return node notification detail', function () {
+            var _nodeNotificationMessage = _.cloneDeep(nodeNotificationMessage);
+            _nodeNotificationMessage.nodeIp = '127.0.0.1';
             return helper.request('http://localhost:8091')
             .post('/api/2.0/notification?nodeId=' +
                   nodeNotificationMessage.nodeId +
@@ -55,10 +57,12 @@ describe('Http.Api.Notification', function () {
             .then(function () {
                 expect(notificationApiService.postNodeNotification).to.have.been.calledOnce;
                 expect(notificationApiService.postNodeNotification)
-                    .to.have.been.calledWith(nodeNotificationMessage);
+                    .to.have.been.calledWith(_nodeNotificationMessage);
             });
         });
         it('should return broadcast notification detail', function () {
+            var _broadcastNotificationMessage = _.cloneDeep(broadcastNotificationMessage);
+            _broadcastNotificationMessage.nodeIp = '127.0.0.1';
             return helper.request('http://localhost:8091')
             .post('/api/2.0/notification')
             .send(broadcastNotificationMessage)
@@ -68,7 +72,7 @@ describe('Http.Api.Notification', function () {
             .then(function () {
                 expect(notificationApiService.postBroadcastNotification).to.have.been.calledOnce;
                 expect(notificationApiService.postBroadcastNotification)
-                    .to.have.been.calledWith(broadcastNotificationMessage);
+                    .to.have.been.calledWith(_broadcastNotificationMessage);
             });
         });
         it('should pass with nodeId in query body', function () {


### PR DESCRIPTION
1. Why we need to get node IP:
RackHD needs to access http service on a compute node in  diag related tasks with node IP. The normal way to get IP/MAC from lookups can't work because lookups may contain more than one IPs that are legacy and incorrect. 

2. How this feature is implemented:
Retried node IP in on-http and add IP into notification AMQP messages => Install OS job retrieve IP from AMQP message and add it to graph context => following jobs to retrieve IP from graph context.

Jenkins depends on: https://github.com/RackHD/on-tasks/pull/470