### PR TITLE
clean up unit-test errors when it timeouts

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -21,6 +21,27 @@ global.onHttpContext = index.onHttpContextFactory();
 // Legacy
 global.dihelper = onHttpContext.helper;
 
+helper.httpServerBefore = function(overrides, endpointOpt) {
+    before('helper.httpServer.before', function() {
+        this.timeout(10000);
+        return helper.startServer(overrides, endpointOpt);
+    });
+
+    beforeEach(function () {
+        this.sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        this.sandbox.restore();
+    });
+};
+
+helper.httpServerAfter = function() {
+    after('helper.httpServer.after', function() {
+        return helper.stopServer();
+    });
+};
+
 helper.startServer = function (overrides, endpointOpt) {
     overrides = (overrides || []).concat([
         onHttpContext.helper.simpleWrapper({
@@ -64,7 +85,9 @@ helper.startServer = function (overrides, endpointOpt) {
 };
 
 helper.stopServer = function () {
-    return helper.injector.get('app').stop();
+    if (helper.injector) {
+        return helper.injector.get('app').stop();
+    }
 };
 
 helper.request = function (url, options) {

--- a/spec/lib/api/2.0/catalogs-spec.js
+++ b/spec/lib/api/2.0/catalogs-spec.js
@@ -9,32 +9,23 @@ describe('2.0 Http.Api.Catalogs', function () {
     var Errors;
     var stubNeedByIdentifier;
     var stubFind;
+    var waterline;
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer([]).then(function () {
-            Promise = helper.injector.get('Promise');
-            Errors = helper.injector.get('Errors');
-            var w = helper.injector.get('Services.Waterline');
-            stubNeedByIdentifier = sinon.stub(w.catalogs, "needByIdentifier");
-            stubFind = sinon.stub(w.catalogs, "find");
-        });
-    });
+    helper.httpServerBefore();
 
-    beforeEach('loading views', function(){
+    before(function () {
+        Promise = helper.injector.get('Promise');
+        Errors = helper.injector.get('Errors');
+        waterline = helper.injector.get('Services.Waterline');
         return helper.injector.get('Views').load();
     });
 
-    afterEach("reset stubs", function() {
-        stubFind.reset();
-        stubNeedByIdentifier.reset();
+    beforeEach('set up mocks', function() {
+        stubNeedByIdentifier = this.sandbox.stub(waterline.catalogs, "needByIdentifier");
+        stubFind = this.sandbox.stub(waterline.catalogs, "find");
     });
 
-    after('stop HTTP server', function () {
-        stubFind.restore();
-        stubNeedByIdentifier.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe("GET /catalogs", function() {
 

--- a/spec/lib/api/2.0/config-spec.js
+++ b/spec/lib/api/2.0/config-spec.js
@@ -5,25 +5,19 @@
 
 describe('Http.Api.Config v2.0', function () {
     var configuration;
-    before('start HTTP server', function () {
-        this.timeout(10000);
-        return helper.startServer().then(function() {
-            configuration = helper.injector.get('Services.Configuration');
-            sinon.stub(configuration, 'set').returns(configuration);
-            sinon.stub(configuration, 'getAll').returns({});
-        });
+
+    helper.httpServerBefore();
+
+    before(function () {
+        configuration = helper.injector.get('Services.Configuration');
     });
 
-    afterEach('tear down mocks', function () {
-        configuration.set.reset();
-        configuration.getAll.reset();
+    beforeEach('set up mocks', function() {
+        this.sandbox.stub(configuration, 'set').returns(configuration);
+        this.sandbox.stub(configuration, 'getAll').returns({});
     });
 
-    after('stop HTTP server', function () {
-        configuration.set.restore();
-        configuration.getAll.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return configuration', function () {
         return helper.request().get('/api/2.0/config')

--- a/spec/lib/api/2.0/files-spec.js
+++ b/spec/lib/api/2.0/files-spec.js
@@ -8,11 +8,12 @@ describe('Http.Api.Internal.Files', function () {
     var badFilename = "RackHD_Rulez";
     var badUuid = "617";
 
-    before('start HTTP server and add file', function () {
-        this.timeout(10000);
+    helper.httpServerBefore();
 
-        return helper.startServer([]).then(function () {
-            Promise = helper.injector.get('Promise');
+    before('add file', function () {
+        var Promise = helper.injector.get('Promise');
+
+        return Promise.try(function () {
             return helper.request().get('/api/2.0/files');
         }).then(function (res) {
             return Promise.map(res.body, function (file) {
@@ -33,9 +34,7 @@ describe('Http.Api.Internal.Files', function () {
         });
     });
 
-    after('stop HTTP server', function () {
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe('GET /files/{fileidentifier}', function () {
         it('should get file by name', function () {

--- a/spec/lib/api/2.0/hooks-spec.js
+++ b/spec/lib/api/2.0/hooks-spec.js
@@ -11,29 +11,21 @@ describe('Http.Api.Hooks v2.0', function () {
         id: "testid",
         filters: []
     }];
-    var sandbox = sinon.sandbox.create();
-    before('start HTTP server', function () {
-        this.timeout(10000);
-        return helper.startServer([])
-        .then(function() {
-            hookService = helper.injector.get('Http.Services.Api.Hooks');
-            Errors = helper.injector.get('Errors');
-            _ = helper.injector.get('_');
-            hookPayload = _.omit(hookSample[0], 'id');
-        });
+
+    helper.httpServerBefore();
+
+    before(function () {
+        hookService = helper.injector.get('Http.Services.Api.Hooks');
+        Errors = helper.injector.get('Errors');
+        _ = helper.injector.get('_');
+        hookPayload = _.omit(hookSample[0], 'id');
     });
 
-    afterEach('tear down mocks', function () {
-        sandbox.restore();
-    });
-
-    after('stop HTTP server', function () {
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return hooks', function () {
         var hookList = _.cloneDeep(hookSample);
-        sandbox.stub(hookService, 'getHooks').resolves(hookList);
+        this.sandbox.stub(hookService, 'getHooks').resolves(hookList);
         return helper.request()
             .get('/api/2.0/hooks')
             .expect('Content-Type', /^application\/json/)
@@ -46,7 +38,7 @@ describe('Http.Api.Hooks v2.0', function () {
 
     it('should return hook by id', function () {
         var hook = _.cloneDeep(hookSample[0]);
-        sandbox.stub(hookService, 'getHookById').resolves(hook);
+        this.sandbox.stub(hookService, 'getHookById').resolves(hook);
         return helper.request()
             .get('/api/2.0/hooks/test')
             .expect('Content-Type', /^application\/json/)
@@ -59,7 +51,7 @@ describe('Http.Api.Hooks v2.0', function () {
 
     it('should post new hooks', function () {
         var hookList = _.cloneDeep(hookSample[0]);
-        sandbox.stub(hookService, 'createHook').resolves(hookList);
+        this.sandbox.stub(hookService, 'createHook').resolves(hookList);
         return helper.request()
             .post('/api/2.0/hooks')
             .send(hookPayload)
@@ -77,7 +69,7 @@ describe('Http.Api.Hooks v2.0', function () {
         var hookList = _.cloneDeep(hookSample[0]);
         var hookWithNoUrl = _.cloneDeep(hookList);
         delete hookWithNoUrl.url;
-        sandbox.stub(hookService, 'createHook').resolves(hookList);
+        this.sandbox.stub(hookService, 'createHook').resolves(hookList);
         return helper.request()
             .post('/api/2.0/hooks')
             .send(hookWithNoUrl)
@@ -86,7 +78,7 @@ describe('Http.Api.Hooks v2.0', function () {
     });
 
     it('should throw 400 with bad request error', function () {
-        sandbox.stub(hookService, 'createHook').rejects(new Errors.BadRequestError());
+        this.sandbox.stub(hookService, 'createHook').rejects(new Errors.BadRequestError());
         return helper.request()
             .post('/api/2.0/hooks')
             .send({})
@@ -98,7 +90,7 @@ describe('Http.Api.Hooks v2.0', function () {
 
     it('should patch hook', function () {
         var hookList = _.cloneDeep(hookSample[0]);
-        sandbox.stub(hookService, 'updateHookById').resolves(hookList);
+        this.sandbox.stub(hookService, 'updateHookById').resolves(hookList);
         return helper.request()
             .patch('/api/2.0/hooks/test')
             .send(hookPayload)
@@ -112,7 +104,7 @@ describe('Http.Api.Hooks v2.0', function () {
     });
 
     it('should delete hook', function () {
-        sandbox.stub(hookService, 'deleteHookById').resolves(hookSample);
+        this.sandbox.stub(hookService, 'deleteHookById').resolves(hookSample);
         return helper.request()
             .delete('/api/2.0/hooks/test')
             .expect(204)
@@ -123,7 +115,8 @@ describe('Http.Api.Hooks v2.0', function () {
     });
 
     it('should return a 404 if the hook was not found', function () {
-        sandbox.stub(hookService, 'deleteHookById').rejects(new Errors.NotFoundError('Not Found'));
+        this.sandbox.stub(hookService, 'deleteHookById')
+            .rejects(new Errors.NotFoundError('Not Found'));
         return helper.request()
             .delete('/api/2.0/hooks/test')
             .expect(404);

--- a/spec/lib/api/2.0/lookups-spec.js
+++ b/spec/lib/api/2.0/lookups-spec.js
@@ -54,36 +54,23 @@ describe('Http.Api.Lookup 2.0', function () {
         }
     ];
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer().then(function () {
-            Promise = helper.injector.get('Promise');
-            _ = helper.injector.get('_');
-            waterline = helper.injector.get('Services.Waterline');
-            findByTerm = sinon.stub(waterline.lookups, 'findByTerm').resolves(data);
-            create = sinon.stub(waterline.lookups, 'create').resolves(data[0]);
-            needOneById = sinon.stub(waterline.lookups, 'needOneById').resolves(data[0]);
-            updateOneById = sinon.stub(waterline.lookups, 'updateOneById').resolves(data[0]);
-            destroyOneById = sinon.stub(waterline.lookups, 'destroyOneById').resolves(data[0]);
-        });
+    helper.httpServerBefore();
+
+    before(function () {
+        Promise = helper.injector.get('Promise');
+        _ = helper.injector.get('_');
+        waterline = helper.injector.get('Services.Waterline');
     });
 
-    afterEach(function () {
-        findByTerm.reset();
-        create.reset();
-        needOneById.reset();
-        updateOneById.reset();
-        destroyOneById.reset();
+    beforeEach('set up mocks', function () {
+        findByTerm = this.sandbox.stub(waterline.lookups, 'findByTerm').resolves(data);
+        create = this.sandbox.stub(waterline.lookups, 'create').resolves(data[0]);
+        needOneById = this.sandbox.stub(waterline.lookups, 'needOneById').resolves(data[0]);
+        updateOneById = this.sandbox.stub(waterline.lookups, 'updateOneById').resolves(data[0]);
+        destroyOneById = this.sandbox.stub(waterline.lookups, 'destroyOneById').resolves(data[0]);
     });
 
-    after('stop HTTP server', function () {
-        findByTerm.restore();
-        create.restore();
-        needOneById.restore();
-        updateOneById.restore();
-        destroyOneById.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe('/api/2.0/lookups', function () {
         describe('GET', function () {

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -16,67 +16,37 @@ describe('2.0 Http.Api.Nodes', function () {
     var mockConsul;
     var mockGrpc = require('../../../mock-grpc.js');
 
-    before('start HTTP server', function () {
-        this.timeout(10000);
+    helper.httpServerBefore();
+
+    before(function () {
         mockConsul = new Consul();
-        return helper.startServer([
-        ]).then(function () {
-            configuration = helper.injector.get('Services.Configuration');
-            lookupService = helper.injector.get('Services.Lookup');
-            lookupService.ipAddressToMacAddress = sinon.stub().resolves();
-            lookupService.ipAddressToNodeId = sinon.stub().resolves();
-            sinon.stub(configuration);
-
-            waterline = helper.injector.get('Services.Waterline');
-            sinon.stub(waterline.nodes);
-            sinon.stub(waterline.ibms);
-            sinon.stub(waterline.catalogs);
-            sinon.stub(waterline.workitems);
-            sinon.stub(waterline.graphobjects);
-
-            ObmService = helper.injector.get('Task.Services.OBM');
-            sinon.stub(ObmService.prototype, 'identifyOn');
-            sinon.stub(ObmService.prototype, 'identifyOff');
-            nodeApiService = helper.injector.get('Http.Services.Api.Nodes');
-            sinon.stub(nodeApiService, "getAllNodes");
-            sinon.stub(nodeApiService, "getNodeById");
-
-            Promise = helper.injector.get('Promise');
-            Constants = helper.injector.get('Constants');
-            Errors = helper.injector.get('Errors');
-            nodesApi = helper.injector.get('Http.Services.Api.Nodes');
-
-        });
-    });
-
-    afterEach('reset stubs', function () {
-        function resetStubs(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (obj[method] && obj[method].reset) {
-                  obj[method].reset();
-                }
-            }).value();
-        }
-
-        resetStubs(configuration);
-        resetStubs(lookupService);
-        resetStubs(waterline.lookups);
-        resetStubs(waterline.nodes);
-        resetStubs(waterline.catalogs);
-        resetStubs(waterline.workitems);
-        resetStubs(waterline.graphobjects);
-
-        ObmService.prototype.identifyOn.reset();
-        ObmService.prototype.identifyOff.reset();
-
+        configuration = helper.injector.get('Services.Configuration');
         lookupService = helper.injector.get('Services.Lookup');
-        lookupService.ipAddressToMacAddress = sinon.stub().resolves();
-        lookupService.ipAddressToNodeId = sinon.stub().resolves();
+        waterline = helper.injector.get('Services.Waterline');
+        ObmService = helper.injector.get('Task.Services.OBM');
+        nodeApiService = helper.injector.get('Http.Services.Api.Nodes');
+        Promise = helper.injector.get('Promise');
+        Constants = helper.injector.get('Constants');
+        Errors = helper.injector.get('Errors');
+        nodesApi = helper.injector.get('Http.Services.Api.Nodes');
     });
 
-    after('stop HTTP server', function () {
-        return helper.stopServer();
+    beforeEach('set up mocks', function() {
+        lookupService.ipAddressToMacAddress = this.sandbox.stub().resolves();
+        lookupService.ipAddressToNodeId = this.sandbox.stub().resolves();
+        this.sandbox.stub(configuration);
+        this.sandbox.stub(waterline.nodes);
+        this.sandbox.stub(waterline.ibms);
+        this.sandbox.stub(waterline.catalogs);
+        this.sandbox.stub(waterline.workitems);
+        this.sandbox.stub(waterline.graphobjects);
+        this.sandbox.stub(ObmService.prototype, 'identifyOn');
+        this.sandbox.stub(ObmService.prototype, 'identifyOff');
+        this.sandbox.stub(nodeApiService, "getAllNodes");
+        this.sandbox.stub(nodeApiService, "getNodeById");
     });
+
+    helper.httpServerAfter();
 
     var obm =[{
         config: {},
@@ -156,11 +126,7 @@ describe('2.0 Http.Api.Nodes', function () {
 
     describe('2.0 POST /nodes', function () {
         beforeEach(function() {
-            sinon.stub(nodeApiService, 'postNode');
-        });
-
-        afterEach(function() {
-            nodeApiService.postNode.restore();
+            this.sandbox.stub(nodeApiService, 'postNode');
         });
 
         it('should create a node', function () {
@@ -233,11 +199,7 @@ describe('2.0 Http.Api.Nodes', function () {
 
     describe('DELETE /nodes/:identifier', function () {
         beforeEach(function() {
-            sinon.stub(nodeApiService, 'removeNode');
-        });
-
-        afterEach(function() {
-            nodeApiService.removeNode.restore();
+            this.sandbox.stub(nodeApiService, 'removeNode');
         });
 
         it('should delete a node', function () {
@@ -283,14 +245,10 @@ describe('2.0 Http.Api.Nodes', function () {
     describe('PUT /nodes/:identifier/relations', function() {
         var relationUpdate;
         beforeEach(function() {
-            sinon.stub(nodeApiService, 'editNodeRelations');
+            this.sandbox.stub(nodeApiService, 'editNodeRelations');
             relationUpdate = {
                 containedBy: ['rackNodeId']
             };
-        });
-
-        afterEach(function() {
-            nodeApiService.editNodeRelations.restore();
         });
 
         it('should add to and update a node\'s relations', function() {
@@ -333,14 +291,10 @@ describe('2.0 Http.Api.Nodes', function () {
     describe('DELETE /nodes/:identifier/relations', function() {
         var relationDeletion;
         beforeEach(function() {
-            sinon.stub(nodeApiService, 'editNodeRelations');
+            this.sandbox.stub(nodeApiService, 'editNodeRelations');
             relationDeletion = {
                 containedBy: ['rackNodeId']
             };
-        });
-
-        afterEach(function() {
-            nodeApiService.editNodeRelations.restore();
         });
 
         it('should delete the given relations from a node', function() {
@@ -661,10 +615,11 @@ describe('2.0 Http.Api.Nodes', function () {
                 .expect(200, node.workflows)
                 .then(function(res){
                     expect(res.body[0]).to.have.property('status', 'pending');
-		});
+            });
         });
 
         it('should return a 404 if the node was not found', function () {
+            waterline.nodes.needByIdentifier.resolves(node);
             mockGrpc.setResponse(new Errors.NotFoundError('Not Found'));
             waterline.graphobjects.find.rejects(new Errors.NotFoundError('Not Found'));
             return helper.request().get('/api/2.0/nodes/123/workflows')
@@ -679,11 +634,7 @@ describe('2.0 Http.Api.Nodes', function () {
         };
 
         beforeEach(function() {
-            sinon.stub(nodeApiService, 'setNodeWorkflow');
-        });
-
-        afterEach(function() {
-            nodeApiService.setNodeWorkflow.restore();
+            this.sandbox.stub(nodeApiService, 'setNodeWorkflow');
         });
 
         it('should create a workflow via the querystring', function () {
@@ -808,13 +759,7 @@ describe('2.0 Http.Api.Nodes', function () {
         var action = { command: 'cancel'};
 
         beforeEach(function() {
-            sinon.stub(nodeApiService, 'delActiveWorkflowById');
-        });
-
-        afterEach(function() {
-            if (nodeApiService.delActiveWorkflowById.restore) {
-                nodeApiService.delActiveWorkflowById.restore();
-            }
+            this.sandbox.stub(nodeApiService, 'delActiveWorkflowById');
         });
 
         it('should delete the currently active workflow', function () {
@@ -840,19 +785,12 @@ describe('2.0 Http.Api.Nodes', function () {
     });
 
     describe('Tag support', function() {
-        before(function() {
-            sinon.stub(nodesApi, 'getTagsById').resolves([]);
-            sinon.stub(nodesApi, 'addTagsById').resolves([]);
-            sinon.stub(nodesApi, 'removeTagsById').resolves([]);
-            sinon.stub(nodesApi, 'masterDelTagById')
+        beforeEach(function() {
+            this.sandbox.stub(nodesApi, 'getTagsById').resolves([]);
+            this.sandbox.stub(nodesApi, 'addTagsById').resolves([]);
+            this.sandbox.stub(nodesApi, 'removeTagsById').resolves([]);
+            this.sandbox.stub(nodesApi, 'masterDelTagById')
                 .resolves(['1234abcd1234abcd1234abcd', '5678efgh5678efgh5678efgh']);
-        });
-
-        after(function() {
-            nodesApi.getTagsById.restore();
-            nodesApi.addTagsById.restore();
-            nodesApi.removeTagsById.restore();
-            nodesApi.masterDelTagById.restore();
         });
 
         it('should call getTagsById', function() {
@@ -910,13 +848,8 @@ describe('2.0 Http.Api.Nodes', function () {
             config: {}
         };
 
-        after(function() {
-            nodesApi.getObmsByNodeId.restore();
-            nodesApi.putObmsByNodeId.restore();
-        });
-
         it('should call getObmsByNodeId', function() {
-            sinon.stub(nodesApi, 'getObmsByNodeId').resolves([obmRes]);
+            this.sandbox.stub(nodesApi, 'getObmsByNodeId').resolves([obmRes]);
 
             return helper.request().get('/api/2.0/nodes/123/obm')
                 .expect('Content-Type', /^application\/json/)
@@ -928,7 +861,7 @@ describe('2.0 Http.Api.Nodes', function () {
         });
 
         it('should call putObmsByNodeId', function() {
-            sinon.stub(nodesApi, 'putObmsByNodeId').resolves([]);
+            this.sandbox.stub(nodesApi, 'putObmsByNodeId').resolves([]);
 
             return helper.request().put('/api/2.0/nodes/123/obm')
                 .send(obm)

--- a/spec/lib/api/2.0/notification-spec.js
+++ b/spec/lib/api/2.0/notification-spec.js
@@ -14,33 +14,22 @@ describe('Http.Api.Notification', function () {
         data: 'test data'
     };
 
-    before('start HTTP server', function () {
-        helper.setupInjector([
-             helper.require("/lib/services/notification-api-service.js"),
+    helper.httpServerBefore([
+        helper.require("/lib/services/notification-api-service.js")
+    ]);
 
-        ]);
-        this.timeout(5000);
-        return helper.startServer([]).then(function () {
-            notificationApiService = helper.injector.get('Http.Services.Api.Notification');
-            sinon.stub(notificationApiService, 'postNodeNotification')
-                .resolves(nodeNotificationMessage);
-            sinon.stub(notificationApiService, 'postBroadcastNotification')
-                .resolves(broadcastNotificationMessage);
-            //sinon.stub(notificationApiService, 'redfishAlertProcessing').resolves();
-        });
+    before(function () {
+        notificationApiService = helper.injector.get('Http.Services.Api.Notification');
+    });
 
+    beforeEach('set up mocks', function() {
+        this.sandbox.stub(notificationApiService, 'postNodeNotification')
+            .resolves(nodeNotificationMessage);
+        this.sandbox.stub(notificationApiService, 'postBroadcastNotification')
+            .resolves(broadcastNotificationMessage);
     });
-    after('stop HTTP server', function () {
-        function resetMocks(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (typeof obj[method].restore === 'function') {
-                    obj[method].restore();
-                }
-            }).value();
-        }
-        resetMocks(notificationApiService);
-        return helper.stopServer();
-    });
+
+    helper.httpServerAfter();
 
     describe('POST /notification', function () {
         it('should return node notification detail', function () {
@@ -102,11 +91,7 @@ describe('Http.Api.Notification', function () {
                     value: 2,
                     description: 'foo bar'
                 };
-                sinon.stub(notificationApiService, 'publishTaskProgress').resolves();
-            });
-
-            afterEach(function() {
-                notificationApiService.publishTaskProgress.restore();
+                this.sandbox.stub(notificationApiService, 'publishTaskProgress').resolves();
             });
 
             it('should post progress notification via body', function () {
@@ -259,11 +244,7 @@ describe('Http.Api.Notification', function () {
     describe('GET /notification/progress', function () {
         describe('stub publishTaskProgress', function() {
             beforeEach(function() {
-                sinon.stub(notificationApiService, 'publishTaskProgress').resolves();
-            });
-
-            afterEach(function() {
-                notificationApiService.publishTaskProgress.restore();
+                this.sandbox.stub(notificationApiService, 'publishTaskProgress').resolves();
             });
 
             it('should update progress notification via query', function () {
@@ -316,10 +297,7 @@ describe('Http.Api.Notification', function () {
             "Severity":"Critical"
         };
         beforeEach(function(){
-            sinon.stub(notificationApiService, 'redfishAlertProcessing').resolves();
-        });
-        afterEach(function(){
-            notificationApiService.redfishAlertProcessing.restore();
+            this.sandbox.stub(notificationApiService, 'redfishAlertProcessing').resolves();
         });
 
         it('should post alert notification successfully(json) ', function () {

--- a/spec/lib/api/2.0/obms-spec.js
+++ b/spec/lib/api/2.0/obms-spec.js
@@ -73,26 +73,16 @@ describe('Http.Api.Obms', function () {
     };
     var badLedData = {};
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer().then(function() {
-            waterline = helper.injector.get('Services.Waterline');
-            Errors = helper.injector.get('Errors');
-            nodeApiService = helper.injector.get('Http.Services.Api.Nodes');
-            obmsApiService = helper.injector.get('Http.Services.Api.Obms');
-        });
+    helper.httpServerBefore();
+
+    before(function () {
+        waterline = helper.injector.get('Services.Waterline');
+        Errors = helper.injector.get('Errors');
+        nodeApiService = helper.injector.get('Http.Services.Api.Nodes');
+        obmsApiService = helper.injector.get('Http.Services.Api.Obms');
     });
 
-    afterEach(function () {
-        if (stub) {
-            stub.restore();
-            stub = undefined;
-        }
-    });
-
-    after('stop HTTP server', function () {
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe('/api/2.0/obms/definitions', function () {
         it('should return a list of OBM schemas', function () {
@@ -142,7 +132,7 @@ describe('Http.Api.Obms', function () {
 
     describe('/api/2.0/obms', function () {
         it('should return a list of OBM instances', function () {
-            stub = sinon.stub(waterline.obms, 'find').resolves(goodData);
+            stub = this.sandbox.stub(waterline.obms, 'find').resolves(goodData);
 
             return helper.request().get('/api/2.0/obms')
                 .expect('Content-Type', /^application\/json/)
@@ -157,7 +147,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should put an OBM instance', function () {
-            stub = sinon.stub(waterline.obms, 'upsertByNode').resolves(goodData[0]);
+            stub = this.sandbox.stub(waterline.obms, 'upsertByNode').resolves(goodData[0]);
 
             return helper.request().put('/api/2.0/obms')
                 .send(goodSendData[0])
@@ -169,7 +159,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should 400 when put with unloaded schema', function () {
-            stub = sinon.stub(waterline.obms, 'upsertByNode');
+            stub = this.sandbox.stub(waterline.obms, 'upsertByNode');
 
             return helper.request().put('/api/2.0/obms')
                 .send(badData1)
@@ -181,7 +171,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should 400 when put with missing field', function () {
-            stub = sinon.stub(waterline.obms, 'upsertByNode');
+            stub = this.sandbox.stub(waterline.obms, 'upsertByNode');
 
             return helper.request().put('/api/2.0/obms')
                 .send(badData2)
@@ -196,7 +186,7 @@ describe('Http.Api.Obms', function () {
 
     describe('/api/2.0/obms/:id', function () {
         it('should get an OBM instance', function () {
-            stub = sinon.stub(waterline.obms, 'needByIdentifier').resolves(goodData[0]);
+            stub = this.sandbox.stub(waterline.obms, 'needByIdentifier').resolves(goodData[0]);
 
             return helper.request().get('/api/2.0/obms/123')
                 .expect('Content-Type', /^application\/json/)
@@ -209,7 +199,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should 404 if OBM instance is not found', function () {
-            stub = sinon.stub(waterline.obms, 'needByIdentifier').rejects(
+            stub = this.sandbox.stub(waterline.obms, 'needByIdentifier').rejects(
                 new Errors.NotFoundError('not found'));
 
             return helper.request().get('/api/2.0/obms/123')
@@ -217,7 +207,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should patch an OBM instance', function () {
-            stub = sinon.stub(obmsApiService, 'updateObmById').resolves(goodData[0]);
+            stub = this.sandbox.stub(obmsApiService, 'updateObmById').resolves(goodData[0]);
 
             return helper.request().patch('/api/2.0/obms/123')
                 .send(goodSendData[0])
@@ -229,7 +219,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should 400 when patching with bad data', function () {
-            stub = sinon.stub(obmsApiService, 'updateObmById');
+            stub = this.sandbox.stub(obmsApiService, 'updateObmById');
 
             return helper.request().patch('/api/2.0/obms/123')
                 .send(badData1)
@@ -241,7 +231,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should delete an OBM instance', function () {
-            stub = sinon.stub(obmsApiService, 'removeObmById');
+            stub = this.sandbox.stub(obmsApiService, 'removeObmById');
 
             return helper.request().delete('/api/2.0/obms/123')
                 .expect(204)
@@ -253,7 +243,7 @@ describe('Http.Api.Obms', function () {
 
     describe('/api/2.0/obms/led', function () {
         it('should post a body', function () {
-            stub = sinon.stub(nodeApiService, 'postNodeObmIdById');
+            stub = this.sandbox.stub(nodeApiService, 'postNodeObmIdById');
 
             return helper.request().post('/api/2.0/obms/led')
                 .send(goodLedData)
@@ -264,7 +254,7 @@ describe('Http.Api.Obms', function () {
         });
 
         it('should 400 if node is not specified in body', function () {
-            stub = sinon.stub(nodeApiService, 'postNodeObmIdById');
+            stub = this.sandbox.stub(nodeApiService, 'postNodeObmIdById');
 
             return helper.request().post('/api/2.0/obms/led')
                 .send(badLedData)

--- a/spec/lib/api/2.0/pollers-spec.js
+++ b/spec/lib/api/2.0/pollers-spec.js
@@ -4,26 +4,24 @@
 'use strict';
 
 describe('Http.Api.Pollers', function () {
-    var taskProtocol;
-    before('start HTTP server', function () {
-        this.timeout(10000);
-        taskProtocol = {
-            requestPollerCache: sinon.stub()
-        };
-        return helper.startServer([
-            dihelper.simpleWrapper(taskProtocol, 'Protocol.Task')
-        ]);
-    });
+    var taskProtocol = {};
 
-    beforeEach('reset test DB', function () {
+    helper.httpServerBefore([
+        dihelper.simpleWrapper(taskProtocol, 'Protocol.Task')
+    ]);
+
+    beforeEach('set up mocks', function () {
+        taskProtocol.requestPollerCache = this.sandbox.stub();
         return helper.reset().then(function() {
             return helper.injector.get('Views').load();
         });
     });
 
-    after('stop HTTP server', function () {
-        return helper.stopServer();
+    after(function() {
+        return helper.reset();
     });
+
+    helper.httpServerAfter();
 
     it('should return an empty array from GET /pollers', function () {
         return helper.request().get('/api/2.0/pollers')

--- a/spec/lib/api/2.0/profiles-spec.js
+++ b/spec/lib/api/2.0/profiles-spec.js
@@ -12,70 +12,52 @@ describe('Http.Api.Profiles', function () {
     var Errors;
     var waterline;
 
-    before('start HTTP server', function () {
-        this.timeout(10000);
-        return helper.startServer([]);
-    });
+    helper.httpServerBefore();
 
-    beforeEach('set up mocks', function () {
+    before(function() {
         taskProtocol = helper.injector.get('Protocol.Task');
         lookupService = helper.injector.get('Services.Lookup');
         Errors = helper.injector.get('Errors');
-
-        sinon.stub(lookupService, 'ipAddressToMacAddress').resolves('00:00:00:00:00:00');
-        sinon.stub(taskProtocol, 'activeTaskExists').resolves({});
-        sinon.stub(taskProtocol, 'requestCommands').resolves({ testcommands: 'cmd' });
-        sinon.stub(taskProtocol, 'requestProfile').resolves();
-        sinon.stub(taskProtocol, 'requestProperties').resolves();
-
         workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
-        sinon.stub(workflowApiService, 'findActiveGraphForTarget').resolves({});
-
         taskgraphApiService = helper.injector.get('Http.Services.Api.Taskgraph.Scheduler');
-        sinon.stub(taskgraphApiService, 'workflowsPost').resolves({ instanceId: 'test' });
-
         profiles = helper.injector.get('Profiles');
-        sinon.stub(profiles, 'getAll').resolves();
-        sinon.stub(profiles, 'getName').resolves();
-        sinon.stub(profiles, 'get').resolves();
-        sinon.stub(profiles, 'put').resolves();
-
         profileApiService = helper.injector.get('Http.Services.Api.Profiles');
-        sinon.stub(profileApiService, 'getNode').resolves({});
-        sinon.stub(profileApiService, 'createNodeAndRunDiscovery').resolves({});
-        sinon.stub(profileApiService, 'runDiscovery').resolves({});
-        sinon.stub(profileApiService, 'setLookup').resolves();
-
         waterline = helper.injector.get('Services.Waterline');
-        sinon.stub(waterline.lookups, "findOneByTerm").resolves();
+    });
+
+    beforeEach('set up mocks', function () {
+        this.sandbox.stub(lookupService, 'ipAddressToMacAddress').resolves('00:00:00:00:00:00');
+        this.sandbox.stub(taskProtocol, 'activeTaskExists').resolves({});
+        this.sandbox.stub(taskProtocol, 'requestCommands').resolves({ testcommands: 'cmd' });
+        this.sandbox.stub(taskProtocol, 'requestProfile').resolves();
+        this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
+
+        this.sandbox.stub(workflowApiService, 'findActiveGraphForTarget').resolves({});
+
+        this.sandbox.stub(taskgraphApiService, 'workflowsPost').resolves({ instanceId: 'test' });
+
+        this.sandbox.stub(profiles, 'getAll').resolves();
+        this.sandbox.stub(profiles, 'getName').resolves();
+        this.sandbox.stub(profiles, 'get').resolves();
+        this.sandbox.stub(profiles, 'put').resolves();
+
+        this.sandbox.stub(profileApiService, 'getNode').resolves({});
+        this.sandbox.stub(profileApiService, 'createNodeAndRunDiscovery').resolves({});
+        this.sandbox.stub(profileApiService, 'runDiscovery').resolves({});
+        this.sandbox.stub(profileApiService, 'setLookup').resolves();
+
+        this.sandbox.stub(waterline.lookups, "findOneByTerm").resolves();
 
         return helper.reset().then(function() {
             return helper.injector.get('Views').load();
         });
     });
 
-    afterEach('teardown mocks', function () {
-        function resetMocks(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (typeof obj[method].restore === 'function') {
-                    obj[method].restore();
-                }
-            }).value();
-        }
-        resetMocks(lookupService);
-        resetMocks(taskProtocol);
-        resetMocks(workflowApiService);
-        resetMocks(profiles);
-        resetMocks(profileApiService);
-        resetMocks(taskgraphApiService);
-        resetMocks(waterline.lookups);
+    after(function () {
+        return helper.reset();
     });
 
-    after('stop HTTP server', function () {
-        return helper.reset().then(function() {
-            return helper.stopServer();
-        });
-    });
+    helper.httpServerAfter();
 
     var profile = [{
         id: '1234abcd5678effe9012dcba',
@@ -277,9 +259,9 @@ describe('Http.Api.Profiles', function () {
 
     describe("2.0 GET /profiles/switch/:vendor", function() {
         it("should get switch profile via proxy", function() {
-            sinon.stub(profileApiService, 'getProfilesSwitchVendor').resolves(
+            this.sandbox.stub(profileApiService, 'getProfilesSwitchVendor').resolves(
                 'switch_node_profile');
-            sinon.stub(profileApiService, 'renderProfile').resolves('#!ipxe\n');
+            this.sandbox.stub(profileApiService, 'renderProfile').resolves('#!ipxe\n');
 
             return helper.request()
                 .get('/api/2.0/profiles/switch/testswitchvendor')
@@ -287,16 +269,16 @@ describe('Http.Api.Profiles', function () {
                 .set("X-RackHD-API-proxy-ip", "127.0.0.1")
                 .set("X-RackHD-API-proxy-port", "7180")
                 .expect(200)
-                .then(function(res) {
+                .then(function() {
                     expect(profileApiService.getProfilesSwitchVendor).to.have.been.calledWith(
                         "188.1.1.1", "testswitchvendor");
                 });
         });
 
         it("should get switch profile", function() {
-            sinon.stub(profileApiService, 'getProfilesSwitchVendor').resolves(
+            this.sandbox.stub(profileApiService, 'getProfilesSwitchVendor').resolves(
                 'switch_node_profile');
-            sinon.stub(profileApiService, 'renderProfile').resolves('#!ipxe\n');
+            this.sandbox.stub(profileApiService, 'renderProfile').resolves('#!ipxe\n');
             waterline.lookups.findOneByTerm.resolves({macAddress: '11:11:11:11:11:11'});
             profileApiService.getProfilesSwitchVendor.resolves('switch_node_profile');
             profileApiService.renderProfile.resolves('#!ipxe\n');
@@ -320,8 +302,8 @@ describe('Http.Api.Profiles', function () {
         });
 
         it("should return 404 for invalid switch vendor name", function() {
-            sinon.stub(profileApiService, 'getProfilesSwitchVendor').resolves();
-            sinon.stub(profileApiService, 'renderProfile').resolves();
+            this.sandbox.stub(profileApiService, 'getProfilesSwitchVendor').resolves();
+            this.sandbox.stub(profileApiService, 'renderProfile').resolves();
             waterline.lookups.findOneByTerm.resolves({macAddress: '11:11:11:11:11:11'});
             profileApiService.getProfilesSwitchVendor.rejects(new Errors.NotFoundError(
                 'invalid switch name'));

--- a/spec/lib/api/2.0/roles2.0-spec.js
+++ b/spec/lib/api/2.0/roles2.0-spec.js
@@ -16,25 +16,18 @@ describe('Http.Api.Roles', function () {
 
     var accountService;
 
-    before('start HTTP server', function () {
-        var self = this;
-        this.timeout(5000);
-        this.sandbox = sinon.sandbox.create();
-        return helper.startServer([])
-        .then(function () {
-            accountService = helper.injector.get('Http.Services.Api.Account');
-            self.sandbox.stub(accountService, 'listRoles').resolves([roleObj]);
-            self.sandbox.stub(accountService, 'getRoleByName').resolves(newRole);
-            self.sandbox.stub(accountService, 'createRole').resolves(newRole);
-            self.sandbox.stub(accountService, 'modifyRoleByRoleName').resolves(newRole);
-            self.sandbox.stub(accountService, 'removeRoleByName').resolves();
-        });
+    helper.httpServerBefore();
+
+    beforeEach('set up mocks', function () {
+        accountService = helper.injector.get('Http.Services.Api.Account');
+        this.sandbox.stub(accountService, 'listRoles').resolves([roleObj]);
+        this.sandbox.stub(accountService, 'getRoleByName').resolves(newRole);
+        this.sandbox.stub(accountService, 'createRole').resolves(newRole);
+        this.sandbox.stub(accountService, 'modifyRoleByRoleName').resolves(newRole);
+        this.sandbox.stub(accountService, 'removeRoleByName').resolves();
     });
 
-    after('stop HTTP server', function () {
-        this.sandbox.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return a list of roles', function () {
         return helper.request().get('/api/2.0/roles')

--- a/spec/lib/api/2.0/schemas-spec.js
+++ b/spec/lib/api/2.0/schemas-spec.js
@@ -7,31 +7,21 @@ describe('Http.Api.Schemas', function () {
     var schemaService;
     var workflowApiService;
     var Task;
-    var sandbox;
 
-    before('start HTTP server', function () {
-        this.timeout(10000);
-        sandbox = sinon.sandbox.create();
+    helper.httpServerBefore();
 
-        return helper.startServer([]).then(function () {
-            schemaService = helper.injector.get('Http.Api.Services.Schema');
-            workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
-            Task = helper.injector.get('Task.Task');
-        });
+    before(function () {
+        schemaService = helper.injector.get('Http.Api.Services.Schema');
+        workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
+        Task = helper.injector.get('Task.Task');
     });
 
-    afterEach("reset stubs", function() {
-        sandbox.restore();
-    });
-
-    after('stop HTTP server', function () {
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe("GET /schemas", function() {
 
         it("should a list of all schemas", function() {
-            sandbox.stub(schemaService, "getNamespace").returns([
+            this.sandbox.stub(schemaService, "getNamespace").returns([
                 "schema1",
                 "schema2"
             ]);
@@ -47,7 +37,7 @@ describe('Http.Api.Schemas', function () {
         });
 
         it("should return an empty array if no schemas exist", function() {
-            sandbox.stub(schemaService, "getNamespace").returns([]);
+            this.sandbox.stub(schemaService, "getNamespace").returns([]);
 
             return helper.request().get('/api/2.0/schemas')
                 .expect('Content-Type', /^application\/json/)
@@ -61,7 +51,7 @@ describe('Http.Api.Schemas', function () {
     describe("GET /schemas/:identifier", function() {
 
         it("should return an individual schema", function() {
-            sandbox.stub(schemaService, "getSchema").returns({
+            this.sandbox.stub(schemaService, "getSchema").returns({
                     title: 'schema',
                     description: 'a schema',
                     type: 'object',
@@ -79,7 +69,7 @@ describe('Http.Api.Schemas', function () {
         });
 
         it("should return a 404 if no schema can be found", function() {
-            sandbox.stub(schemaService, "getSchema").returns(undefined);
+            this.sandbox.stub(schemaService, "getSchema").returns(undefined);
 
             return helper.request().get('/api/2.0/schemas/junk')
                 .expect('Content-Type', /^application\/json/)
@@ -90,7 +80,7 @@ describe('Http.Api.Schemas', function () {
     describe("GET /schemas/tasks", function() {
 
         it("should return a list of all task schemas' name", function() {
-            sandbox.stub(workflowApiService, 'getTaskDefinitions').resolves([
+            this.sandbox.stub(workflowApiService, 'getTaskDefinitions').resolves([
                 {
                     injectableName: 'Task.foo',
                     friendlyName: 'foo',
@@ -117,7 +107,7 @@ describe('Http.Api.Schemas', function () {
         });
 
         it("should return an empty array if no schemas exist", function() {
-            sandbox.stub(workflowApiService, 'getTaskDefinitions').resolves([]);
+            this.sandbox.stub(workflowApiService, 'getTaskDefinitions').resolves([]);
             return helper.request().get('/api/2.0/schemas/tasks')
                 .expect('Content-Type', /^application\/json/)
                 .expect(200)
@@ -146,9 +136,9 @@ describe('Http.Api.Schemas', function () {
         };
 
         it("should return a task schema", function() {
-            sandbox.stub(workflowApiService, 'getWorkflowsTasksByName')
+            this.sandbox.stub(workflowApiService, 'getWorkflowsTasksByName')
                 .withArgs('Task.foo').resolves([task]);
-            sandbox.stub(Task, 'getFullSchema')
+            this.sandbox.stub(Task, 'getFullSchema')
                 .withArgs(task).returns(testSchema);
 
             return helper.request().get('/api/2.0/schemas/tasks/Task.foo')
@@ -160,7 +150,7 @@ describe('Http.Api.Schemas', function () {
         });
 
         it("should return a 404 if no schema can be found", function() {
-            sandbox.stub(workflowApiService, 'getWorkflowsTasksByName')
+            this.sandbox.stub(workflowApiService, 'getWorkflowsTasksByName')
                 .withArgs('junk').resolves([]);
             return helper.request().get('/api/2.0/schemas/tasks/junk')
                 .expect('Content-Type', /^application\/json/)

--- a/spec/lib/api/2.0/skus-spec.js
+++ b/spec/lib/api/2.0/skus-spec.js
@@ -11,57 +11,34 @@ describe('Http.Api.Skus.2.0', function() {
     var Errors;
     var skuApiService;
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer([
-        ]).then(function() {
-            waterline = helper.injector.get('Services.Waterline');
-            sinon.stub(waterline.skus);
-            workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
+    helper.httpServerBefore();
 
-            skuApiService = helper.injector.get('Http.Services.SkuPack');
-            Promise = helper.injector.get('Promise');
-            Constants = helper.injector.get('Constants');
-            Errors = helper.injector.get('Errors');
+    before(function () {
+        waterline = helper.injector.get('Services.Waterline');
+        workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
 
-            sinon.stub(skuApiService, 'getSkus');
-            sinon.stub(skuApiService, 'postSku');
-            sinon.stub(skuApiService, 'getSkusById');
-            sinon.stub(skuApiService, 'upsertSku');
-            sinon.stub(skuApiService, 'patchSku');
-            sinon.stub(skuApiService, 'getNodesSkusById');
-            sinon.stub(skuApiService, 'regenerateSkus');
-            sinon.stub(skuApiService, 'deleteSkuById');
-
-            sinon.stub(workflowApiService, 'createAndRunGraph');
-        });
+        skuApiService = helper.injector.get('Http.Services.SkuPack');
+        Promise = helper.injector.get('Promise');
+        Constants = helper.injector.get('Constants');
+        Errors = helper.injector.get('Errors');
     });
 
-    afterEach('reset stubs', function () {
-        function resetStubs(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (obj[method] && obj[method].reset) {
-                    obj[method].reset();
-                }
-            }).value();
-        }
-        resetStubs(waterline.skus);
-        resetStubs(workflowApiService);
+    beforeEach('set up mocks', function() {
+        this.sandbox.stub(waterline.skus);
+
+        this.sandbox.stub(skuApiService, 'getSkus');
+        this.sandbox.stub(skuApiService, 'postSku');
+        this.sandbox.stub(skuApiService, 'getSkusById');
+        this.sandbox.stub(skuApiService, 'upsertSku');
+        this.sandbox.stub(skuApiService, 'patchSku');
+        this.sandbox.stub(skuApiService, 'getNodesSkusById');
+        this.sandbox.stub(skuApiService, 'regenerateSkus');
+        this.sandbox.stub(skuApiService, 'deleteSkuById');
+
+        this.sandbox.stub(workflowApiService, 'createAndRunGraph');
     });
 
-    after('stop HTTP server', function () {
-        skuApiService.getSkus.restore();
-        skuApiService.postSku.restore();
-        skuApiService.getSkusById.restore();
-        skuApiService.upsertSku.restore();
-        skuApiService.patchSku.restore();
-        skuApiService.regenerateSkus.restore();
-        skuApiService.getNodesSkusById.restore();
-        skuApiService.deleteSkuById.restore();
-        workflowApiService.createAndRunGraph.restore();
-
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     var node = {
         id: '1234abcd1234abcd1234abcd',
@@ -141,7 +118,6 @@ describe('Http.Api.Skus.2.0', function() {
                 .expect(200)
                 .then(function (res) {
                     expect(skuApiService.getSkus).to.have.been.called;
-                    var checkSku = res.body;
                     expect(res.body).to.have.lengthOf(1);
                     expect(res.body[0]).to.have.property('name').that.equals(record.name);
                     expect(res.body[0]).to.have.property('rules').that.deep.equals(record.rules);
@@ -263,19 +239,14 @@ describe('Http.Api.Skus.2.0', function() {
 
             beforeEach('setup', function () {
                 skuService = helper.injector.get('Http.Services.SkuPack');
-                sinon.stub(skuService, 'installPack');
-                sinon.stub(skuService, 'registerPack');
+                this.sandbox.stub(skuService, 'installPack');
+                this.sandbox.stub(skuService, 'registerPack');
                 skuService.installPack.resolves(['filename', 'contents']);
                 skuService.registerPack.resolves();
             });
 
             beforeEach('reset createAndRunGraph stub', function () {
                 workflowApiService.createAndRunGraph.resolves();
-            });
-
-            afterEach('teardown', function () {
-                skuService.installPack.restore();
-                skuService.registerPack.restore();
             });
 
             it('should process a .tar.gz file', function (done) {
@@ -297,12 +268,10 @@ describe('Http.Api.Skus.2.0', function() {
 
         describe('POST sku pack', function () {
             beforeEach('setup', function () {
-                sinon.stub(skuApiService, 'skuPackHandler');
+                this.sandbox.stub(skuApiService, 'skuPackHandler');
                 skuApiService.skuPackHandler.resolves();
             });
-            afterEach('teardown', function () {
-                skuApiService.skuPackHandler.restore();
-            });
+
             it('should post a sku pack', function (done) {
                 var fs = helper.injector.get('fs');
                 var skuPack = {id: 'sku name test'};
@@ -326,12 +295,10 @@ describe('Http.Api.Skus.2.0', function() {
 
         describe('PUT sku pack', function () {
             beforeEach('setup', function () {
-                sinon.stub(skuApiService, 'putPackBySkuId');
+                this.sandbox.stub(skuApiService, 'putPackBySkuId');
                 skuApiService.putPackBySkuId.resolves();
             });
-            afterEach('teardown', function () {
-                skuApiService.putPackBySkuId.restore();
-            });
+
             it('should put a sku pack', function (done) {
                 var fs = helper.injector.get('fs');
                 var skuPack = {id : 'sku name test'};

--- a/spec/lib/api/2.0/tasks-spec.js
+++ b/spec/lib/api/2.0/tasks-spec.js
@@ -7,68 +7,45 @@ describe('Http.Api.Tasks', function () {
     var taskProtocol;
     var tasksApiService;
     var taskGraphApiService;
-    var sandbox;
     var lookupService;
     var templates;
 
-    before('start HTTP server', function () {
-        this.timeout(20000);
-        return helper.startServer();
+    helper.httpServerBefore();
+
+    before(function() {
+        taskProtocol = helper.injector.get('Protocol.Task');
+        tasksApiService = helper.injector.get('Http.Services.Api.Tasks');
+        taskGraphApiService = helper.injector.get("Http.Services.Api.Taskgraph.Scheduler");
+        lookupService = helper.injector.get('Services.Lookup');
+        templates = helper.injector.get('Templates');
     });
 
     beforeEach('set up mocks', function () {
-        taskProtocol = helper.injector.get('Protocol.Task');
         // Defaults, you can tack on .resolves().rejects().resolves(), etc. like so
-        taskProtocol.activeTaskExists = sinon.stub().resolves();
-        taskProtocol.requestCommands = sinon.stub().resolves({
+        taskProtocol.activeTaskExists = this.sandbox.stub().resolves();
+        taskProtocol.requestCommands = this.sandbox.stub().resolves({
                                                             "identifier":"1234", 
                                                             "tasks": [ {"cmd": "testfoo"}
                                                              ]});
-        taskProtocol.respondCommands = sinon.stub();
+        taskProtocol.respondCommands = this.sandbox.stub();
+        tasksApiService.getNode = this.sandbox.stub();
+        lookupService.ipAddressToMacAddress = this.sandbox.stub().resolves('00:11:22:33:44:55');
 
-        tasksApiService = helper.injector.get('Http.Services.Api.Tasks');
-        tasksApiService.getNode = sinon.stub();
-        taskGraphApiService = helper.injector.get("Http.Services.Api.Taskgraph.Scheduler");
-
-        lookupService = helper.injector.get('Services.Lookup');
-        lookupService.ipAddressToMacAddress = sinon.stub().resolves('00:11:22:33:44:55');
-
-        templates = helper.injector.get('Templates');
-
-        sandbox = sinon.sandbox.create();
         return helper.reset().then(function(){
-          return helper.injector.get('Views').load();
-          });
-    });
-
-    afterEach('restoring stubs', function() {
-        function resetStubs(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (obj[method] && obj[method].reset) {
-                    obj[method].reset();
-                }
-            }).value();
-        }
-
-        resetStubs(taskProtocol.activeTaskExists);
-        resetStubs(taskProtocol.requestCommands);
-        resetStubs(taskProtocol.respondCommands);
-        resetStubs(tasksApiService.getNode);
-        resetStubs(lookupService.ipAddressToMacAddress);
-
-        sandbox.restore();
-    });
-
-    after('stop HTTP server', function () {
-        return helper.reset().then(function(){
-            return helper.stopServer();
+            return helper.injector.get('Views').load();
         });
     });
 
+    after(function () {
+        return helper.reset();
+    });
+
+    helper.httpServerAfter();
+
     describe('GET /tasks/:id', function () {
         it("should send down tasks", function() {
-            sandbox.stub(taskGraphApiService, 'getTasksById').resolves({
-                "identifier":"1234", 
+            this.sandbox.stub(taskGraphApiService, 'getTasksById').resolves({
+                "identifier":"1234",
                 "tasks": [ {"cmd": "testfoo"}
             ]});
             return helper.request().get('/api/2.0/tasks/testnodeid')
@@ -82,7 +59,7 @@ describe('Http.Api.Tasks', function () {
         });
 
         it("should error if no task available", function() {
-            sandbox.stub(taskGraphApiService, 'getTasksById').rejects(new Error(''));
+            this.sandbox.stub(taskGraphApiService, 'getTasksById').rejects(new Error(''));
             return helper.request().get('/api/2.0/tasks/testnodeid')
             .expect(404);
         });
@@ -91,15 +68,11 @@ describe('Http.Api.Tasks', function () {
     describe("GET /tasks/bootstrap.js", function() {
         var stubTemplates;
 
-        before(function() {
-            stubTemplates = sinon.stub(templates, 'get');
+        beforeEach(function() {
+            stubTemplates = this.sandbox.stub(templates, 'get');
             stubTemplates.withArgs('bootstrap.js').resolves({
                 contents: 'test node id: <%= identifier %>'
             });
-        });
-
-        after(function() {
-            stubTemplates.restore();
         });
 
        it("should render a bootstrap for the node", function() {
@@ -131,7 +104,7 @@ describe('Http.Api.Tasks', function () {
         it("should accept a large entity response", function() {
             var data = { foo: new Array(200000).join('1') };
 
-            sandbox.stub(taskGraphApiService, 'postTaskById').resolves({});
+            this.sandbox.stub(taskGraphApiService, 'postTaskById').resolves({});
             return helper.request().post('/api/2.0/tasks/123')
             .send(data)
             .expect(201)

--- a/spec/lib/api/2.0/templates-spec.js
+++ b/spec/lib/api/2.0/templates-spec.js
@@ -13,70 +13,45 @@ describe('Http.Api.Templates', function () {
     var findActiveGraphForTarget;
     var nodeApiService;
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
+    helper.httpServerBefore();
 
-        return helper.startServer([
-        ]);
-    });
-
-    beforeEach('set up mocks', function () {
+    before(function() {
         taskProtocol = helper.injector.get('Protocol.Task');
         lookupService = helper.injector.get('Services.Lookup');
         Errors = helper.injector.get('Errors');
         waterline = helper.injector.get('Services.Waterline');
         swagger = helper.injector.get('Http.Services.Swagger');
-        sinon.stub(swagger, 'makeRenderableOptions').resolves({});
-        this.sandbox = sinon.sandbox.create();
-
         tasksApiService = helper.injector.get('Http.Services.Api.Tasks');
-        tasksApiService.getNode = sinon.stub().resolves({ id: '1234abcd5678effe9012dcba' });
-
         nodeApiService = helper.injector.get('Http.Services.Api.Nodes');
-        nodeApiService.getNodeByIdentifier = sinon.stub()
-            .resolves({ id: '1234abcd5678effe9012dcba' });
-
-        lookupService.ipAddressToMacAddress = sinon.stub().resolves('00:11:22:33:44:55');
-        lookupService.reqIpAddressToMacAddress = sinon.stub().resolves();
-
-        sinon.stub(taskProtocol, 'activeTaskExists').resolves({});
-        sinon.stub(taskProtocol, 'requestCommands').resolves({ testcommands: 'cmd' });
-        sinon.stub(taskProtocol, 'requestProfile').resolves();
-        sinon.stub(taskProtocol, 'requestProperties').resolves();
-
         workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
-        findActiveGraphForTarget = this.sandbox.stub(
-            workflowApiService, 'findActiveGraphForTarget');
-
         templates = helper.injector.get('Templates');
-        sinon.stub(templates, 'getAll').resolves();
-        sinon.stub(templates, 'getName').resolves();
-        sinon.stub(templates, 'get').resolves();
-        sinon.stub(templates, 'put').resolves();
-        sinon.stub(templates, 'unlink').resolves();
-        sinon.stub(templates, 'render').resolves();
-
         return helper.injector.get('Views').load();
     });
 
-    afterEach('teardown mocks', function () {
-        function resetMocks(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (typeof obj[method].restore === 'function') {
-                    obj[method].restore();
-                }
-            }).value();
-        }
-        resetMocks(lookupService);
-        resetMocks(taskProtocol);
-        resetMocks(workflowApiService);
-        resetMocks(templates);
-        resetMocks(swagger);
+    beforeEach('set up mocks', function () {
+        this.sandbox.stub(swagger, 'makeRenderableOptions').resolves({});
+        tasksApiService.getNode = this.sandbox.stub().resolves({ id: '1234abcd5678effe9012dcba' });
+        nodeApiService.getNodeByIdentifier = this.sandbox.stub()
+            .resolves({ id: '1234abcd5678effe9012dcba' });
+        lookupService.ipAddressToMacAddress = this.sandbox.stub().resolves('00:11:22:33:44:55');
+        lookupService.reqIpAddressToMacAddress = this.sandbox.stub().resolves();
+        this.sandbox.stub(taskProtocol, 'activeTaskExists').resolves({});
+        this.sandbox.stub(taskProtocol, 'requestCommands').resolves({ testcommands: 'cmd' });
+        this.sandbox.stub(taskProtocol, 'requestProfile').resolves();
+        this.sandbox.stub(taskProtocol, 'requestProperties').resolves();
+
+        findActiveGraphForTarget = this.sandbox.stub(
+            workflowApiService, 'findActiveGraphForTarget');
+
+        this.sandbox.stub(templates, 'getAll').resolves();
+        this.sandbox.stub(templates, 'getName').resolves();
+        this.sandbox.stub(templates, 'get').resolves();
+        this.sandbox.stub(templates, 'put').resolves();
+        this.sandbox.stub(templates, 'unlink').resolves();
+        this.sandbox.stub(templates, 'render').resolves();
     });
 
-    after('stop HTTP server', function () {
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     var template = {
         id: '1234abcd5678effe9012dcba',

--- a/spec/lib/api/2.0/views-spec.js
+++ b/spec/lib/api/2.0/views-spec.js
@@ -9,42 +9,28 @@ describe('Http.Api.Views', function () {
     var _;
     var ejs;
 
-    before('start HTTP server', function () {
-        this.timeout(10000);
-        return helper.startServer([
-        ]).then(function() {
-            _ = helper.injector.get('_');
-            viewsProtocol = helper.injector.get('Views');
-            ejs = helper.injector.get('ejs');
-            Promise = helper.injector.get('Promise');
-            sinon.stub(viewsProtocol, 'load');
-            sinon.stub(viewsProtocol, 'getAll');
-            sinon.stub(viewsProtocol, 'get');
-            sinon.stub(viewsProtocol, 'put');
-            sinon.stub(viewsProtocol, 'unlink');
-        });
+    helper.httpServerBefore();
+
+    before(function () {
+        _ = helper.injector.get('_');
+        viewsProtocol = helper.injector.get('Views');
+        ejs = helper.injector.get('ejs');
+        Promise = helper.injector.get('Promise');
     });
 
-    afterEach('reset stubs', function () {
-        _(viewsProtocol).methods().forEach(function (method) {
-            if (viewsProtocol[method].reset) {
-              viewsProtocol[method].reset();
-            }
-        }).value();
+    beforeEach('set up mocks', function() {
+        this.sandbox.stub(viewsProtocol, 'load');
+        this.sandbox.stub(viewsProtocol, 'getAll');
+        this.sandbox.stub(viewsProtocol, 'get');
+        this.sandbox.stub(viewsProtocol, 'put');
+        this.sandbox.stub(viewsProtocol, 'unlink');
     });
 
-    after('stop HTTP server', function () {
-        _(viewsProtocol).methods().forEach(function (method) {
-            if (viewsProtocol[method].restore) {
-              viewsProtocol[method].restore();
-            }
-        }).value();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe('2.0 Views', function() {
-        before(function() {
-            sinon.stub(viewsProtocol, 'render', function(viewName, options) {
+        beforeEach(function() {
+            this.sandbox.stub(viewsProtocol, 'render', function(viewName, options) {
                 switch(viewName) {
                     case 'renderable.2.0.json':
                         return Promise.resolve(
@@ -58,19 +44,13 @@ describe('Http.Api.Views', function () {
                         });
                     default:
                         return Promise.resolve();
-                };
+                }
             });
-            sinon.stub(ejs, 'render', function(template, options) {
+            this.sandbox.stub(ejs, 'render', function(template, options) {
                 return Promise.resolve(
                     JSON.stringify(_.omit(options, '_', 'Constants', 'basepath'))
                 );
             });
-        });
-
-        after(function() {
-            viewsProtocol.render.restore();
-            viewsProtocol.get.reset();
-            ejs.render.restore();
         });
 
         it('should get all views', function() {
@@ -113,12 +93,8 @@ describe('Http.Api.Views', function () {
     });
 
     describe('2.0 Views', function() {
-        before(function() {
-            sinon.stub(viewsProtocol, 'render').resolves('{"message": "error"}');
-        });
-
-        after(function() {
-            viewsProtocol.render.restore();
+        beforeEach(function() {
+            this.sandbox.stub(viewsProtocol, 'render').resolves('{"message": "error"}');
         });
 
         it('should fail to get non-existant view', function() {

--- a/spec/lib/api/2.0/workflowGraphs-spec.js
+++ b/spec/lib/api/2.0/workflowGraphs-spec.js
@@ -4,36 +4,23 @@
 'use strict';
 
 describe('Http.Api.Workflows.2.0', function () {
-    var workflowApiService;
-    var arpCache = {
-        getCurrent: sinon.stub().resolves([])
-    };
+    var workflowApiService = {};
+    var arpCache = {};
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        workflowApiService = {
-            getGraphDefinitions: sinon.stub(),
-            workflowsGetGraphsByName: sinon.stub(),
-            defineTaskGraph: sinon.stub(),
-            destroyGraphDefinition: sinon.stub()
-        };
+    helper.httpServerBefore([
+        dihelper.simpleWrapper(workflowApiService, 'Http.Services.Api.Workflows'),
+        dihelper.simpleWrapper(arpCache, 'ARPCache')
+    ]);
 
-        return helper.startServer([
-            dihelper.simpleWrapper(workflowApiService, 'Http.Services.Api.Workflows'),
-            dihelper.simpleWrapper(arpCache, 'ARPCache')
-        ]);
+    beforeEach('set up mocks', function () {
+        workflowApiService.getGraphDefinitions = this.sandbox.stub();
+        workflowApiService.workflowsGetGraphsByName = this.sandbox.stub();
+        workflowApiService.defineTaskGraph = this.sandbox.stub();
+        workflowApiService.destroyGraphDefinition = this.sandbox.stub();
+        arpCache.getCurrent =  this.sandbox.stub().resolves([]);
     });
 
-    afterEach('set up mocks', function () {
-        workflowApiService.getGraphDefinitions.reset();
-        workflowApiService.workflowsGetGraphsByName.reset();
-        workflowApiService.defineTaskGraph.reset();
-        workflowApiService.destroyGraphDefinition.reset();
-    });
-
-    after('stop HTTP server', function () {
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe('workflowsGetGraphs', function () {
         it('should retrieve the workflow Graphs', function () {

--- a/spec/lib/api/2.0/workflows-spec.js
+++ b/spec/lib/api/2.0/workflows-spec.js
@@ -4,71 +4,27 @@
 'use strict';
 
 describe('Http.Api.Workflows.2.0', function () {
-    var waterline;
     var Errors;
     var workflowApiService;
-    var arpCache = {
-        getCurrent: sinon.stub().resolves([])
-    };
 
-    before('start HTTP server', function () {
-        var self = this;
-        this.timeout(10000);
+    helper.httpServerBefore();
 
-        waterline = {
-            start: sinon.stub(),
-            stop: sinon.stub(),
-            lookups: {
-                setIndexes: sinon.stub()
-            }
-        };
-        this.sandbox = sinon.sandbox.create();
-
-        return helper.startServer([
-        ])
-        .then(function() {
-            Errors = helper.injector.get('Errors');
-            workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
-            self.sandbox.stub(workflowApiService, 'defineTask').resolves();
-            self.sandbox.stub(workflowApiService, 'getAllWorkflows').resolves();
-            self.sandbox.stub(workflowApiService, 'createAndRunGraph').resolves();
-            self.sandbox.stub(workflowApiService, 'getWorkflowByInstanceId').resolves();
-            self.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves();
-            self.sandbox.stub(workflowApiService, 'deleteTaskGraph').resolves();
-
-        });
+    before(function () {
+        Errors = helper.injector.get('Errors');
+        workflowApiService = helper.injector.get('Http.Services.Api.Workflows');
     });
 
     beforeEach('set up mocks', function () {
-        waterline.nodes = {
-            findByIdentifier: sinon.stub().resolves()
-        };
-        waterline.graphobjects = {
-            find: sinon.stub().resolves([]),
-            findOne: sinon.stub().resolves(),
-            findByIdentifier: sinon.stub().resolves(),
-            needByIdentifier: sinon.stub().resolves(),
-            count: sinon.stub().resolves()
-        };
-        waterline.lookups = {
-            // This method is for lookups only and it
-            // doesn't impact behavior whether it is a
-            // resolve or a reject since it's related
-            // to logging.
-            findOneByTerm: sinon.stub().rejects()
-        };
+        this.sandbox.stub(workflowApiService, 'defineTask').resolves();
+        this.sandbox.stub(workflowApiService, 'getAllWorkflows').resolves();
+        this.sandbox.stub(workflowApiService, 'createAndRunGraph').resolves();
+        this.sandbox.stub(workflowApiService, 'getWorkflowByInstanceId').resolves();
+        this.sandbox.stub(workflowApiService, 'cancelTaskGraph').resolves();
+        this.sandbox.stub(workflowApiService, 'deleteTaskGraph').resolves();
         return helper.injector.get('Views').load();
-
     });
 
-    afterEach('clean up mocks', function () {
-        this.sandbox.reset();
-    });
-
-    after('stop HTTP server', function () {
-        this.sandbox.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     describe('workflowsGet', function () {
         it('should return a list of persisted graph objects', function () {

--- a/spec/lib/api/login/login-spec.js
+++ b/spec/lib/api/login/login-spec.js
@@ -81,7 +81,7 @@ describe('Http.Api.Login', function () {
     before('setup default admin user', function() {
         waterline = helper.injector.get('Services.Waterline');
         waterline.localusers = {
-            findOne: sinon.stub()
+            findOne: sandbox.stub()
         };
         waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
             username: 'admin',
@@ -90,9 +90,6 @@ describe('Http.Api.Login', function () {
         waterline.localusers.findOne.resolves();
     });
 
-    after('remove waterline definition', function() {
-        delete waterline.localusers;
-    });
     describe('test with authentication enabled', function () {
         before('start HTTPs server', function () {
             this.timeout(5000);

--- a/spec/lib/api/redfish-1.0/chassis-spec.js
+++ b/spec/lib/api/redfish-1.0/chassis-spec.js
@@ -117,69 +117,47 @@ describe('Redfish Chassis Root', function () {
         oper_state: "on"
     };
 
-    before('start HTTP server', function () {
-        var self = this;
-        this.timeout(5000);
-        this.sandbox = sinon.sandbox.create();
+    helper.httpServerBefore();
 
-        return helper.startServer([]).then(function () {
-            redfish = helper.injector.get('Http.Api.Services.Redfish');
-            self.sandbox.spy(redfish, 'render');
-
-            validator = helper.injector.get('Http.Api.Services.Schema');
-            self.sandbox.spy(validator, 'validate');
-
-            waterline = helper.injector.get('Services.Waterline');
-            self.sandbox.stub(waterline.nodes);
-            waterline.nodes.findByIdentifier.withArgs('4567efgh4567efgh4567efgh').resolves(enclosure);
-            waterline.nodes.findByIdentifier.withArgs('1234abcd1234abcd1234abcd').resolves(system);
-            waterline.nodes.findByIdentifier.withArgs('aaaabbbbcccc111122223333').resolves(ucsEnclosure);
-            waterline.nodes.findByIdentifier.withArgs('ddddeeeeffff444455556666').resolves(ucsSystem);
-            waterline.nodes.findByIdentifier.resolves();
-
-            Promise = helper.injector.get('Promise');
-            Errors = helper.injector.get('Errors');
-
-            taskProtocol = helper.injector.get('Protocol.Task');
-            self.sandbox.stub(taskProtocol);
-
-            env = helper.injector.get('Services.Environment');
-            self.sandbox.stub(env, "get").resolves({});
-
-            var nodeFs = helper.injector.get('fs');
-            fs = Promise.promisifyAll(nodeFs);
-
-            nodeApi = helper.injector.get('Http.Services.Api.Nodes');
-            self.sandbox.stub(nodeApi, "getAllNodes");
-            self.sandbox.stub(nodeApi, "getNodeCatalogSourceById");
-            self.sandbox.stub(nodeApi, "getPollersByNodeId");
-            self.sandbox.stub(nodeApi, "getNodeById");
-            nodeApi.getNodeById.withArgs('4567efgh4567efgh4567efgh').resolves(enclosure);
-            nodeApi.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(system);
-            nodeApi.getNodeById.withArgs('aaaabbbbcccc111122223333').resolves(ucsEnclosure);
-            nodeApi.getNodeById.withArgs('ddddeeeeffff444455556666').resolves(ucsSystem);
-
-            nodeApi.getNodeById.rejects(new Errors.NotFoundError('Not Found'));
-        });
-
+    before(function () {
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        validator = helper.injector.get('Http.Api.Services.Schema');
+        waterline = helper.injector.get('Services.Waterline');
+        Promise = helper.injector.get('Promise');
+        Errors = helper.injector.get('Errors');
+        taskProtocol = helper.injector.get('Protocol.Task');
+        env = helper.injector.get('Services.Environment');
+        var nodeFs = helper.injector.get('fs');
+        fs = Promise.promisifyAll(nodeFs);
+        nodeApi = helper.injector.get('Http.Services.Api.Nodes');
+        tv4 = require('tv4');
     });
 
     beforeEach('set up mocks', function () {
-        tv4 = require('tv4');
-        sinon.spy(tv4, "validate");
-
-        this.sandbox.reset();
+        this.sandbox.spy(tv4, "validate");
+        this.sandbox.spy(redfish, 'render');
+        this.sandbox.spy(validator, 'validate');
+        this.sandbox.stub(waterline.nodes);
+        waterline.nodes.findByIdentifier.withArgs('4567efgh4567efgh4567efgh').resolves(enclosure);
+        waterline.nodes.findByIdentifier.withArgs('1234abcd1234abcd1234abcd').resolves(system);
+        waterline.nodes.findByIdentifier.withArgs('aaaabbbbcccc111122223333').resolves(ucsEnclosure);
+        waterline.nodes.findByIdentifier.withArgs('ddddeeeeffff444455556666').resolves(ucsSystem);
+        waterline.nodes.findByIdentifier.resolves();
+        this.sandbox.stub(taskProtocol);
+        this.sandbox.stub(env, "get").resolves({});
+        this.sandbox.stub(nodeApi, "getAllNodes");
+        this.sandbox.stub(nodeApi, "getNodeCatalogSourceById");
+        this.sandbox.stub(nodeApi, "getPollersByNodeId");
+        this.sandbox.stub(nodeApi, "getNodeById");
+        nodeApi.getNodeById.withArgs('4567efgh4567efgh4567efgh').resolves(enclosure);
+        nodeApi.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(system);
+        nodeApi.getNodeById.withArgs('aaaabbbbcccc111122223333').resolves(ucsEnclosure);
+        nodeApi.getNodeById.withArgs('ddddeeeeffff444455556666').resolves(ucsSystem);
+        nodeApi.getNodeById.rejects(new Errors.NotFoundError('Not Found'));
         nodeApi.getAllNodes.resolves([enclosure]);
     });
 
-    afterEach('tear down mocks', function () {
-        tv4.validate.restore();
-    });
-
-    after('stop HTTP server', function () {
-        this.sandbox.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return a valid chassis root', function () {
         nodeApi.getAllNodes.resolves([enclosure]);

--- a/spec/lib/api/redfish-1.0/event-service-spec.js
+++ b/spec/lib/api/redfish-1.0/event-service-spec.js
@@ -15,10 +15,10 @@ describe('Redfish Event Service', function () {
     var eventDestination = {
         Destination: 'http://1.1.1.1:8080',
         EventTypes: [
-            'Alert', 
-            'StatusChange', 
-            'ResourceAdded', 
-            'ResourceUpdated', 
+            'Alert',
+            'StatusChange',
+            'ResourceAdded',
+            'ResourceUpdated',
             'ResourceRemoved'
         ],
         Context: 'Event Context',
@@ -39,62 +39,32 @@ describe('Redfish Event Service', function () {
             }
         }]
     };
-    
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        function redfishTool() {
-            this.clientRequest = sinon.stub(); // jshint ignore:line
-        }
-        helper.setupInjector([
-            helper.di.simpleWrapper(redfishTool,'JobUtils.RedfishTool')
-        ]);
 
-        return helper.startServer([]).then(function () {
-            Constants = helper.injector.get('Constants');
-            Promise = helper.injector.get('Promise');
-            
-            redfish = helper.injector.get('Http.Api.Services.Redfish');
-            sinon.spy(redfish, 'render');
-            
-            validator = helper.injector.get('Http.Api.Services.Schema');
-            sinon.spy(validator, 'validate');
-            
-            var Subscription = helper.injector.get('Subscription');
-            subscription = new Subscription({},{});
-            
-            messenger = helper.injector.get('Services.Messenger');
-            sinon.stub(messenger);
-            messenger.subscribe = sinon.spy(function(name,exchange,callback) {
-                callback(eventDestination);
-                return Promise.resolve(subscription);
-            });
-        });
+    helper.httpServerBefore();
+
+    before(function () {
+        Constants = helper.injector.get('Constants');
+        Promise = helper.injector.get('Promise');
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        validator = helper.injector.get('Http.Api.Services.Schema');
+        var Subscription = helper.injector.get('Subscription');
+        subscription = new Subscription({},{});
+        messenger = helper.injector.get('Services.Messenger');
+        tv4 = require('tv4');
     });
 
     beforeEach('set up mocks', function () {
-        tv4 = require('tv4');
-        sinon.spy(tv4, "validate");
-        validator.validate.reset();
-        redfish.render.reset();
+        this.sandbox.spy(tv4, "validate");
+        this.sandbox.spy(redfish, 'render');
+        this.sandbox.spy(validator, 'validate');
+        this.sandbox.stub(messenger);
+        messenger.subscribe = this.sandbox.spy(function(name,exchange,callback) {
+            callback(eventDestination);
+            return Promise.resolve(subscription);
+        });
     });
 
-    afterEach('tear down mocks', function () {
-        tv4.validate.restore();
-    });
-
-    after('stop HTTP server', function () {
-        validator.validate.restore();
-        redfish.render.restore();
-        function restoreStubs(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (obj[method] && obj[method].restore) {
-                  obj[method].restore();
-                }
-            }).value();
-        }
-        restoreStubs(messenger);
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return a valid event service root', function () {
         return helper.request().get('/redfish/v1/EventService')

--- a/spec/lib/api/redfish-1.0/registry-spec.js
+++ b/spec/lib/api/redfish-1.0/registry-spec.js
@@ -19,41 +19,28 @@ describe('Redfish Registries', function () {
             });
     }
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer([]).then(function () {
-            redfish = helper.injector.get('Http.Api.Services.Redfish');
-            sinon.spy(redfish, 'render');
-            validator = helper.injector.get('Http.Api.Services.Schema');
-            sinon.spy(validator, 'validate');
-            view = helper.injector.get('Views');
-            sinon.stub(view, "get", redirectGet);
-            Promise = helper.injector.get('Promise');
-            var nodeFs = helper.injector.get('fs');
-            fs = Promise.promisifyAll(nodeFs);
-            env = helper.injector.get('Services.Environment');
-            sinon.stub(env, "get").resolves();
-        });
-    });
-    beforeEach('set up mocks', function () {
+    helper.httpServerBefore();
+
+    before(function () {
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        validator = helper.injector.get('Http.Api.Services.Schema');
+        view = helper.injector.get('Views');
+        Promise = helper.injector.get('Promise');
+        var nodeFs = helper.injector.get('fs');
+        fs = Promise.promisifyAll(nodeFs);
+        env = helper.injector.get('Services.Environment');
         tv4 = require('tv4');
-        sinon.spy(tv4, "validateResult");
-
-        validator.validate.reset();
-        redfish.render.reset();
     });
 
-    afterEach('tear down mocks', function () {
-        tv4.validateResult.restore();
+    beforeEach('set up mocks', function () {
+        this.sandbox.spy(tv4, "validateResult");
+        this.sandbox.spy(redfish, 'render');
+        this.sandbox.spy(validator, 'validate');
+        this.sandbox.stub(view, "get", redirectGet);
+        this.sandbox.stub(env, "get").resolves();
     });
 
-    after('stop HTTP server', function () {
-        validator.validate.restore();
-        redfish.render.restore();
-        view.get.restore();
-        env.get.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return a valid collection of registries', function() {
         return helper.request().get('/redfish/v1/Registries')

--- a/spec/lib/api/redfish-1.0/roles-spec.js
+++ b/spec/lib/api/redfish-1.0/roles-spec.js
@@ -6,22 +6,17 @@
 describe('Redfish Roles', function () {
     var redfish;
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer([]).then(function () {
-            redfish = helper.injector.get('Http.Api.Services.Redfish');
-            sinon.spy(redfish, 'render');
-        });
+    helper.httpServerBefore();
+
+    before(function () {
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
     });
 
     beforeEach('set up mocks', function () {
-         redfish.render.reset();    });
-
-
-    after('stop HTTP server', function () {
-        redfish.render.restore();
-        return helper.stopServer();
+        this.sandbox.spy(redfish, 'render');
     });
+
+    helper.httpServerAfter();
 
     it('should return valid roles', function () {
         return helper.request().get('/redfish/v1/AccountService/Roles')

--- a/spec/lib/api/redfish-1.0/schemas-spec.js
+++ b/spec/lib/api/redfish-1.0/schemas-spec.js
@@ -11,38 +11,23 @@ describe('Redfish Schemas', function () {
     var Promise;
     var fromRoot = process.cwd();
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer([]).then(function () {
-            redfish = helper.injector.get('Http.Api.Services.Redfish');
-            sinon.spy(redfish, 'render');
+    helper.httpServerBefore();
 
-            validator = helper.injector.get('Http.Api.Services.Schema');
-            Promise = helper.injector.get('Promise');
-            fs = Promise.promisifyAll( helper.injector.get('fs') );
-            sinon.spy(validator, 'validate');
-        });
+    before(function () {
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        validator = helper.injector.get('Http.Api.Services.Schema');
+        Promise = helper.injector.get('Promise');
+        fs = Promise.promisifyAll( helper.injector.get('fs') );
+        tv4 = require('tv4');
     });
 
     beforeEach('set up mocks', function () {
-        tv4 = require('tv4');
-        sinon.spy(tv4, "validate");
-
-        validator.validate.reset();
-        redfish.render.reset();
-
+        this.sandbox.spy(tv4, "validate");
+        this.sandbox.spy(redfish, 'render');
+        this.sandbox.spy(validator, 'validate');
     });
 
-    afterEach('tear down mocks', function () {
-        tv4.validate.restore();
-    });
-
-    after('stop HTTP server', function () {
-        validator.validate.restore();
-        redfish.render.restore();
-        
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return valid schemas', function () {
 

--- a/spec/lib/api/redfish-1.0/service-root-spec.js
+++ b/spec/lib/api/redfish-1.0/service-root-spec.js
@@ -20,43 +20,28 @@ describe('Redfish Endpoint', function () {
             });
     }
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
-        return helper.startServer([]).then(function () {
-            redfish = helper.injector.get('Http.Api.Services.Redfish');
-            sinon.spy(redfish, 'render');
-            validator = helper.injector.get('Http.Api.Services.Schema');
-            sinon.spy(validator, 'validate');
-            view = helper.injector.get('Views');
-            sinon.stub(view, "get", redirectGet);
-            Promise = helper.injector.get('Promise');
-            var nodeFs = helper.injector.get('fs');
-            fs = Promise.promisifyAll(nodeFs);
-            systemUuid = helper.injector.get('SystemUuid');
-            sinon.stub(systemUuid, 'getUuid');
-        });
+    helper.httpServerBefore();
+
+    before(function() {
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        validator = helper.injector.get('Http.Api.Services.Schema');
+        view = helper.injector.get('Views');
+        Promise = helper.injector.get('Promise');
+        var nodeFs = helper.injector.get('fs');
+        fs = Promise.promisifyAll(nodeFs);
+        systemUuid = helper.injector.get('SystemUuid');
+        tv4 = require('tv4');
     });
 
     beforeEach('set up mocks', function () {
-        tv4 = require('tv4');
-        sinon.spy(tv4, "validate");
-
-        validator.validate.reset();
-        redfish.render.reset();
-        systemUuid.getUuid.reset();
+        this.sandbox.spy(tv4, "validate");
+        this.sandbox.spy(redfish, 'render');
+        this.sandbox.spy(validator, 'validate');
+        this.sandbox.stub(view, "get", redirectGet);
+        this.sandbox.stub(systemUuid, 'getUuid');
     });
 
-    afterEach('tear down mocks', function () {
-        tv4.validate.restore();
-        systemUuid.getUuid.restore();
-    });
-
-    after('stop HTTP server', function () {
-        validator.validate.restore();
-        redfish.render.restore();
-        view.get.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return a valid service root', function () {
         systemUuid.getUuid.resolves('66ddf9c7-a3a4-47fc-b603-60737d1f15a8');

--- a/spec/lib/api/redfish-1.0/session-service-spec.js
+++ b/spec/lib/api/redfish-1.0/session-service-spec.js
@@ -23,95 +23,47 @@ describe('Redfish Session Service', function () {
             });
     }
 
-    before('start HTTP server', function () {
-        this.timeout(5000);
+    helper.httpServerBefore([], { authEnabled: true });
 
-        return helper.startServer([], { authEnabled: true }).then(function () {
-            Constants = helper.injector.get('Constants');
-
-            view = helper.injector.get('Views');
-            sinon.stub(view, "get", redirectGet);
-
-            redfish = helper.injector.get('Http.Api.Services.Redfish');
-            sinon.spy(redfish, 'render');
-
-            validator = helper.injector.get('Http.Api.Services.Schema');
-            sinon.spy(validator, 'validate');
-
-            waterline = helper.injector.get('Services.Waterline');
-            sinon.stub(waterline.graphobjects);
-            sinon.stub(waterline.nodes);
-            sinon.stub(waterline.localusers, 'findOne');
-            waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
-                username: 'admin',
-                comparePassword: function(password) { return password === 'admin123'; }
-            });
-            waterline.localusers.findOne.resolves();
-
-            Promise = helper.injector.get('Promise');
-
-            env = helper.injector.get('Services.Environment');
-            sinon.stub(env, "get").resolves();
-
-            var nodeFs = helper.injector.get('fs');
-            fs = Promise.promisifyAll(nodeFs);
-
-            helper.injector.get('Auth.Services').init();
-            accountService = helper.injector.get('Http.Services.Api.Account');
-
-            // Setup ACL rules that are missed during startServer
-            return Promise.all([
-                accountService.aclMethod('addUserRoles', 'admin', 'Administrator'),
-                accountService.aclMethod('addUserRoles', 'readonly', 'ReadOnly'),
-                accountService.aclMethod('addRoleParents', 'Administrator', ['ConfigureUsers']),
-                accountService.aclMethod('addRoleParents', 'ReadOnly', ['ConfigureSelf'])
-            ]);
-
-        });
+    before(function () {
+        Constants = helper.injector.get('Constants');
+        view = helper.injector.get('Views');
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        validator = helper.injector.get('Http.Api.Services.Schema');
+        waterline = helper.injector.get('Services.Waterline');
+        Promise = helper.injector.get('Promise');
+        env = helper.injector.get('Services.Environment');
+        var nodeFs = helper.injector.get('fs');
+        fs = Promise.promisifyAll(nodeFs);
+        helper.injector.get('Auth.Services').init();
+        accountService = helper.injector.get('Http.Services.Api.Account');
+        tv4 = require('tv4');
     });
 
     beforeEach('set up mocks', function () {
-        tv4 = require('tv4');
-        sinon.spy(tv4, "validate");
-
-        validator.validate.reset();
-        redfish.render.reset();
-
-        function resetStubs(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (obj[method] && obj[method].reset) {
-                  obj[method].reset();
-                }
-            }).value();
-        }
-
-        resetStubs(waterline.graphobjects);
-        resetStubs(waterline.nodes);
+        this.sandbox.spy(tv4, "validate");
+        this.sandbox.stub(view, "get", redirectGet);
+        this.sandbox.spy(redfish, 'render');
+        this.sandbox.spy(validator, 'validate');
+        this.sandbox.stub(env, "get").resolves();
+        this.sandbox.stub(waterline.graphobjects);
+        this.sandbox.stub(waterline.nodes);
+        this.sandbox.stub(waterline.localusers, 'findOne');
+        waterline.localusers.findOne.withArgs({username: 'admin'}).resolves({
+            username: 'admin',
+            comparePassword: function(password) { return password === 'admin123'; }
+        });
+        waterline.localusers.findOne.resolves();
+        // Setup ACL rules that are missed during startServer
+        return Promise.all([
+            accountService.aclMethod('addUserRoles', 'admin', 'Administrator'),
+            accountService.aclMethod('addUserRoles', 'readonly', 'ReadOnly'),
+            accountService.aclMethod('addRoleParents', 'Administrator', ['ConfigureUsers']),
+            accountService.aclMethod('addRoleParents', 'ReadOnly', ['ConfigureSelf'])
+        ]);
     });
 
-    afterEach('tear down mocks', function () {
-        tv4.validate.restore();
-    });
-
-    after('stop HTTP server', function () {
-        validator.validate.restore();
-        redfish.render.restore();
-        view.get.restore();
-        env.get.restore();
-
-        function restoreStubs(obj) {
-            _(obj).methods().forEach(function (method) {
-                if (obj[method] && obj[method].restore) {
-                  obj[method].restore();
-                }
-            }).value();
-        }
-
-        restoreStubs(waterline.graphobjects);
-        restoreStubs(waterline.nodes);
-        waterline.localusers.findOne.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return a valid session service root', function () {
         return helper.request().get('/redfish/v1/SessionService')

--- a/spec/lib/api/redfish-1.0/update-service-spec.js
+++ b/spec/lib/api/redfish-1.0/update-service-spec.js
@@ -189,41 +189,31 @@ describe('Redfish Update Service', function () {
         "type": "compute"
     };
 
-    before('start HTTP server', function () {
-        var self = this;
+    helper.httpServerBefore([], {authEnabled: false});
+
+    before(function () {
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        waterline = helper.injector.get('Services.Waterline');
+        workflow = helper.injector.get('Http.Services.Api.Workflows');
+        validator = helper.injector.get('Http.Api.Services.Schema');
         tv4 = require('tv4');
-
-        this.timeout(15000);
-        this.sandbox = sinon.sandbox.create();
-
-        return helper.startServer([], {authEnabled: false})
-            .then(function () {
-                redfish = helper.injector.get('Http.Api.Services.Redfish');
-                waterline = helper.injector.get('Services.Waterline');
-                workflow = helper.injector.get('Http.Services.Api.Workflows');
-                validator = helper.injector.get('Http.Api.Services.Schema');
-                self.sandbox.spy(tv4, "validate");
-                self.sandbox.spy(validator, 'validate');
-                self.sandbox.spy(redfish, 'validateSchema');
-                self.sandbox.spy(redfish, 'handleError');
-                self.sandbox.spy(redfish, 'render');
-                self.sandbox.stub(waterline.obms, 'findAllByNode');
-                self.sandbox.stub(waterline.nodes, 'getNodeById');
-                self.sandbox.stub(waterline.nodes, 'findByIdentifier');
-                self.sandbox.stub(waterline.catalogs, 'find');
-                self.sandbox.stub(waterline.catalogs, 'findMostRecent');
-                self.sandbox.stub(workflow, 'createAndRunGraph');
-            });
     });
 
-    afterEach('tear down mocks', function () {
-        this.sandbox.reset();
+    beforeEach('set up mocks', function() {
+        this.sandbox.spy(tv4, "validate");
+        this.sandbox.spy(validator, 'validate');
+        this.sandbox.spy(redfish, 'validateSchema');
+        this.sandbox.spy(redfish, 'handleError');
+        this.sandbox.spy(redfish, 'render');
+        this.sandbox.stub(waterline.obms, 'findAllByNode');
+        this.sandbox.stub(waterline.nodes, 'getNodeById');
+        this.sandbox.stub(waterline.nodes, 'findByIdentifier');
+        this.sandbox.stub(waterline.catalogs, 'find');
+        this.sandbox.stub(waterline.catalogs, 'findMostRecent');
+        this.sandbox.stub(workflow, 'createAndRunGraph');
     });
 
-    after('stop HTTP server', function () {
-        this.sandbox.restore();
-        return helper.stopServer();
-    });
+    helper.httpServerAfter();
 
     it('should return a valid updateService root', function () {
         return helper.request().get('/redfish/v1/UpdateService')

--- a/spec/lib/services/redfish-validator-service-spec.js
+++ b/spec/lib/services/redfish-validator-service-spec.js
@@ -44,7 +44,7 @@ describe("Redfish Validator Service", function() {
         view.get.reset();
     });
 
-    helper.after(function () {
+    after(function () {
         view.get.restore();
         env.get.restore();
     });

--- a/spec/lib/services/schema-api-service-spec.js
+++ b/spec/lib/services/schema-api-service-spec.js
@@ -45,7 +45,7 @@ describe("Schema API Service", function() {
         template.get.reset();
     });
 
-    helper.after(function () {
+    after(function () {
         template.get.restore();
     });
 

--- a/spec/lib/services/sku-pack-service-spec.js
+++ b/spec/lib/services/sku-pack-service-spec.js
@@ -74,7 +74,7 @@ describe("SKU Pack Service", function() {
         self.sandbox.reset();
     });
 
-    helper.after(function () {
+    after(function () {
         self.sandbox.restore();
     });
 

--- a/spec/lib/services/upnp-service-spec.js
+++ b/spec/lib/services/upnp-service-spec.js
@@ -90,7 +90,7 @@ describe("UPnP Service", function() {
         uPnPService.cache.removeAllListeners('expired');
     });
 
-    helper.after(function () {
+    after(function () {
         sandbox.restore();
     });
 


### PR DESCRIPTION
**Backgroud**
This is for the story https://rackhd.atlassian.net/browse/RAC-5639.

During work of https://rackhd.atlassian.net/browse/RAC-5593, we found many unit test cases won't do the clean-up work if running into failure (aka exception handler) , so the plan is to add clean-up work in unit test cases.

**DONE**
1) add helper.httpServerBefore and helper.httpServerAfter as common
methods to start and stop mock HTTP server.
2) fix the issue that some unit test file doesn't stop mock HTTP server
when starting mock server timeouts.
3) add global sandbox in beforeEach, and restore it in afterEach
4) remove unnecessary resetStubs and restoreStubs

**TEST**
It's tested in sandbox:
http://10.62.59.175:8080/job/on-core_jamie/



@RackHD/corecommitters 