### PR TITLE
RAC-5098 GET /Systems/{identifier}/Processors/{socket} implementation for redfish api

### DIFF
--- a/data/views/redfish-1.0/ucs.1.0.0.processor.1.0.0.json
+++ b/data/views/redfish-1.0/ucs.1.0.0.processor.1.0.0.json
@@ -5,22 +5,23 @@
     "Oem" : {},
     "Id": "<%=socketId%>",
     "Name": "",
-    "Socket": "",
+    "Socket": "<%= ucsData.data.children["cpu-collection"][socketId].socket_designation %>",
     "ProcessorType": "CPU",
     "ProcessorArchitecture": "x86",
     "InstructionSet": "x86-64",
-    "Manufacturer": "<%= ucsData.data.vendor %>",
-    "Model": "<%= ucsData.data.model %>",
-    "MaxSpeedMHz": null,
-    "TotalCores": <%= ucsData.data.num_of_cores %>,
-    "TotalThreads": <%= ucsData.data.num_of_threads %>,
+    "Manufacturer": "<%= ucsData.data.children["cpu-collection"][socketId].vendor %>",
+    "Model": "<%= ucsData.data.children["cpu-collection"][socketId].model %>",
+    "MaxSpeedMHz":
+        <%=_.trim(_.last(ucsData.data.children["cpu-collection"][socketId].model.split(' ')), 'GHz') * 1000 %>,
+    "TotalCores": <%= ucsData.data.children["cpu-collection"][socketId].cores %>,
+    "TotalThreads": <%= ucsData.data.children["cpu-collection"][socketId].threads %>,
     "Status": {},
     "ProcessorId" : {
-        "VendorId": "<%= ucsData.data.vendor %>",
+        "VendorId": "<%= ucsData.data.children["cpu-collection"][socketId].vendor %>",
         "IdentificationRegisters": "",
-        "EffectiveFamily": "",
-        "EffectiveModel": "<%= ucsData.data.model %>",
-        "Step": "",
+        "EffectiveFamily": "<%= ucsData.data.children["cpu-collection"][socketId].arch %>",
+        "EffectiveModel": "<%= ucsData.data.children["cpu-collection"][socketId].model %>",
+        "Step": "<%= ucsData.data.children["cpu-collection"][socketId].stepping %>",
         "MicrocodeInfo": ""
     }
 }

--- a/data/views/redfish-1.0/ucs.1.0.0.processor.1.0.0.json
+++ b/data/views/redfish-1.0/ucs.1.0.0.processor.1.0.0.json
@@ -1,0 +1,26 @@
+{
+    "@odata.context" : "<%= basepath %>/$metadata#Processor.Processor",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#Processor.v1_0_0.Processor",
+    "Oem" : {},
+    "Id": "<%=socketId%>",
+    "Name": "",
+    "Socket": "",
+    "ProcessorType": "CPU",
+    "ProcessorArchitecture": "x86",
+    "InstructionSet": "x86-64",
+    "Manufacturer": "<%= ucsData.data.vendor %>",
+    "Model": "<%= ucsData.data.model %>",
+    "MaxSpeedMHz": null,
+    "TotalCores": <%= ucsData.data.num_of_cores %>,
+    "TotalThreads": <%= ucsData.data.num_of_threads %>,
+    "Status": {},
+    "ProcessorId" : {
+        "VendorId": "<%= ucsData.data.vendor %>",
+        "IdentificationRegisters": "",
+        "EffectiveFamily": "",
+        "EffectiveModel": "<%= ucsData.data.model %>",
+        "Step": "",
+        "MicrocodeInfo": ""
+    }
+}

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -32,6 +32,7 @@ var dataFactory = function(identifier, dataName) {
         case 'UCS':
         case 'UCS:locator-led':
         case 'UCS:bios':
+        case 'UCS:blade-2':
             return nodeApi.getNodeCatalogSourceById(identifier, dataName);
         case 'catData':
             return Promise.all([nodeApi.getNodeCatalogSourceById(identifier,'ohai'), nodeApi.getNodeCatalogSourceById(identifier,'dmi')])
@@ -49,7 +50,7 @@ var dataFactory = function(identifier, dataName) {
                 });
             });
         case 'Redfish':
-            return waterline.catalogs.find({"node": identifier, "source":dataName });
+            return waterline.catalogs.find({ "node": identifier, "source": dataName });
         case 'chassisData':
             return nodeApi.getPollersByNodeId(identifier)
             .filter(function(poller) {
@@ -669,9 +670,9 @@ var getSystemProcessor = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return wsman.isDellSystem(identifier)
-    .then(function(result){
-        if(result.isDell){
+    return redfish.getVendorNameById(identifier)
+    .then(function(result) {
+        if(result.vendor === 'Dell'){
             return Promise.props({
                 socketId: req.swagger.params.socket.value,
                 hardware: dataFactory(identifier, 'hardware')
@@ -680,6 +681,20 @@ var getSystemProcessor = controller(function(req, res)  {
                     throw new Errors.NotFoundError('invalid socketId');
                 }
                 return redfish.render('wsman.1.0.0.processor.1.0.0.json',
+                                'Processor.v1_0_3.json#/definitions/Processor',
+                                _.merge(options, data));
+            }).catch(function(error) {
+                return redfish.handleError(error, res);
+            });
+        } else if(result.vendor === 'Cisco') {
+            return Promise.props({
+                socketId: req.swagger.params.socket.value,
+                ucsData: dataFactory(identifier, 'UCS:blade-2')
+            }).then(function(data) {
+                if(data.ucsData.data.num_of_cpus <= data.socketId) {
+                    throw new Errors.NotFoundError('invalid socketId');
+                }
+                return redfish.render('ucs.1.0.0.processor.1.0.0.json',
                                 'Processor.v1_0_3.json#/definitions/Processor',
                                 _.merge(options, data));
             }).catch(function(error) {
@@ -1077,7 +1092,7 @@ var getDrive = controller(function(req, res)  {
                 for(var i = 0; i < hardware.data.storage.virtualDisks.length; i+=1){
                     if (hardware.data.storage.virtualDisks[i].physicalDiskIds.indexOf(currFqdd) > -1){
                         options.volumeIds.push(i);
-                    } 
+                    }
                 }
                 return redfish.render('redfish.2016.3.drive.1.1.1.json',
                                 'Drive.v1_1_1.json#/definitions/Drive',
@@ -1095,7 +1110,7 @@ var listVolume = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var index = req.swagger.params.index.value;
     var options = redfish.makeOptions(req, res, identifier);
-    
+
     options.identifier = identifier;
     options.index = index;
     return wsman.isDellSystem(identifier)
@@ -1636,7 +1651,7 @@ var listSystemEthernetInterfacesById = controller(function(req, res)  {
                     throw new Errors.NotFoundError('No Ethernet index found for node ' + index);
                 }
                 return options;
-            }).then(function(options) { 
+            }).then(function(options) {
                 options.name = "Systems Ethernet Interface";
                 options.index = index;
                 options.mtusize = options.nic.mtu;
@@ -1784,7 +1799,7 @@ var doBootImage = controller(function(req,res) {
 });
 
 var deleteVolume = controller(function(req,res) {
-    var identifier = req.swagger.params.identifier.value;   
+    var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
     var volumeIndex = req.swagger.params.volumeIndex.value;
     var payload = req.swagger.params.payload.value;
@@ -1818,7 +1833,7 @@ var deleteVolume = controller(function(req,res) {
 });
 
 var addVolume = controller(function(req,res) {
-    var identifier = req.swagger.params.identifier.value;   
+    var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
     var graphName = 'Graph.Add.Volume';
@@ -1854,7 +1869,7 @@ var addVolume = controller(function(req,res) {
                 graphOptions.defaults.drives = "";
                 for(i = 0; i < driveIndices.length; i+=1) {
                     if (driveIndices[i] >= hardware.data.storage.physicalDisks.length){
-                        throw "No drive exists with id " + driveIndices[i]; 
+                        throw "No drive exists with id " + driveIndices[i];
                     }
                     graphOptions.defaults.drives += hardware.data.storage.physicalDisks[driveIndices[i]].fqdd;
                     if (i+1 < driveIndices.length){
@@ -1901,7 +1916,7 @@ var addVolume = controller(function(req,res) {
 });
 
 var addHotspare = controller(function(req,res) {
-    var identifier = req.swagger.params.identifier.value;   
+    var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
     var driveIndex = req.swagger.params.driveIndex.value;
     var payload = req.swagger.params.payload.value;

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -32,7 +32,7 @@ var dataFactory = function(identifier, dataName) {
         case 'UCS':
         case 'UCS:locator-led':
         case 'UCS:bios':
-        case 'UCS:blade-2':
+        case 'UCS:board':
             return nodeApi.getNodeCatalogSourceById(identifier, dataName);
         case 'catData':
             return Promise.all([nodeApi.getNodeCatalogSourceById(identifier,'ohai'), nodeApi.getNodeCatalogSourceById(identifier,'dmi')])
@@ -689,11 +689,14 @@ var getSystemProcessor = controller(function(req, res)  {
         } else if(result.vendor === 'Cisco') {
             return Promise.props({
                 socketId: req.swagger.params.socket.value,
-                ucsData: dataFactory(identifier, 'UCS:blade-2')
+                ucsData: dataFactory(identifier, 'UCS:board')
             }).then(function(data) {
-                if(data.ucsData.data.num_of_cpus <= data.socketId) {
+                data.ucsData.data.children['cpu-collection']
+                    = _.sortBy(data.ucsData.data.children['cpu-collection'], 'rn');
+                if(data.ucsData.data.children['cpu-collection'].length <= data.socketId) {
                     throw new Errors.NotFoundError('invalid socketId');
                 }
+                options._ = _; //In this case, lodash is required in view
                 return redfish.render('ucs.1.0.0.processor.1.0.0.json',
                                 'Processor.v1_0_3.json#/definitions/Processor',
                                 _.merge(options, data));


### PR DESCRIPTION
**Background**
---
Previous api didn't support to retrieve processor info from UCS.

----

Details
---

1. Implemented /systems/{identifier}/Processors/{socketId} API to get Dell/Cisco/Others Processors information

2. Implemented details to identify Dell/Cisco and other hardware platforms

@iceiilin @anhou @pengz1 @yaolingling