### PR TITLE
RAC-5414 - LogServices/sel/Entries "Cannot read property '3' of null"

### DIFF
--- a/data/views/redfish-1.0/redfish.1.0.0.logentry.1.0.0.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.logentry.1.0.0.json
@@ -6,7 +6,9 @@
     "Id": "<%= entry.logId %>",
     "Name": "name",
     "EntryType": "<%= type %>",
+    <% if (entry.timestamp !== "") { %>
     "Created": "<%= entry.timestamp %>",
+    <% } %>
     "OemRecordFormat": "",
     "EntryCode": "<%= entry.value %>",
     "SensorType": "<%= entry.sensorType %>",

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -196,15 +196,16 @@ var selTranslator = function(selArray, identifier) {
     };
 
     return Promise.map(selArray, function(entry) {
-        var dates = dateRegex.exec(entry.date);
-        var times = timeRegex.exec(entry.time);
+        // if date is an enty string then so is time
+        var dates = entry.date !== "" ? dateRegex.exec(entry.date) : "";
+        var times = entry.date !== "" ? timeRegex.exec(entry.time) : "";
         if(entry.sensorNumber.indexOf('#') !== 0) {
             entry.sensorNumber = '#'+entry.sensorNumber;
         }
         return Promise.props({
             logId: entry.logId,
             // Month is zero indexed by moment so we must decrement
-            timestamp: moment.utc([dates[3], dates[1] - 1, dates[2], times[1], times[2], times[3]]).format(),
+            timestamp: dates !== "" ? moment.utc([dates[3], dates[1] - 1, dates[2], times[1], times[2], times[3]]).format() : "",
             sensorType: _.get(ipmiSensorTypeMap, entry.sensorType, 'Other Units-based Sensor'),
             value: _.get(ipmiEventTypeMap, entry.value, entry.value),
             event: entry.event,

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -196,7 +196,7 @@ var selTranslator = function(selArray, identifier) {
     };
 
     return Promise.map(selArray, function(entry) {
-        // if date is an enty string then so is time
+        // if date is an empty string then so is time
         var dates = entry.date !== "" ? dateRegex.exec(entry.date) : "";
         var times = entry.date !== "" ? timeRegex.exec(entry.time) : "";
         if(entry.sensorNumber.indexOf('#') !== 0) {


### PR DESCRIPTION
* In redfish logentry.1.0.0.json, bypass "Created' keyword if timestamp is null
* In systems.js, skip time and date processing if date is ""
* Create test to validate empty date and time processing