### PR TITLE
rac-5909 - ipv6 PrefixLength returned as string instead of int

### DIFF
--- a/data/views/redfish-1.0/redfish.1.0.0.ethernetinterface.1.0.0.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.ethernetinterface.1.0.0.json
@@ -45,7 +45,7 @@
             {
                 "Address": "<%= ipv6.ipaddr %>"
                 <% if(typeof ipv6.prefixlength !== 'undefined') { %>
-                ,"PrefixLength": "<%= ipv6.prefixlength %>"
+                ,"PrefixLength": <%= ipv6.prefixlength %>
                 <% } %>
                 <% if(typeof ipv6.ipsrc !== 'undefined') { %>
                 ,"AddressOrigin": "<%= ipv6.ipsrc %>"


### PR DESCRIPTION
* removed quotes that forced a string