### PR TITLE
Fix TravisCI unittest failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: node_js
 sudo: true
 node_js:


### PR DESCRIPTION
Recently, TravisCI has an upgrade from precise to higher ubuntu distribution. mongo verison is also upgraded, add `dist: precise` to make TravisCI still use previous ubuntu precise version to let it pass. it's only a temporary method.  later, we'll submit PR to all repos to fix the compatibility problem.