### PR TITLE
RAC-5629 - Fix typo in reference for MessageRegistry to be v1_0_0.

### DIFF
--- a/static/redfishMetadata.xml
+++ b/static/redfishMetadata.xml
@@ -101,7 +101,7 @@
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/Schemas/MessageRegistryFileCollection_v1.xml">
         <edmx:Include Namespace="MessageRegistryFileCollection"/>
-        <edmx:Include Namespace="MessageRegistryFileCollection.v_1_0_0"/>
+        <edmx:Include Namespace="MessageRegistryFileCollection.v1_0_0"/>
     </edmx:Reference>
     <edmx:Reference Uri="/redfish/v1/Schemas/Power_v1.xml">
         <edmx:Include Namespace="Power"/>


### PR DESCRIPTION
Need to fix a typo in redfishMetadata.xml file for compliance testing.