### PR TITLE
Refine error log when http request failure in on-http.log

### DIFF
--- a/lib/services/http-service.js
+++ b/lib/services/http-service.js
@@ -345,7 +345,15 @@ function httpServiceFactory(
                         data
                     );
                 }
-                logger.error('http: ' + JSON.stringify(res.body));
+                var errorMessage;
+                if (typeof(res.body) !== 'undefined'){
+                    errorMessage = {
+                        "message" : res.body.message,
+                        "status" : res.body.status,
+                        "uuid" : res.body.uuid
+                    };
+                }
+                logger.error('http: ' + JSON.stringify(errorMessage));
             }
 
             eventsProtocol.publishHttpResponse(


### PR DESCRIPTION
Before the code change, on-http.log has a whole bunch of information that doesn't help. To help the developers grasp important information sooner, remove the unnecessary information. For example, when executing a curl command that fails, the log only shows the information of "message", "status" and "uuid".
This is to solve  the issue in:
https://rackhd.atlassian.net/browse/RAC-5457
@iceiilin @anhou @pengz1 