### PR TITLE
 Change redfish-validator-service.js  filename to align with injector name

### DIFF
--- a/lib/services/redfish-api-service.js
+++ b/lib/services/redfish-api-service.js
@@ -5,10 +5,10 @@
 var di = require('di');
 var path = require('path');
 
-module.exports = redfishValidatorFactory;
+module.exports = redfishApiServiceFactory;
 
-di.annotate(redfishValidatorFactory, new di.Provide('Http.Api.Services.Redfish'));
-di.annotate(redfishValidatorFactory,
+di.annotate(redfishApiServiceFactory, new di.Provide('Http.Api.Services.Redfish'));
+di.annotate(redfishApiServiceFactory,
     new di.Inject(
         'Services.Configuration',
         'Logger',
@@ -26,7 +26,7 @@ di.annotate(redfishValidatorFactory,
     )
 );
 
-function redfishValidatorFactory(
+function redfishApiServiceFactory(
     configuration,
     Logger,
     Promise,
@@ -41,7 +41,7 @@ function redfishValidatorFactory(
     validator,
     waterline
 ) {
-    var logger = Logger.initialize(redfishValidatorFactory);
+    var logger = Logger.initialize(redfishApiServiceFactory);
     var fs = Promise.promisifyAll(nodeFs);
     var ready;
     var messageRegistry = fs.readFileAsync(
@@ -50,7 +50,7 @@ function redfishValidatorFactory(
         return JSON.parse(contents);
     });
 
-    function RedfishValidator() {
+    function RedfishApiService() {
         var redfishV1 = [{
                 root: path.resolve(__dirname, '../../static/DSP8010_2016.3/json-schema'),
                 namespace: 'http://redfish.dmtf.org/schemas/v1/'
@@ -77,7 +77,7 @@ function redfishValidatorFactory(
         });
     }
 
-    RedfishValidator.prototype.get = function(viewName, options) {
+    RedfishApiService.prototype.get = function(viewName, options) {
         return views.get(viewName, options.templateScope || ['global'])
             .then(function(view) {
                 return view.contents;
@@ -87,7 +87,7 @@ function redfishValidatorFactory(
             });
     };
 
-    RedfishValidator.prototype.render = function(viewName, schemaName, options) {
+    RedfishApiService.prototype.render = function(viewName, schemaName, options) {
         var self = this;
         return Promise.props({
             sku: options.templateScope ? env.get('config', {}, [ options.templateScope[0] ]) : null,
@@ -110,7 +110,7 @@ function redfishValidatorFactory(
         });
     };
 
-    RedfishValidator.prototype.makeOptions = function(req, res, identifier) {
+    RedfishApiService.prototype.makeOptions = function(req, res, identifier) {
         return {
             basepath: req.swagger.operation.api.basePath,
             templateScope: res.locals.scope,
@@ -120,14 +120,14 @@ function redfishValidatorFactory(
     };
 
 
-    RedfishValidator.prototype.getSchemas = function(){
+    RedfishApiService.prototype.getSchemas = function(){
         return ready.then(function() {
             var arr = schemaApiService.getNamespace('http://redfish.dmtf.org/schemas/v1/');
             return arr;
         });
     };
 
-    RedfishValidator.prototype.getSchema = function(identifier){
+    RedfishApiService.prototype.getSchema = function(identifier){
         var schemaURL = 'http://redfish.dmtf.org/schemas/v1/' + identifier + ".json";
         return ready.then(function() {
             var schemaContent = schemaApiService.getSchema(schemaURL);
@@ -135,7 +135,7 @@ function redfishValidatorFactory(
         });
     };
 
-    RedfishValidator.prototype.SchemaXmlFile = function(identifier, res){
+    RedfishApiService.prototype.SchemaXmlFile = function(identifier, res){
         var self= this;
         var fromRoot = process.cwd();
 
@@ -156,7 +156,7 @@ function redfishValidatorFactory(
             });
     };
 
-    RedfishValidator.prototype.validateSchema = function(obj, schemaName) {
+    RedfishApiService.prototype.validateSchema = function(obj, schemaName) {
         return ready.then(function() {
             return schemaApiService.validate(obj, schemaName);
         });
@@ -174,7 +174,7 @@ function redfishValidatorFactory(
         }).omit(_.isUndefined).omit(_.isNull).value();
     }
 
-    RedfishValidator.prototype.handleError = function(err, res, messageId, status) {
+    RedfishApiService.prototype.handleError = function(err, res, messageId, status) {
         var self = this;
         var options = {
             messages: []
@@ -202,7 +202,7 @@ function redfishValidatorFactory(
         });
     };
 
-    RedfishValidator.prototype.getMessageRegistry = function(identifier) {
+    RedfishApiService.prototype.getMessageRegistry = function(identifier) {
         if (identifier === 'Base.1.0.0') {
             return messageRegistry.then(function (messages) {
                 return messages;
@@ -216,7 +216,7 @@ function redfishValidatorFactory(
     * @param {String} id: nodeId
     * @return {Object}: Object contains node vendor name and node info retrieved from database.
     */
-    RedfishValidator.prototype.getVendorNameById = function(id) {
+    RedfishApiService.prototype.getVendorNameById = function(id) {
         return waterline.nodes.getNodeById(id)
         .then(function(node){
             if(!node){
@@ -245,5 +245,6 @@ function redfishValidatorFactory(
         });
         return vendor;
     }
-    return new RedfishValidator();
+
+    return new RedfishApiService();
 }

--- a/spec/lib/services/redfish-api-service-spec.js
+++ b/spec/lib/services/redfish-api-service-spec.js
@@ -4,7 +4,7 @@
 
 require('../../helper');
 
-describe("Redfish Validator Service", function() {
+describe("Redfish Api Service", function() {
     var redfish;
     var view;
     var _;
@@ -27,7 +27,7 @@ describe("Redfish Validator Service", function() {
     before(function() {
         helper.setupInjector([
             helper.require("/lib/services/schema-api-service"),
-            helper.require("/lib/services/redfish-validator-service"),
+            helper.require("/lib/services/redfish-api-service"),
             helper.require("/lib/api/view/view"),
             dihelper.simpleWrapper(function() { arguments[1](); }, 'rimraf'),
             dihelper.simpleWrapper({}, 'Services.Waterline')


### PR DESCRIPTION
Background
redfish-validator-service.js uses an injectable name Http.Api.Services.Redfish, this is a little confusing. We should align filename with injectable name

Details:
Change redfish-validator-service.js  filename to redfish-validator-service.js
Change redfish-validator-service-spec.js  filename to redfish-validator-service-spec.js
Modified related variables and description in the two documents