### PR TITLE
RAC-5100 : UCS redfsh is broke GET GET /Systems/{identifier}/SimpleStorage/{index}	

### DIFF
--- a/data/views/redfish-1.0/ucs.1.0.0.simplestorage.1.1.1.json
+++ b/data/views/redfish-1.0/ucs.1.0.0.simplestorage.1.1.1.json
@@ -1,0 +1,29 @@
+{
+    "@odata.context" : "<%= basepath %>/$metadata#SimpleStorage.SimpleStorage",
+    "@odata.id": "<%= url %>",
+    "@odata.type": "#SimpleStorage.v1_1_1.SimpleStorage",
+    "Oem" : {},
+    "Name": "Simple Storage Controller",
+    "Id": "<%= index %>",
+    "Description": "<%= description %>",
+    "Devices": [
+        <% devices.forEach(function(device, i, arr) { %>
+            {
+                "Oem": {
+                    "Cisco" : {
+                        "Revision": "<%= device.revision || 'Unknown' %>",
+                        "Capacity": "<%= device.size || 'Unknown' %>",
+                        "SerialNumbers": "<%= device.serial || 'Unknown' %>",
+                        "Type": "<%= device.device_type || 'Unknown' %>"
+                    }
+                },
+                "Name": "<%= device.rn || 'Unknown' %>",
+                "Status": {},
+                "Manufacturer": "<%= device.vendor || 'Unknown' %>",
+                "Model": "<%= device.model || 'Unknown' %>"
+            }
+            <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
+        <% }); %>
+    ],
+    "Status": {}
+}

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -32,6 +32,7 @@ var dataFactory = function(identifier, dataName) {
         case 'UCS':
         case 'UCS:locator-led':
         case 'UCS:bios':
+        case 'UCS:board':
             return nodeApi.getNodeCatalogSourceById(identifier, dataName);
         case 'catData':
             return Promise.all([nodeApi.getNodeCatalogSourceById(identifier,'ohai'), nodeApi.getNodeCatalogSourceById(identifier,'dmi')])
@@ -749,9 +750,9 @@ var getSimpleStorage = controller(function(req, res)  {
 
     options.index = index;
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        if(result.vendor === 'Dell'){
             return Promise.resolve(dataFactory(identifier, 'hardware'))
             .then(function(hardware) {
                 options.hardware = hardware;
@@ -779,7 +780,30 @@ var getSimpleStorage = controller(function(req, res)  {
             }).catch(function(error) {
                 return redfish.handleError(error, res);
             });
-        } else {
+        } else if(result.vendor === 'Cisco'){
+            return dataFactory(identifier, 'UCS:board')
+                .then(function(catalogsData){
+                    var controllerId = 'storage-' + index.split('_')[0] + '-collection';
+                    if(catalogsData.data.children[controllerId] === undefined){
+                        return Promise.reject(new Errors.NotFoundError('simplestorage contorller not found'));
+                    }
+                    _.forEach(catalogsData.data.children[controllerId], function(ele){
+                        var newIndex = index.split('_')[0] + "_" + ele.pci_addr.replace(/[:.]/g, '_')
+                                        + "_" + ele.id;
+                        if(index === newIndex){
+                            options.description = ele.model;
+                            options.devices = ele.children['disk-collection'];
+                            return false;
+                        }
+                    });
+                    return redfish.render('ucs.1.0.0.simplestorage.1.1.1.json',
+                                    'SimpleStorage.v1_1_1.json#/definitions/SimpleStorage',
+                                    options);
+                }).catch(function(error){
+                    return redfish.handleError(error, res);
+                });
+        }
+        else{
             return Promise.all([ dataFactory(identifier, 'dmi'),
                           dataFactory(identifier, 'smart') ])
                 .spread(function(dmi, smart) {


### PR DESCRIPTION
## Background
The UCS redfish api 'GET /Systems/{identifier}/SimpleStorage/{index}' is broken. Try to fix it.

## Details
1. Execute the command to get simpleStorage. The result is shown in the screenshot.
curl localhost:8080/redfish/v1/Systems/59a66a30e466b6e2457f0f01/SimpleStorage/SAS_01_00_0_1 | jq '.'
![image](https://user-images.githubusercontent.com/20394473/29954446-6cc533ea-8f0a-11e7-93a9-2cfd64516713.png)

## Reviewers
@iceiilin @pengz1 @anhou @mcgG 
