### PR TITLE
remove the swaggerdoc step in TravisCI

### DIFF
--- a/extra/make-docs.sh
+++ b/extra/make-docs.sh
@@ -7,4 +7,3 @@ cd $SCRIPT_DIR/..
 npm install
 npm run apidoc
 npm run taskdoc
-npm run swaggerdoc


### PR DESCRIPTION
the swaggerdoc script was removed in in package.json in commit 9ee580308264f25ebfbf8af1c2577f195201e1c6
but people forgot to remove it in TravisCI scripts.