### PR TITLE
RAC-4984 [cookie]npm install on-http missing static/files folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,8 @@ node_modules
 
 # static images
 static/ansible/
-static/files/
+static/files/*
+!static/files/.gitkeep
 static/http/
 static/smb/
 static/tftp/


### PR DESCRIPTION
**Background**
Previously, static/files/ is ignored by .gitignore, but npm publish will match the ignore rule in .gitignore if .npmignore file is not specified. So after we install on-http by using npm, a _static/files folder not found error_ will occur when trying to upload a file to on-http.

**Solution**
In order to solve this problem, we can ignore all the files under static/files folder except the .gitkeep file by changing the .gitignore file. 