### PR TITLE
Fix: failed to run unit test as user root

### DIFF
--- a/HWIMO-TEST
+++ b/HWIMO-TEST
@@ -48,6 +48,7 @@ restoreDependencies(){
 
 build(){
     rm -rf node_modules
+    ./install-swagger-ui.sh
     npm install
 }
 


### PR DESCRIPTION
Failed to run script "HWIMO-TEST"  as user root.
Cause: 
```npm install``` does not run scripts specified in package.json files as user root.
That causes the failure of unit test.
Because the file may be run in docker, we need to fix the issue.

Solution:
1. Run ```npm install --unsate-perm```
2. Run the scripts specified in package.json files after ```npm install```. That brings duplicate between package.json and HWIMO-TEST.

@geoff-reid @anhou @iceiilin @keedya @panpan0000 Looking forward to your comments!
