### PR TITLE
OBM Settings Object Update

### DIFF
--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -211,9 +211,12 @@ definitions:
         type: object
       service:
         type: string
+      nodeId:
+        type: string
     required:
     - service
     - config
+    - nodeId
     type: object
   obm_led:
     properties:


### PR DESCRIPTION
The node Id was missing for the appropriate OBM Settings update call to work, this generates the correc object as consumed by the Monorail API