### PR TITLE
[RAC5316]Travis CI: failed to build debian packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - dh-make
       - devscripts
       - debhelper
+      - fakeroot
       - git
       - default-jdk
       - maven


### PR DESCRIPTION
Fix RAC-5316: Travis CI: failed to build debian packages
Error message:
`+debuild --no-lintian --no-tgz-check -us -uc
debuild: fatal error at line 948:
problem running fakeroot: either install the fakeroot package,
use a -r option to select another root command program to use or
run me as root!`
The PR: install fakeroot for debuild to fix the issue.

@anhou @iceiilin 