### PR TITLE
[RAC-6232]Node 6/8 unit test fix

### DIFF
--- a/lib/services/rest-api-service.js
+++ b/lib/services/rest-api-service.js
@@ -204,9 +204,9 @@ function restFactory(
                 }).catch(function (err) {
                     // Need to check to string here since we wrap errors with new Error() to support
                     // util.isError checks by swagger going forward.
-                    if (err && err.toString().contains(Errors.ValidationError.name)) {
+                    if (err && err.toString().includes(Errors.ValidationError.name)) {
                         err.status = BAD_REQUEST_STATUS;
-                    } else if (err && err.toString().contains(Errors.SchemaError.name)) {
+                    } else if (err && err.toString().includes(Errors.SchemaError.name)) {
                         err.status = BAD_REQUEST_STATUS;
                     }
                     throw err;

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "//": "Copyright 2017, Dell EMC, Inc.",
   "name": "on-http",
   "version": "2.29.0",
   "description": "OnRack Http Server",
@@ -50,7 +51,7 @@
     "passport": "^0.3.2",
     "passport-anonymous": "~1.0.1",
     "passport-http": "~0.3.0",
-    "passport-jwt": "~2.0.0",
+    "passport-jwt": "~3.0.0",
     "passport-local": "^1.0.0",
     "pluralize": "~1.1.2",
     "restify-links": "~1.1.0",

--- a/spec/lib/services/hooks-api-service-spec.js
+++ b/spec/lib/services/hooks-api-service-spec.js
@@ -73,7 +73,7 @@ describe('Http.Services.Api.Hooks', function () {
             done(new Error('Test should fail'));
         })
         .catch(function(err){
-            expect(err.name).equals('AssertionError');
+            expect(err.name).match(/AssertionError.*/);
             done();
         });
     });

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -1162,7 +1162,7 @@ describe("Http.Services.Api.Nodes", function () {
         it('should reject an invalid tag array', function() {
             return nodeApiService.addTagsById(node.id, 'tag')
                 .catch(function(e) {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(waterline.nodes.addTags).to.not.be.called;
                     expect(needByIdentifier).to.not.be.called;
                 });
@@ -1180,7 +1180,7 @@ describe("Http.Services.Api.Nodes", function () {
         it('should reject an invalid tag', function() {
             return nodeApiService.removeTagsById(node.id, 1)
                 .catch(function(e) {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(waterline.nodes.remTags).to.not.be.called;
                     expect(needByIdentifier).to.not.be.called;
                 });
@@ -1204,7 +1204,7 @@ describe("Http.Services.Api.Nodes", function () {
         it('should reject an invalid tag', function() {
             return nodeApiService.getNodesByTag(1)
                 .catch(function(e) {
-                    expect(e).to.have.property('name').that.equals('AssertionError');
+                    expect(e).to.have.property('name').to.match(/AssertionError.*/);
                     expect(waterline.nodes.findByTag).to.not.be.called;
                     expect(needByIdentifier).to.not.be.called;
                 });

--- a/spec/lib/services/rest-api-service-spec.js
+++ b/spec/lib/services/rest-api-service-spec.js
@@ -136,7 +136,7 @@ describe('Http.Server', function () {
                 .expect(400)
                 .expect(function (req) {
                     expect(req.body).to.have.property('message')
-                        .to.equal('Error parsing JSON: Unexpected token b');
+                        .to.match(/Error parsing JSON: Unexpected token b.*/);
                 });
         });
 


### PR DESCRIPTION
**Background**
----
Currently, unit test will fail in Nodejs 6 and Nodejs 8.
[https://rackhd.atlassian.net/browse/RAC-6232](https://rackhd.atlassian.net/browse/RAC-6232)

**AC**:
- Paired with @PengTian0 
- Fix nodejs6 unit test failures in local machine
- Don’t break nodejs 4 unit test
- Pilot run in travisci environment(don’t commit the fix, because further FIT test should pass before submitting


**Detail**
----

About case Http.Server rest().should 500 if a deserializer returns a rejected promise (from Mocha Tests)
`
AssertionError: expected 'err.toString(...).contains is not a function' to equal 'deserializer reject!'
    at spec/lib/services/rest-api-service-spec.js:418:31
    at Test._assertFunction (node_modules/supertest/lib/test.js:247:11)
    at Test.assert (node_modules/supertest/lib/test.js:148:18)
    at assert (node_modules/supertest/lib/test.js:127:12)
    at node_modules/supertest/lib/test.js:124:5
    at Test.Request.callback (node_modules/superagent/lib/node/index.js:703:3)
    at IncomingMessage.&lt;anonymous&gt; (node_modules/superagent/lib/node/index.js:922:12)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)
`
* *Cause:*
traceur(0.0.33) override String and provides "contains()" function. But new version of traceur doesn't provide that.
* *Fix:*
Change "contains()" to "includes()"


About case Http.Server rest() should 400 when POSTing bad JSON
`
AssertionError: expected 'Error parsing JSON: Unexpected token b in JSON at position 1' to equal 'Error parsing JSON: Unexpected token b'
`
**Cause:*
In Node4 the return error message is 
`
Error parsing JSON: Unexpected token b
`
But in Node6
`
Error parsing JSON: Unexpected token b in JSON at position 1
`
**Fix:*
Use
`
.to.match(/Error parsing JSON: Unexpected token b.*/)
`
Instead of
`
.to.equal('Error parsing JSON: Unexpected token b')
`

About case Http.Api.Users should 201 a user post attempt with localexception
`
Error: expected { username: 'admin', role: 'Administrator' } response body, got { message: 'parsed_url.query.hasOwnProperty is not a function',
status: '400',
UUID: 'c7a85886-0d25-4cf3-b761-491c42397eda' }
    + expected - actual
       {    
      -  "UUID": "c7a85886-0d25-4cf3-b761-491c42397eda"
      -  "message": "parsed_url.query.hasOwnProperty is not a function"
      -  "status": "400"
      +  "role": "Administrator"
      +  "username": "admin"
       }
`
**Cause:*
Third party module bug
**Fix:*
Update passport-jwt@2.0.0 to passport-jwt@3.0.0


For case AssertionError
This is the same issue with on-tasks
Change
* spec/lib/services/hooks-api-service-spec.js:L76
* spec/lib/services/nodes-api-service-spec.js:L1165, 1183, 1207
* spec/lib/services/rest-api-service-spec.js:L139

`
expect(err.name).equals('xxx');
{code}
`
`
expect(err.name).match(/xxx.*/);
`



@iceiilin @anhou @pengz1 @bbcyyb @PengTian0 

