### PR TITLE
RAC-5001 Change WWID to SATA name for ESXi SATA drive ID

### DIFF
--- a/data/templates/get_driveid.js
+++ b/data/templates/get_driveid.js
@@ -85,7 +85,7 @@ function parseDriveWwid(idList) {
 
     //According to SCSI-3 spec, vendor specified logic unit name string is 60
 	//Only IDE and SCSI disk will be retrieved
-    var scsiLines = [], sataLines = [], wwnLines = [], usbLines = [];
+    var scsiLines = [], sataLines = [], usbLines = [];
     lines.forEach(function(line){
         if ( line && !(line.match('part')) && line.match(/[sh]d[a-z]?[a-z]$/i)){
             var nameIndex = line.lastIndexOf('/'), idIndex = line.lastIndexOf('->');
@@ -95,21 +95,10 @@ function parseDriveWwid(idList) {
             else if (line.indexOf('ata') === 0) {
                 sataLines.push([line.slice(nameIndex + 1), line.slice(0, idIndex)]);
             }
-            else if (line.indexOf('wwn') === 0) {
-                wwnLines.push([line.slice(nameIndex + 1), line.slice(0, idIndex)]);
-            }
             else if (line.indexOf('usb') === 0) {
                 usbLines.push([line.slice(nameIndex + 1), line.slice(0, idIndex)]);
             }
         }
-    });
-
-    //wwnLine example: wwn-0x5000cca23de9e287 -> ../../sdb
-    //esxiWwn example: ["sdb", "naa.5000cca23de9e287"]
-    var esxiWwn = wwnLines.map(function(wwnLine) {
-        var line = wwnLine[1];
-        var split = line.split(/-/);
-        return [wwnLine[0], 'naa.' + split[1].slice(2)];
     });
 
     //ESXi SATA WWID should be ('t10.ATA_____' + logic unit name)
@@ -138,14 +127,7 @@ function parseDriveWwid(idList) {
         return [esxiLine[0], strLine];
     });
 
-    //If one device Name is mapped to both WWN and SATA array, use WWN element instead
-    esxiWwn.forEach(function(line) {
-        esxiSata.forEach(function(subline){
-            if (line[0] === subline[0]){
-                subline [1] = line[1];
-            }
-        });
-    });
+    //If drive have both WWN and SATA ID, ESXi will use SATA name only
 
     //esxiLine example: ["sda", "scsi-35000c500725f45d7"]
     //esxiScsi example: ["sda", "naa.5000c500725f45d7"]

--- a/spec/data/templates/get_driveid-spec.js
+++ b/spec/data/templates/get_driveid-spec.js
@@ -11,6 +11,15 @@ describe('get_driveid script', function() {
     var mockScsiDvd =
         '[0:0:0:0]    disk    ATA      QEMU HARDDISK    2.2.  /dev/sda\n' +
         '[1:0:0:0]    cd/dvd  QEMU     QEMU DVD-ROM     2.2.  /dev/sr0';
+    var mockScsiEmpty ='';
+    var mockVdInfoStdEmpty = 
+        'total 0\n' +
+        'drwxr-xr-x 2 root root 360 Dec 22 10:02 ./\n' +
+        'drwxr-xr-x 5 root root 100 Dec 22 10:02 ../';
+    var mockWwidStdEmpty = 
+        'total 0\n' +
+        'drwxr-xr-x 2 root root 360 Dec 22 10:02 ./\n' +
+        'drwxr-xr-x 5 root root 100 Dec 22 10:02 ../';
     var mockVdInfoDvd = '';
     var mockWwidDvd =
         'total 0\n' +
@@ -113,7 +122,7 @@ describe('get_driveid script', function() {
                     {
                         "scsiId":"5:0:0:0",
                         "virtualDisk":"",
-                        "esxiWwid":"naa.5000cca23de98340",
+                        "esxiWwid":"t10.ATA_____QEMU_HARDDISK___________________________QM00001_____________",
                         "devName":"sda",
                         "identifier":1,
                         "linuxWwid":"/dev/disk/by-id/ata-HUS724040ALA640_PBJY9ZJX"
@@ -146,6 +155,20 @@ describe('get_driveid script', function() {
                 //jshint ignore: end
             ));
         });
+
+        it('should parser empty lsscsi response', function() {
+            var mockExec = function() {
+                return mockScsiEmpty;
+            };
+            getDriveId.__set__('execSync', mockExec);
+            var result = buildDriveMap(mockWwidStdEmpty, mockVdInfoStdEmpty, mockScsiEmpty);
+            expect(result).to.deep.equal(JSON.stringify(
+                //jshint ignore: start
+                []
+                //jshint ignore: end
+            ));
+        });
+
 
         it('should parser raw SATA data with ASCII code 0x00', function() {
             var mockExec = function() {


### PR DESCRIPTION
## Background
The ESXi use their own method to generate a identity for the hard drives they found in the system. We use this script run microkernel to gernerate the same ID using the same algorithm as vmware. However in some latest server, we found some SSD's ESXi ID is wrong in RackHD.  It is because RackHD will use WWID to overide the SATA name if it is available. But in fact, ESXi use SATA name to identify this kind of SATA drive.
## Details
Revert the overide process. Use SATA name as ESXi  ID if drive have both SATA name and WWID.

## Result
Validated PASS on EMC platforms.

@pengz1 @iceiilin 
