### PR TITLE
RAC-5786 - Normalization of system-spec.js

### DIFF
--- a/lib/services/wsman-service.js
+++ b/lib/services/wsman-service.js
@@ -100,13 +100,13 @@ function wsmanServiceFactory(
             }
             return node;        
         }).then(function(node){
-            return waterline.obms.findByNode(node.id, 'redfish-obm-service', true)
+            Promise.resolve(waterline.obms.findByNode(node.id, 'redfish-obm-service', true))
             .then(function (obmSetting) {
                 if(obmSetting){
                     result.isRedfishCapable = true;
                 }
-                return result;
             });
+            return result;
         });
     };
 


### PR DESCRIPTION
* Dell vs non-dell is not handled quite right. The wsman.isDellSystem call
  should be allowed to succeed or fail based on the result of getNodeById.
* Default resolve statements mask various blocks of code.
* Add some consistency to the use of node ids. Reference object ids
  when possible instead of writing duplicate ids.
* Add consistency to sel and lc case