### PR TITLE
Raid configuration support

### DIFF
--- a/data/templates/megaraid-config.sh
+++ b/data/templates/megaraid-config.sh
@@ -1,97 +1,95 @@
 #!/usr/bin/env bash
-ssdStoragePoolArr=<%=ssdStoragePoolArr%>
-ssdCacheCadeArr=<%=ssdCacheCadeArr%>
-type=<%=type%>
+hddArr=<%- JSON.stringify(hddArr) || [] %>
+ssdStoragePoolArr=<%- JSON.stringify(ssdStoragePoolArr) || [] %>
+ssdCacheCadeArr=<%- JSON.stringify(ssdCacheCadeArr) || [] %>
 path=<%=path%>
-hddArr=<%- JSON.stringify(hddArr) %>
 controller=<%=controller%>
 
 echo hddArr is: $hddArr
 echo ssdStoragePoolArr is: $ssdStoragePoolArr
 echo ssdCacheCadeArr is: $ssdCacheCadeArr
-echo type is: $type
 echo path is: $path
-
+echo controller is: $controller
 
 function create_vd_for_hdd()
 {
-    echo "Creating Virtual Disks For Hard Drives using hddArr"
+    echo "Creating Virtual Disks For Hard Drives"
     <% hddArr.forEach(function (value){ %>
-        echo running check for Ugood before
         convertedDrivesList=(<%=value.drives.replace(/[[\],]/g,' ')%>)
-        echo printing convertedListt "${convertedDrivesList[0]}"
         for i in "${convertedDrivesList[@]}"
             do
-               echo inside loop $i
+               echo Assesing drive $i for Ugood state
                cmdReturn=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /eall /sall show | grep <%=value.enclosure%>:$i)
-               myarray=(${cmdReturn})
-               echo ${myarray[2]}
-               if [[ ${myarray[2]} == "Onln" ]]; then
-                   echo "BINGO, online"
-                   #vdMatch1=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep ${myarray[3]}\/)
-
-                   vdMatch1=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep ${myarray[3]}\/ |cut -d / -f2 |cut -d " " -f1)
-                   echo printing output : $vdMatch1
-                   #KU: Using |grep followed by |cut with delimiters / and " " to get the number after the DG/ : that worked
-                   #get the regex on vdMatch
+               stateInfo=(${cmdReturn})
+               if [[ ${stateInfo[2]} == "Onln" ]]; then
+                   echo "Given disk is online, changing into Ugood State"
+                   #Using |grep followed by |cut with delimiters / and " " to get the number after the DG/
+                   vdMatch1=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep ${stateInfo[3]}\/ |cut -d / -f2 |cut -d " " -f1)
                    # split on / and call delete
                    delete_individual_vd $vdMatch1
                fi
             done
-        hardDrives=<%=value.drives.replace(/[[\]]/g,'')%>
-        echo printing hardDrives: $hardDrives
         echo running: $path /c$controller add vd type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> direct wb ra pdcache=off
         $path /c$controller add vd type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> direct wb ra pdcache=off
-    echo "Done Creating Virtual Disks For Hard Drives using"
     <% }); %>
+    echo "Done Creating Virtual Disks For Hard Drives"
+
 }
 
 function create_vd_for_ssd_sp()
 {
     echo "Creating Virtual Disks for Solid  State Drives For Storage Pool"
-    if [ ! -z $ssdStoragePoolArr ]; then
-        convertedSsdStoragePoolArr=(<%= ssdStoragePoolArr.join(" ") %>)
-        for i in "${convertedSsdStoragePoolArr[@]}"
+    <% ssdStoragePoolArr.forEach(function (value){ %>
+        convertedDrivesList=(<%=value.drives.replace(/[[\],]/g,' ')%>)
+        for i in "${convertedDrivesList[@]}"
             do
-                echo running: $path /c$controller add vd type=$type drives=$i  direct wt ra
-                $path /c$controller add vd type=$type drives=$i  direct wt ra
+               echo Accessing drive $i for Ugood state
+               cmdReturn=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /eall /sall show | grep <%=value.enclosure%>:$i)
+               stateInfo=(${cmdReturn})
+               if [[ ${stateInfo[2]} == "Onln" ]]; then
+                   echo "Given disk is online, changing into Ugood State"
+                   #Using |grep followed by |cut with delimiters / and " " to get the number after the DG/
+                   vdMatch1=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep ${stateInfo[3]}\/ |cut -d / -f2 |cut -d " " -f1)
+                   # split on / and call delete
+                   delete_individual_vd $vdMatch1
+               fi
             done
-    fi
+        echo running: $path /c$controller add vd type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> direct wt ra
+        $path /c$controller add vd type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> direct wt ra
+    <% }); %>
     echo "Done creating Virtual Disks for Solid  State Drives For Storage Pool"
 }
-
 
 #revisit/test on Dell nodes because currently H730 mini controller does not support cachecading
 # seeing SSC-spread spectrum clocking is not supported
 function create_sp_for_ssd_cache()
 {
     echo "Creating Virtual Disks for Solid  State Drives For Cache Cade"
-    if [ ! -z ssdCacheCadeArr ]; then
-        convertedSsdCacheCadeArr=(<%= ssdCacheCadeArr.join(" ") %>)
-        ITER=0
-        for i in "${convertedSsdCacheCadeArr[@]}"
+    <% ssdCacheCadeArr.forEach(function (value){ %>
+        convertedDrivesList=(<%=value.drives.replace(/[[\],]/g,' ')%>)
+        for i in "${convertedDrivesList[@]}"
             do
-                echo running:  $path /c$controller add vd cc type=$type drives=$i WB
-                $path /c$controller add vd cc type=$type drives=$i WB
-
-                echo running: $path  /c$controller/v$i  set rdcache=nora
-                $path  /c$controller/v$ITER  set rdcache=nora
-                ITER=$(expr $ITER + 1)
+               echo Assesing drive $i for Ugood state
+               cmdReturn=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /eall /sall show | grep <%=value.enclosure%>:$i)
+               stateInfo=(${cmdReturn})
+               if [[ ${stateInfo[2]} == "Onln" ]]; then
+                   echo "Given disk is online, changing into Ugood State"
+                   #Using |grep followed by |cut with delimiters / and " " to get the number after the DG/
+                   vdMatch1=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep ${stateInfo[3]}\/ |cut -d / -f2 |cut -d " " -f1)
+                   # split on / and call delete
+                   delete_individual_ssd_cc $vdMatch1
+               fi
             done
-
-    fi
+        echo running: $path /c$controller add vd cc type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> WB
+        $path /c$controller add vd cc type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> WB
+        #Currently only Cac0 exists
+        ssdVD=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep 'Cac0' |cut -d / -f2 |cut -d " " -f1)
+        #Disabling read ahead cache (nora) on the VD that was created above
+        echo running: $path  /c$controller/v$ssdVD  set rdcache=nora
+        $path  /c$controller/v$ssdVD  set rdcache=nora
+    <% }); %>
     echo "Done creating Virtual Disks for Solid  State Drives For Cache Cade"
-}
 
-function delete_vd()
-{
-    echo "Deleting Virtual Disks"
-	for i in {0..5}
-		do
-		    echo running: $path /c$controller/v$i del force
-		    $path /c$controller/v$i del force
-        done
-    echo "Done Deleting Virtual Disks"
 }
 
 function delete_individual_vd()
@@ -102,19 +100,14 @@ function delete_individual_vd()
     echo "Done Deleting Virtual Disks"
 }
 
-function delete_cc()
+function delete_individual_ssd_cc()
 {
-    echo "Deleting CacheCade"
-	for i in {0..0}
-		do
-		    echo running: $path /c0/v$i del cc
-		    $path /c0/v$i del cc
-        done
-    echo "Done Deleting CacheCade"
+    echo "Deleting $1 Virtual Disks"
+    echo running: $path /c$controller/v$1 del cc
+    $path /c$controller/v$1 del cc
+    echo "Done Deleting Virtual Disks"
 }
 
-#delete_vd
-#delete_cc
-#create_sp_for_ssd_cache
+create_sp_for_ssd_cache
 create_vd_for_hdd
-#create_vd_for_ssd_sp
+create_vd_for_ssd_sp

--- a/data/templates/megaraid-config.sh
+++ b/data/templates/megaraid-config.sh
@@ -1,25 +1,50 @@
 #!/usr/bin/env bash
-hddArr=<%=hddArr%>
 ssdStoragePoolArr=<%=ssdStoragePoolArr%>
 ssdCacheCadeArr=<%=ssdCacheCadeArr%>
+type=<%=type%>
+path=<%=path%>
+hddArr=<%- JSON.stringify(hddArr) %>
+controller=<%=controller%>
+
 echo hddArr is: $hddArr
 echo ssdStoragePoolArr is: $ssdStoragePoolArr
 echo ssdCacheCadeArr is: $ssdCacheCadeArr
+echo type is: $type
+echo path is: $path
+
 
 function create_vd_for_hdd()
 {
-    echo "Creating Virtual Disks for Hard Drives"
-    if [ ! -z "$hddArr" ]; then
-    convertedHddArr=(<%= hddArr.join(" ") %>)
-	for i in "${convertedHddArr[@]}"
-		do
-		    echo running: /opt/MegaRAID/storcli/storcli64 /c0 add vd type=raid0 drives=$i direct wb ra pdcache=off
-		    /opt/MegaRAID/storcli/storcli64 /c0 add vd type=raid0 drives=$i direct wb ra pdcache=off
-         done
-     fi
-    echo "Done Creating Virtual Disks For Hard Drives"
-}
+    echo "Creating Virtual Disks For Hard Drives using hddArr"
+    <% hddArr.forEach(function (value){ %>
+        echo running check for Ugood before
+        convertedDrivesList=(<%=value.drives.replace(/[[\],]/g,' ')%>)
+        echo printing convertedListt "${convertedDrivesList[0]}"
+        for i in "${convertedDrivesList[@]}"
+            do
+               echo inside loop $i
+               cmdReturn=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /eall /sall show | grep <%=value.enclosure%>:$i)
+               myarray=(${cmdReturn})
+               echo ${myarray[2]}
+               if [[ ${myarray[2]} == "Onln" ]]; then
+                   echo "BINGO, online"
+                   #vdMatch1=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep ${myarray[3]}\/)
 
+                   vdMatch1=$(sudo /opt/MegaRAID/storcli/storcli64 /c0 /vall show | grep ${myarray[3]}\/ |cut -d / -f2 |cut -d " " -f1)
+                   echo printing output : $vdMatch1
+                   #KU: Using |grep followed by |cut with delimiters / and " " to get the number after the DG/ : that worked
+                   #get the regex on vdMatch
+                   # split on / and call delete
+                   delete_individual_vd $vdMatch1
+               fi
+            done
+        hardDrives=<%=value.drives.replace(/[[\]]/g,'')%>
+        echo printing hardDrives: $hardDrives
+        echo running: $path /c$controller add vd type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> direct wb ra pdcache=off
+        $path /c$controller add vd type=<%=value.type%> drives=<%=value.enclosure%>:<%=value.drives.replace(/[[\]]/g,'')%> direct wb ra pdcache=off
+    echo "Done Creating Virtual Disks For Hard Drives using"
+    <% }); %>
+}
 
 function create_vd_for_ssd_sp()
 {
@@ -28,14 +53,16 @@ function create_vd_for_ssd_sp()
         convertedSsdStoragePoolArr=(<%= ssdStoragePoolArr.join(" ") %>)
         for i in "${convertedSsdStoragePoolArr[@]}"
             do
-                echo running: /opt/MegaRAID/storcli/storcli64 /c0 add vd type=raid0 drives=$i  direct wt ra
-                /opt/MegaRAID/storcli/storcli64 /c0 add vd type=raid0 drives=$i  direct wt ra
+                echo running: $path /c$controller add vd type=$type drives=$i  direct wt ra
+                $path /c$controller add vd type=$type drives=$i  direct wt ra
             done
     fi
     echo "Done creating Virtual Disks for Solid  State Drives For Storage Pool"
 }
 
 
+#revisit/test on Dell nodes because currently H730 mini controller does not support cachecading
+# seeing SSC-spread spectrum clocking is not supported
 function create_sp_for_ssd_cache()
 {
     echo "Creating Virtual Disks for Solid  State Drives For Cache Cade"
@@ -44,43 +71,50 @@ function create_sp_for_ssd_cache()
         ITER=0
         for i in "${convertedSsdCacheCadeArr[@]}"
             do
-                echo running:  /opt/MegaRAID/storcli/storcli64 /c0 add vd cc type=raid0 drives=$i WB
-                /opt/MegaRAID/storcli/storcli64 /c0 add vd cc type=raid0 drives=$i WB
+                echo running:  $path /c$controller add vd cc type=$type drives=$i WB
+                $path /c$controller add vd cc type=$type drives=$i WB
 
-                echo running: /opt/MegaRAID/storcli/storcli64  /c0/v$i  set rdcache=nora
-                /opt/MegaRAID/storcli/storcli64  /c0/v$ITER  set rdcache=nora
+                echo running: $path  /c$controller/v$i  set rdcache=nora
+                $path  /c$controller/v$ITER  set rdcache=nora
                 ITER=$(expr $ITER + 1)
             done
+
     fi
     echo "Done creating Virtual Disks for Solid  State Drives For Cache Cade"
 }
 
-
 function delete_vd()
 {
     echo "Deleting Virtual Disks"
-	for i in {1..5}
+	for i in {0..5}
 		do
-		    echo running: /opt/MegaRAID/storcli/storcli64 /c0/v$i del force
-		    /opt/MegaRAID/storcli/storcli64 /c0/v$i del force
+		    echo running: $path /c$controller/v$i del force
+		    $path /c$controller/v$i del force
         done
     echo "Done Deleting Virtual Disks"
 }
 
+function delete_individual_vd()
+{
+    echo "Deleting $1 Virtual Disks"
+    echo running: $path /c$controller/v$1 del force
+    $path /c$controller/v$1 del force
+    echo "Done Deleting Virtual Disks"
+}
 
 function delete_cc()
 {
     echo "Deleting CacheCade"
 	for i in {0..0}
 		do
-		    echo running: /opt/MegaRAID/storcli/storcli64 /c0/v$i del cc
-		    /opt/MegaRAID/storcli/storcli64 /c0/v$i del cc
+		    echo running: $path /c0/v$i del cc
+		    $path /c0/v$i del cc
         done
     echo "Done Deleting CacheCade"
 }
 
 #delete_vd
 #delete_cc
-create_sp_for_ssd_cache
+#create_sp_for_ssd_cache
 create_vd_for_hdd
-create_vd_for_ssd_sp
+#create_vd_for_ssd_sp


### PR DESCRIPTION
Enhance the existing script that meets CPSD's FRU replacement guidelines. Works on Quanta and Dell nodes with appropriate payload.
Example payload for quanta:

{
"options": {
"config-raid":{
"ssdStoragePoolArr":[],
"ssdCacheCadeArr":[
	           {
               "enclosure": 252,
               "type": "raid0",
               "drives":"[0]"
               }
	],
"controller": 0,
"path":"/opt/MegaRAID/storcli/storcli64",
"hddArr":[
           {
               "enclosure": 252,
               "type": "raid0",
               "drives":"[1]"
           },
           {
               "enclosure": 252,
               "type": "raid1",
               "drives":"[4,5]"
           }
       ]
}
}
}

@RackHD/corecommitters  