### PR TITLE
RAC-6084: Remove .0, .1 indexes from system linkages. (ie ManagedBy)

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -272,16 +272,7 @@ var getSystem = controller(function(req, res) {
                 chassis: dataFactory(identifier, 'chassis'),
                 chassisData: dataFactory(identifier, 'chassisData'),
                 secureBoot: true,
-                obm: Promise.resolve(node)
-                    .then(function(node) {
-                        return _.map(node.obms, function(val, idx) {
-                            return node.id + '.' + idx;
-                        });
-                    })
-                    .then(function(obms) {
-                        obms.push('RackHD');
-                        return obms;
-                    })
+                obm: [node.id, 'RackHD']
             }).then(function(data) {
                 return redfish.render('redfish.2016.3.computersystem.1.3.0.json',
                                 'ComputerSystem.v1_3_0.json#/definitions/ComputerSystem',
@@ -302,13 +293,7 @@ var getSystem = controller(function(req, res) {
                                 return val.targets;
                             }
                         }),
-                obm: Promise.map(node.obms, function(val, idx){
-                        return node.id + '.' + idx;
-                    })
-                    .then(function(obms){
-                        obms.push('RackHD');
-                        return obms;
-                    })
+                obm: [node.id, 'RackHD']
             }).then(function(data){
                 return redfish.render('ucs.1.0.0.computersystem.1.3.0.json',
                                 'ComputerSystem.v1_3_0.json#/definitions/ComputerSystem',
@@ -322,16 +307,7 @@ var getSystem = controller(function(req, res) {
                 chassis: dataFactory(identifier, 'chassis'),
                 chassisData: dataFactory(identifier, 'chassisData'),
                 secureBoot: false,
-                obm: Promise.resolve(node)
-                    .then(function(node) {
-                        return _.map(node.obms, function(val, idx) {
-                            return node.id + '.' + idx;
-                        });
-                    })
-                    .then(function(obms) {
-                        obms.push('RackHD');
-                        return obms;
-                    })
+                obm: [node.id, 'RackHD']
             }).then(function(data) {
                 return redfish.render('redfish.1.0.0.computersystem.1.1.0.json',
                                 'ComputerSystem.v1_3_0.json#/definitions/ComputerSystem',


### PR DESCRIPTION
No need to iterate over (and return) obm settings when the
/redfish/v1/managers query ignores the indexes anyway.

Redfish ServiceValidator found index issues where the ManagedBy
resources were not valid query urls.