### PR TITLE
remove lookup for macAddress when call /profiles?macs&&ips

### DIFF
--- a/lib/services/profiles-api-service.js
+++ b/lib/services/profiles-api-service.js
@@ -23,7 +23,8 @@ di.annotate(profileApiServiceFactory,
         'Profiles',
         'Services.Environment',
         'Http.Services.Swagger',
-        'Constants'
+        'Constants',
+        'Assert'
     )
 );
 function profileApiServiceFactory(
@@ -40,7 +41,8 @@ function profileApiServiceFactory(
     profiles,
     Env,
     swaggerService,
-    Constants
+    Constants,
+    assert
 ) {
 
     var logger = Logger.initialize(profileApiServiceFactory);
@@ -75,32 +77,38 @@ function profileApiServiceFactory(
         return _.flattenDeep([macs]);
     };
 
-    ProfileApiService.prototype.setLookup = function(req, res) {
-        var query = req.swagger ? req.swagger.query : req.query;
+    /**
+     * Get macAddress in HTTP request
+     * @param {Object} query      the query in HTTP request
+     * @param {String} requestIp  the IP of the HTTP request
+     * @return {Promise} Resolves to macAddress if found, otherwise undefined.
+     */
+    ProfileApiService.prototype.getMacAddressInRequest = function(query, requestIp) {
+        assert.object(query);
+        assert.string(requestIp);
 
-        if (!query.macs || !query.ips)
-            return Promise.resolve();
+        if (query.macs && query.ips) {
+            var macAddresses = _.flattenDeep([query.macs]);
+            var ipAddresses = _.flattenDeep([query.ips]);
 
-        /* Select request's mac and ip, then set them*/
-        var macAddresses = _.flattenDeep([query.macs]);
-        var ipAddresses = _.flattenDeep([query.ips]);
+            var index = _.findIndex(ipAddresses, function(ip) {
+                return (ip && (ip === requestIp));
+            });
 
-        var index = _.findIndex(ipAddresses, function(ip) {
-            return (ip && (ip === res.locals.ipAddress));
-        });
-
-        if (index < 0 || !macAddresses[index]) {
-            return Promise.resolve();
+            if(index >= 0 && macAddresses[index]) {
+                return Promise.resolve(macAddresses[index]);
+            }
         }
 
-        return lookupService.setIpAddress(ipAddresses[index], macAddresses[index])
+        return Promise.resolve();
+    };
+
+    ProfileApiService.prototype.setLookup = function(ipAddress, macAddress, proxyIp, proxyPort) {
+        return lookupService.setIpAddress(ipAddress, macAddress)
         .then(function() {
-            if (req.get(Constants.HttpHeaders.ApiProxyIp)) {
-                var proxy = 'http://%s:%s'.format(
-                    req.get(Constants.HttpHeaders.ApiProxyIp),
-                    req.get(Constants.HttpHeaders.ApiProxyPort)
-                );
-                return waterline.lookups.upsertProxyToMacAddress(proxy, macAddresses[index]);
+            if (proxyIp) {
+                var proxy = 'http://%s:%s'.format(proxyIp, proxyPort);
+                return waterline.lookups.upsertProxyToMacAddress(proxy, macAddress);
             }
         });
     };
@@ -375,33 +383,44 @@ function profileApiServiceFactory(
 
     ProfileApiService.prototype.getProfiles = function(req, query, res) {
         var self = this;
-        return this.setLookup(req, res)
-            .then(function() {
-                var macs = query.mac || query.macs;
-                if (macs) {
-                    var macAddresses = self.getMacs(macs);
-                    var options = {
-                        type: 'compute'
-                    };
+        var ipAddress = res.locals.ipAddress;
+        return self.getMacAddressInRequest(query, ipAddress)
+        .then(function(macAddress) {
+            if(macAddress) {
+                res.locals.macAddress = macAddress;
+                var proxyIp = req.get(Constants.HttpHeaders.ApiProxyIp);
+                var proxyPort = req.get(Constants.HttpHeaders.ApiProxyPort);
+                return self.setLookup(ipAddress, macAddress, proxyIp, proxyPort);
+            }
+        })
+        .then(function() {
+            var macs = query.mac || query.macs;
+            if (macs) {
+                var macAddresses = self.getMacs(macs);
+                var options = {
+                    type: 'compute'
+                };
 
-                    return self.getNode(macAddresses, options)
-                        .then(function (node) {
-                            return self.getProfileFromTaskOrNode(node, 'compute')
-                                .then(function (render) {
-                                    return(render);
+                return self.getNode(macAddresses, options)
+                    .then(function (node) {
+                        return self.getProfileFromTaskOrNode(node, 'compute')
+                            .then(function (render) {
+                                return _.defaults(render, {
+                                    ignoreLookup: res.locals.macAddress ? true : false
                                 });
-                        });
-                } else {
-                    return { profile: 'redirect.ipxe', ignoreLookup: true };
-                }
-            })
-            .catch(function (err) {
-                if (!err.status) {
-                    throw new Errors.InternalServerError(err.message);
-                } else {
-                    throw err;
-                }
-            });
+                            });
+                    });
+            } else {
+                return { profile: 'redirect.ipxe', ignoreLookup: true };
+            }
+        })
+        .catch(function (err) {
+            if (!err.status) {
+                throw new Errors.InternalServerError(err.message);
+            } else {
+                throw err;
+            }
+        });
     };
 
     ProfileApiService.prototype.getProfilesSwitchVendor = function(

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -291,7 +291,7 @@ function swaggerFactory(
                 ipaddress: res.locals.ipAddress,
                 netmask: config.get('dhcpSubnetMask', '255.255.255.0'),
                 gateway: config.get('dhcpGateway', '10.1.1.1'),
-                macaddress: macAddress,
+                macaddress: res.locals.macAddress || macAddress,
                 sku: env.get('config', {}, [ scope[0] ]),
                 env: env.get('config', {}, scope),
                 // Build structure that mimics the task renderContext

--- a/spec/lib/api/2.0/profiles-spec.js
+++ b/spec/lib/api/2.0/profiles-spec.js
@@ -44,7 +44,7 @@ describe('Http.Api.Profiles', function () {
         this.sandbox.stub(profileApiService, 'getNode').resolves({});
         this.sandbox.stub(profileApiService, 'createNodeAndRunDiscovery').resolves({});
         this.sandbox.stub(profileApiService, 'runDiscovery').resolves({});
-        this.sandbox.stub(profileApiService, 'setLookup').resolves();
+        this.sandbox.stub(profileApiService, 'getMacAddressInRequest').resolves();
 
         this.sandbox.stub(waterline.lookups, "findOneByTerm").resolves();
 
@@ -162,12 +162,12 @@ describe('Http.Api.Profiles', function () {
             return helper.request().get('/api/2.0/profiles?mac=00:01:02:03:04:05&&ip=1.1.1.1')
                 .expect(200)
                 .expect(function() {
-                    expect(profileApiService.setLookup).to.have.been.calledOnce;
+                    expect(profileApiService.getMacAddressInRequest).to.have.been.calledOnce;
                 });
         });
 
         it("should send 500 set mac and ip fails", function() {
-            profileApiService.setLookup.rejects(new Error('error'));
+            profileApiService.getMacAddressInRequest.rejects(new Error('error'));
 
             return helper.request().get('/api/2.0/profiles?mac=00:01:02:03:04:05&&ip=1.1.1.1')
                 .expect(500);


### PR DESCRIPTION
Fix https://rackhd.atlassian.net/browse/RAC-5768
The solution is remove lookup for macAddress when call /profiles?macs&&ips.

@RackHD/corecommitters 