### PR TITLE
RAC-5998: Dell redfish systems/identifier returns "" for hostName

### DIFF
--- a/data/views/redfish-1.0/redfish.2016.3.computersystem.1.3.0.json
+++ b/data/views/redfish-1.0/redfish.2016.3.computersystem.1.3.0.json
@@ -14,7 +14,7 @@
     "SerialNumber": "<%= hardware.data.system.serviceTag %>",
     "PartNumber": "",
     "UUID": "<%= hardware.data.system.uuid.toLowerCase() %>",
-    "HostName": "<% hardware.data.system.hostName %>",
+    "HostName": "<%= hardware.data.system.hostName %>",
     "IndicatorLED": "<%= hardware.data.leds[0] || 'Unknown' %>",
     "PowerState": "<%= hardware.data.system.powerState == 2 ? 'On' : 'Off' %>",
     "Boot": {},
@@ -40,7 +40,7 @@
             "target": "<%=basepath%>/Systems/<%=identifier%>/Actions/ComputerSystem.Reset"
         }
     },
-    "Status": {},    
+    "Status": {},
     "Processors": {
         "@odata.id": "<%= basepath %>/Systems/<%= identifier %>/Processors"
     },

--- a/data/views/redfish-1.0/wsman.1.0.0.computersystem.1.0.0.json
+++ b/data/views/redfish-1.0/wsman.1.0.0.computersystem.1.0.0.json
@@ -14,7 +14,7 @@
     "SerialNumber": "<%= hardware.data.system.serviceTag %>",
     "PartNumber": "",
     "UUID": "<%= hardware.data.system.uuid.toLowerCase() %>",
-    "HostName": "<% hardware.data.system.hostName %>",
+    "HostName": "<%= hardware.data.system.hostName %>",
     "IndicatorLED": "<%= hardware.data.leds[0] || 'Unknown' %>",
     "PowerState": "<%= hardware.data.system.powerState == 2 ? 'On' : 'Off' %>",
     "Bios": {


### PR DESCRIPTION
* fixed in two views a missing '=' in '<%='