### PR TITLE
RAC-5799 - Pv4, IPv6 system IPs are not populated

### DIFF
--- a/data/views/redfish-1.0/redfish.1.0.0.ethernetinterface.1.0.0.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.ethernetinterface.1.0.0.json
@@ -72,8 +72,6 @@
     <% if(typeof linkstatus !== 'undefined') { %>
         <% if(typeof linkstatus === 'string') { %>
             ,"LinkStatus": "<%= linkstatus %>"
-        <% } else { %>
-            ,"LinkStatus": null
         <% } %>
     <% } %>
     <% if(typeof links !== 'undefined') { %>

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -88,13 +88,13 @@ var dataFactory = function(identifier, dataName) {
 
 //DCIM_View mappings to redfish equivalents
 var autoNeg = {
-    "0": null, "2": true, "3": false };
+    "2": true, "3": false };
 
 var fullDuplex = {
-    "0": null, "1": true, "2": false };
+    "1": true, "2": false };
 
 var linkSpeed = {
-    "0": null, "1": 10, "2": 100, "3": 1000, "4": 2500, "5": 10000,
+    "1": 10, "2": 100, "3": 1000, "4": 2500, "5": 10000,
     "6": 20000, "7": 40000, "8": 100000, "9": 25000, "10":50000 };
 
 var selTranslator = function(selArray, identifier) {

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -535,8 +535,8 @@ describe('Redfish Systems Root', function () {
                 "iscsiOffloadMode": "3",
                 "iscsiOffloadSupport": null,
                 "legacyBootProtocol": null,
-                "linkDuplex": "1",
-                "linkSpeed": "3",
+                "linkDuplex": "0",
+                "linkSpeed": "0",
                 "linkStatus": null,
                 "macAddress": null,
                 "maxBandwidth": "0",
@@ -1048,7 +1048,7 @@ describe('Redfish Systems Root', function () {
             });
     });
 
-    it('should return no ip given catalog with no ip and no ip from lookup (DELL catalogs)', function() {
+    it('should return no ip given catalog with no ip and no ip from lookup (1-1-1) (DELL catalogs)', function() {
         waterline.catalogs.findLatestCatalogOfSource.withArgs(dellNode.id, 'nics').resolves(Promise.resolve({
             node: dellNode.id,
             source: 'nics',
@@ -1064,6 +1064,31 @@ describe('Redfish Systems Root', function () {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
                 expect(redfish.render.called).to.be.true;
+                expect(res.body.IPv4Addresses).to.not.exist;
+                expect(res.body.IPv6Addresses).to.not.exist;
+            });
+    });
+
+    it('should return no ip given catalog with no ip and no ip from lookup (1-2-1) (DELL catalogs)', function() {
+        waterline.catalogs.findLatestCatalogOfSource.withArgs(dellNode.id, 'nics').resolves(Promise.resolve({
+            node: dellNode.id,
+            source: 'nics',
+            data: dellCatalogData.nics
+        }));
+
+        lookup.macAddressToIp.resolves(Promise.resolve(undefined));
+
+        return helper.request().get('/redfish/v1/Systems/' + dellNode.id + '/EthernetInterfaces/' + 'NIC.Integrated.1-2-1')
+            .expect('Content-Type', /^application\/json/)
+            .expect(200)
+            .expect(function(res) {
+                expect(tv4.validate.called).to.be.true;
+                expect(validator.validate.called).to.be.true;
+                expect(redfish.render.called).to.be.true;
+                expect(res.body.SpeedMbps).to.not.exist;
+                expect(res.body.FullDuplex).to.not.exist;
+                expect(res.body.LinkStatus).to.not.exist;
+                expect(res.body.LinkStatus).to.not.equal(null);
                 expect(res.body.IPv4Addresses).to.not.exist;
                 expect(res.body.IPv6Addresses).to.not.exist;
             });


### PR DESCRIPTION
* Correct issues with dictionaries that use null as a value
* Do not display LinkStatus if value is null
* Add test to validate