### PR TITLE
 Add redfish /Systems/identifier/Processors API for UCS

### DIFF
--- a/data/views/redfish-1.0/ucs.1.0.0.processorcollection.json
+++ b/data/views/redfish-1.0/ucs.1.0.0.processorcollection.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context" : "<%= basepath %>/$metadata#Systems/Links/Members/<%= identifier %>/Processors/#entity",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#Procssors.1.0.0.ProcessorsCollection",
+    "Oem" : {},
+    "Name": "Processors Collection",
+    "Members@odata.count": <%= processors.data.num_of_cpus %>,
+    "Members": [
+        <% for(var i = 0; i < processors.data.num_of_cpus; i += 1) { %>
+            {
+                "@odata.id": "<%= basepath %>/Systems/<%=identifier%>/Processors/<%=i%>"
+            }
+        <%= ( i + 1 < processors.data.num_of_cpus ) ? ',': '' %>
+        <% }; %>
+    ]
+}

--- a/data/views/redfish-1.0/ucs.1.0.0.processorcollection.json
+++ b/data/views/redfish-1.0/ucs.1.0.0.processorcollection.json
@@ -1,7 +1,7 @@
 {
-    "@odata.context" : "<%= basepath %>/$metadata#Systems/Links/Members/<%= identifier %>/Processors/#entity",
+    "@odata.context" : "<%= basepath %>/$metadata#ProcessorCollection.ProcessorCollection",
     "@odata.id": "<%= url %>",
-    "@odata.type": "#Procssors.1.0.0.ProcessorsCollection",
+    "@odata.type": "#ProcessorCollection.ProcessorCollection",
     "Oem" : {},
     "Name": "Processors Collection",
     "Members@odata.count": <%= processors.data.num_of_cpus %>,

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -29,6 +29,7 @@ var dataFactory = function(identifier, dataName) {
         case 'bios':
         case 'nics':
         case 'DeviceSummary':
+        case 'UCS':
             return nodeApi.getNodeCatalogSourceById(identifier, dataName);
         case 'catData':
             return Promise.all([nodeApi.getNodeCatalogSourceById(identifier,'ohai'), nodeApi.getNodeCatalogSourceById(identifier,'dmi')])
@@ -84,10 +85,6 @@ var dataFactory = function(identifier, dataName) {
                 return data[0].sel;
             });
 
-        default:
-            if (_.startsWith(dataName, 'UCS')) {
-                return nodeApi.getNodeCatalogSourceById(identifier, dataName);
-            }
     }
 };
 
@@ -560,26 +557,23 @@ var listSystemProcessors = controller(function(req, res)  {
                 options.hardware = hardware;
             })
             .then(function(){
-                return redfish.render('wsman.1.0.0.processorcollection.json',
-                            'ProcessorCollection.json#/definitions/ProcessorCollection',
-                            options);
+                return redfish.render(
+                    'wsman.1.0.0.processorcollection.json',
+                    'ProcessorCollection.json#/definitions/ProcessorCollection',
+                    options
+                );
             });
         } else if(result.vendor === 'Cisco'){
-            var source = "UCS:" + result.node.name.split('/').pop();
-            return dataFactory(identifier, source)
-            .catch(function(err){
-                if (err.name === "NotFoundError"){
-                    return dataFactory(identifier, 'UCS');
-                }
-                throw err;
-            })
+            return dataFactory(identifier, 'UCS')
             .then(function(data) {
                 options.processors = data;
             })
             .then(function(){
-                return redfish.render('ucs.1.0.0.processorcollection.json',
-                            'ProcessorCollection.json#/definitions/ProcessorCollection',
-                            options);
+                return redfish.render(
+                    'ucs.1.0.0.processorcollection.json',
+                    'ProcessorCollection.json#/definitions/ProcessorCollection',
+                    options
+                );
             });
         } else {
             return dataFactory(identifier, 'dmi').then(function(dmi) {

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -83,6 +83,11 @@ var dataFactory = function(identifier, dataName) {
             }).then(function(data) {
                 return data[0].sel;
             });
+
+        default:
+            if (_.startsWith(dataName, 'UCS')) {
+                return nodeApi.getNodeCatalogSourceById(identifier, dataName);
+            }
     }
 };
 
@@ -547,15 +552,32 @@ var listSystemProcessors = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        if(result.vendor === 'Dell'){
             return dataFactory(identifier, 'hardware')
             .then(function(hardware) {
                 options.hardware = hardware;
             })
             .then(function(){
                 return redfish.render('wsman.1.0.0.processorcollection.json',
+                            'ProcessorCollection.json#/definitions/ProcessorCollection',
+                            options);
+            });
+        } else if(result.vendor === 'Cisco'){
+            var source = "UCS:" + result.node.name.split('/').pop();
+            return dataFactory(identifier, source)
+            .catch(function(err){
+                if (err.name === "NotFoundError"){
+                    return dataFactory(identifier, 'UCS');
+                }
+                throw err;
+            })
+            .then(function(data) {
+                options.processors = data;
+            })
+            .then(function(){
+                return redfish.render('ucs.1.0.0.processorcollection.json',
                             'ProcessorCollection.json#/definitions/ProcessorCollection',
                             options);
             });

--- a/lib/services/redfish-validator-service.js
+++ b/lib/services/redfish-validator-service.js
@@ -20,7 +20,9 @@ di.annotate(redfishValidatorFactory,
         'Http.Api.Services.Schema',
         'Errors',
         'Services.Environment',
-        'Constants'
+        'Constants',
+        'validator',
+        'Services.Waterline'
     )
 );
 
@@ -35,7 +37,9 @@ function redfishValidatorFactory(
     schemaApiService,
     Errors,
     env,
-    Constants
+    Constants,
+    validator,
+    waterline
 ) {
     var logger = Logger.initialize(redfishValidatorFactory);
     var fs = Promise.promisifyAll(nodeFs);
@@ -207,6 +211,41 @@ function redfishValidatorFactory(
         return Promise.reject(new Errors.NotFoundError ('Message registry not found'));
 
     };
+
+    /**
+    * Get vendor name by id
+    * @param {String} id: nodeId
+    * @return {Object}: Object contains node vendor name and information retrieved from database.
+    */
+    RedfishValidator.prototype.getVendorNameById = function(id) {
+        var result = {node: undefined, vendor: undefined};
+        return waterline.nodes.getNodeById(id)
+        .then(function(node){
+            if(!node){
+                throw new Errors.NotFoundError('invalid node id.');
+            }
+            result.node = node;
+            result.vendor = _getVendorNameByIdentifiers(node.identifiers);
+            return result;
+        });
+    };
+
+    function _getVendorNameByIdentifiers(_identifiers){
+        var vendor;
+        var ucsDnFormat = /^(sys|org-root)(\/[\w-]+)+$/;
+        var dellFormat = /^[0-9|A-Z]{7}$/;
+        _.forEach(_identifiers, function(_identifier){
+            var items = _identifier.split(':');
+            if (dellFormat.test(_identifier)){
+                vendor = 'Dell';
+                return false;
+            } else if (validator.isIP(items[0]) && ucsDnFormat.test(items[1])) {
+                vendor = 'Cisco';
+                return false;
+            }
+        });
+        return vendor;
+    }
 
     return new RedfishValidator();
 }

--- a/lib/services/redfish-validator-service.js
+++ b/lib/services/redfish-validator-service.js
@@ -215,18 +215,18 @@ function redfishValidatorFactory(
     /**
     * Get vendor name by id
     * @param {String} id: nodeId
-    * @return {Object}: Object contains node vendor name and information retrieved from database.
+    * @return {Object}: Object contains node vendor name and node info retrieved from database.
     */
     RedfishValidator.prototype.getVendorNameById = function(id) {
-        var result = {node: undefined, vendor: undefined};
         return waterline.nodes.getNodeById(id)
         .then(function(node){
             if(!node){
                 throw new Errors.NotFoundError('invalid node id.');
             }
-            result.node = node;
-            result.vendor = _getVendorNameByIdentifiers(node.identifiers);
-            return result;
+            return {
+                node: node,
+                vendor: _getVendorNameByIdentifiers(node.identifiers)
+            };
         });
     };
 

--- a/spec/lib/api/redfish-1.0/system-spec.js
+++ b/spec/lib/api/redfish-1.0/system-spec.js
@@ -1260,24 +1260,6 @@ describe('Redfish Systems Root', function () {
 
         it('should return a valid UCS processor list', function() {
             waterline.catalogs.findLatestCatalogOfSource
-                .withArgs(ucsNodeId, 'UCS:rack-unit-2').resolves(ucsCatalog);
-            waterline.nodes.needByIdentifier.withArgs(ucsNodeId).resolves(ucsNode);
-            waterline.nodes.getNodeById.withArgs(ucsNodeId).resolves(ucsNode);
-
-            return helper.request().get('/redfish/v1/Systems/' + ucsNodeId + '/Processors')
-                .expect('Content-Type', /^application\/json/)
-                .expect(200)
-                .expect(function() {
-                    expect(tv4.validate.called).to.be.true;
-                    expect(validator.validate.called).to.be.true;
-                    expect(redfish.render.called).to.be.true;
-                });
-        });
-
-        it('should retry get catalog if the source UCS failed.', function() {
-            waterline.catalogs.findLatestCatalogOfSource
-                .withArgs(ucsNodeId, 'UCS:rack-unit-2').resolves({});
-            waterline.catalogs.findLatestCatalogOfSource
                 .withArgs(ucsNodeId, 'UCS').resolves(ucsCatalog);
             waterline.nodes.needByIdentifier.withArgs(ucsNodeId).resolves(ucsNode);
             waterline.nodes.getNodeById.withArgs(ucsNodeId).resolves(ucsNode);
@@ -1289,29 +1271,10 @@ describe('Redfish Systems Root', function () {
                     expect(tv4.validate.called).to.be.true;
                     expect(validator.validate.called).to.be.true;
                     expect(redfish.render.called).to.be.true;
-                    expect(waterline.catalogs.findLatestCatalogOfSource).to.be.calledTwice;
-                    expect(waterline.catalogs.findLatestCatalogOfSource.getCall(0).args[1])
-                        .to.equal('UCS:rack-unit-2');
-                    expect(waterline.catalogs.findLatestCatalogOfSource.getCall(1).args[1])
-                        .to.equal('UCS');
-                });
-        });
-
-        it('should throw a error which is not NotFoundError.', function() {
-            waterline.catalogs.findLatestCatalogOfSource
-                .withArgs(ucsNodeId, 'UCS:rack-unit-2').rejects("this is a ucs error.");
-            waterline.nodes.needByIdentifier.withArgs(ucsNodeId).resolves(ucsNode);
-            waterline.nodes.getNodeById.withArgs(ucsNodeId).resolves(ucsNode);
-
-            return helper.request().get('/redfish/v1/Systems/' + ucsNodeId + '/Processors')
-                .expect('Content-Type', /^application\/json/)
-                .expect(500)
-                .expect(function(res) {
-                    expect(res.text.indexOf('this is a ucs error.') === -1).to.be.false;
                 });
         });
         
-        it('should return a valid normal processor list for Dell node', function() {
+        it('should return a valid processor list for Dell node', function() {
             waterline.catalogs.findLatestCatalogOfSource.resolves({
                 node: 'DELLabcd1234abcd1234abcd',
                 source: 'dummysource',
@@ -1328,7 +1291,7 @@ describe('Redfish Systems Root', function () {
                 });
         });
     
-        it('should return a valid processor list for non-DELL nodes', function() {
+        it('should return a valid processor list for non-DELL/Ucs nodes', function() {
             waterline.catalogs.findLatestCatalogOfSource.resolves({
                 node: '1234abcd1234abcd1234abcd',
                 source: 'dummysource',
@@ -1345,13 +1308,13 @@ describe('Redfish Systems Root', function () {
                 });
         });
 
-        it('should 404 an invalid processor list', function() {
+        it('should 404 an invalid processor list with invalid nodeId', function() {
             return helper.request().get('/redfish/v1/Systems/bad' + node.id + '/Processors')
                 .expect('Content-Type', /^application\/json/)
                 .expect(404);
         });
 
-        it('should 404 an invalid processor list', function() {
+        it('should 404 an invalid processor list with incorrect catalog', function() {
             waterline.catalogs.findLatestCatalogOfSource.resolves({
                 node: '1234abcd1234abcd1234abcd',
                 source: 'dummysource',

--- a/spec/lib/services/redfish-validator-service-spec.js
+++ b/spec/lib/services/redfish-validator-service-spec.js
@@ -9,6 +9,7 @@ describe("Redfish Validator Service", function() {
     var view;
     var _;
     var env;
+    var waterline;
     var testObj = {
         '@odata.context': '/redfish/v1/$metadata#Systems',
         '@odata.id': '/redfish/v1/Systems/',
@@ -16,7 +17,7 @@ describe("Redfish Validator Service", function() {
         Oem: {},
         Name: 'Computer System Collection',
         'Members@odata.count': 1,
-        Members: [ 
+        Members: [
             {
                 '@odata.id': '/redfish/v1/Systems/56c5ce6b283abbcb6c2b6037'
             }
@@ -28,16 +29,21 @@ describe("Redfish Validator Service", function() {
             helper.require("/lib/services/schema-api-service"),
             helper.require("/lib/services/redfish-validator-service"),
             helper.require("/lib/api/view/view"),
-            dihelper.simpleWrapper(function() { arguments[1](); }, 'rimraf')
+            dihelper.simpleWrapper(function() { arguments[1](); }, 'rimraf'),
+            dihelper.simpleWrapper({}, 'Services.Waterline')
         ]);
         redfish = helper.injector.get('Http.Api.Services.Redfish');
         view = helper.injector.get('Views');
         _ = helper.injector.get('_');
 
         env = helper.injector.get('Services.Environment');
+        waterline = helper.injector.get('Services.Waterline');
         sinon.stub(env, "get").resolves();
 
         sinon.stub(view, "get").resolves({contents: JSON.stringify(testObj)});
+        waterline.nodes = {
+            getNodeById: sinon.stub()
+        };
     });
 
     beforeEach(function() {
@@ -63,5 +69,79 @@ describe("Redfish Validator Service", function() {
             });
     });
 
+    describe("getVendorNameById", function() {
 
+        beforeEach('getVendorNameById beforeEach', function(){
+            waterline.nodes.getNodeById.reset();
+        });
+
+        it('should get Cisco vendor name by identifier', function() {
+            var id = "599337d6ff99ed24305bc58a";
+            var sampleDataInfo = {
+                "id": id,
+                "identifiers": [
+                    "1.1.1.0:sys/rack-unit-2"
+                ]
+            };
+
+            waterline.nodes.getNodeById.resolves(sampleDataInfo);
+            return redfish.getVendorNameById(id)
+                .then(function(result){
+                    expect(result.vendor).to.equal("Cisco");
+                    expect(result.node).to.deep.equal(sampleDataInfo);
+                    expect(waterline.nodes.getNodeById).to.be.calledOnce;
+                    expect(waterline.nodes.getNodeById).to.be
+                        .calledWith("599337d6ff99ed24305bc58a");
+                });
+        });
+
+        it('should get Dell vendor name by identifier', function() {
+            var id = "5bc58a";
+            var sampleDataInfo = {
+                "id": id,
+                "identifiers": [
+                    "1234ABC"
+                ]
+            };
+
+            waterline.nodes.getNodeById.resolves(sampleDataInfo);
+            return redfish.getVendorNameById(id)
+                .then(function(result){
+                    expect(result.vendor).to.equal("Dell");
+                    expect(result.node).to.deep.equal(sampleDataInfo);
+                    expect(waterline.nodes.getNodeById).to.be.calledOnce;
+                    expect(waterline.nodes.getNodeById).to.be.calledWith("5bc58a");
+                });
+        });
+
+        it('should get undefined vendor name by Identifier', function() {
+            var id = "5bc58a";
+            var sampleDataInfo = {
+                "id": id,
+                "identifiers": [
+                    "52:54:be:ef:17:57"
+                ]
+            };
+
+            waterline.nodes.getNodeById.resolves(sampleDataInfo);
+            return redfish.getVendorNameById(id)
+                .then(function(result){
+                    expect(result.vendor).to.equal(undefined);
+                    expect(result.node).to.deep.equal(sampleDataInfo);
+                    expect(waterline.nodes.getNodeById).to.be.calledOnce;
+                    expect(waterline.nodes.getNodeById).to.be.calledWith("5bc58a");
+                });
+        });
+
+        it('should not get vendor name by Identifier', function() {
+            var id = "testid";
+            waterline.nodes.getNodeById.resolves(null);
+            return redfish.getVendorNameById(id)
+                .then(function(){
+                    throw new Error("Test should be failed in this case.");
+                }, function(error){
+                    expect(error.message).to.equal('invalid node id.');
+                });
+        });
+    });
 });


### PR DESCRIPTION
Background
To enable redfish API data access with UCS.

Details
1. Implemented details to identify Dell/Cisco and other hardware platforms
2. Implement /Systems/identifier/Processors API for UCS

Paired with: @bbcyyb

@anhou @iceiilin @yaolingling @mcgG @larry-dean 