### PR TITLE
 Implement ucsCallback API

### DIFF
--- a/lib/api/2.0/callback.js
+++ b/lib/api/2.0/callback.js
@@ -1,11 +1,11 @@
-// Copyright 2016, EMC, Inc.
+// Copyright 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 'use strict';
 
 var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var Errors = injector.get('Errors');
-var eventsProtocol = injector.get('Protocol.Events');
+var callbackService = injector.get('Http.Services.Api.Callback');
 var _ = injector.get('_'); // jshint ignore:line
 
 
@@ -14,12 +14,24 @@ var callbackPost = controller({success: 201}, function (req) {
     if (_.has(req, 'swagger.params.body.value.options.defaults')) {
         var id = req.swagger.params.identifier.value;
         var data = req.body.options.defaults;
-        return Promise.resolve(eventsProtocol.publishHttpResponseUuid(id, data));
+        return callbackService.publishHttpCallbackData(id, data);
     } else {
         throw new Errors.BadRequestError('CALLBACK: Callback data is invalid.');
     }
 });
 
+// POST /ucsCallback
+var ucsCallbackPost = controller({success: 200}, function (req) {
+    var body = _.defaults(req.body ||{}, req.swagger.body || {});
+    var taskId = req.swagger.query.taskId || body.taskId;
+    if (!taskId) {
+        throw new Errors.BadRequestError('taskId does not exist.');
+    } else {
+        return callbackService.publishHttpCallbackData(taskId, body);
+    }
+});
+
 module.exports = {
-    callbackPost: callbackPost
+    callbackPost: callbackPost,
+    ucsCallbackPost: ucsCallbackPost
 };

--- a/lib/api/2.0/callback.js
+++ b/lib/api/2.0/callback.js
@@ -23,11 +23,11 @@ var callbackPost = controller({success: 201}, function (req) {
 // POST /ucsCallback
 var ucsCallbackPost = controller({success: 200}, function (req) {
     var body = _.defaults(req.body ||{}, req.swagger.body || {});
-    var taskId = req.swagger.query.taskId || body.taskId;
-    if (!taskId) {
-        throw new Errors.BadRequestError('taskId does not exist.');
+    var callbackId = req.swagger.query.callbackId || body.callbackId;
+    if (!callbackId) {
+        throw new Errors.BadRequestError('callbackId does not exist.');
     } else {
-        return callbackService.publishHttpCallbackData(taskId, body);
+        return callbackService.publishHttpCallbackData(callbackId, body);
     }
 });
 

--- a/lib/services/callback-api-service.js
+++ b/lib/services/callback-api-service.js
@@ -1,0 +1,27 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+'use strict';
+
+var di = require('di');
+
+module.exports = CallbackApiServiceFactory;
+di.annotate(CallbackApiServiceFactory, new di.Provide('Http.Services.Api.Callback'));
+di.annotate(CallbackApiServiceFactory,
+    new di.Inject(
+        'Protocol.Events'
+    )
+);
+
+function CallbackApiServiceFactory(
+    eventsProtocol
+) {
+
+    function CallbackApiService() {
+    }
+
+    CallbackApiService.prototype.publishHttpCallbackData = function(id, data) {
+        return eventsProtocol.publishHttpResponseUuid(id, data);
+    };
+
+    return new CallbackApiService();
+}

--- a/spec/lib/api/2.0/callback-spec.js
+++ b/spec/lib/api/2.0/callback-spec.js
@@ -1,0 +1,75 @@
+// Copyright © 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+/* jshint node:true */
+
+'use strict';
+
+describe('Http.Api.Callback v2.0', function () {
+    var eventsProtocol, Errors;
+    var taskId = "abc";
+    var data = {"data": "test"};
+
+    helper.httpServerBefore();
+
+    before(function () {
+        eventsProtocol = helper.injector.get('Protocol.Events');
+        Errors = helper.injector.get('Errors');
+    });
+
+    helper.httpServerAfter();
+
+    afterEach('Http.Api.Callback v2.0 afterEach', function(){
+        this.sandbox.restore();
+    });
+
+    it('should return a 200 for ucsCallback success', function () {
+        this.sandbox.stub(eventsProtocol, 'publishHttpResponseUuid').resolves();
+        return helper.request('http://localhost:8091')
+            .post('/api/2.0/ucsCallback')
+            .query({taskId: taskId})
+            .set('Content-Type', 'application/json')
+            .send(data)
+            .expect(200)
+            .expect(function(){
+                expect(eventsProtocol.publishHttpResponseUuid).to.be.calledOnce;
+                expect(eventsProtocol.publishHttpResponseUuid).to.be.calledWith(taskId, data);
+            });
+    });
+
+    it('should return a 400 for ucsCallback failure', function () {
+        this.sandbox.stub(eventsProtocol, 'publishHttpResponseUuid').resolves();
+        return helper.request('http://localhost:8091')
+            .post('/api/2.0/ucsCallback')
+            .set('Content-Type', 'application/json')
+            .send(data)
+            .expect(400)
+            .expect(function(){
+                expect(eventsProtocol.publishHttpResponseUuid).to.not.be.calledOnce;
+            });
+    });
+
+    it('should return a 201 for wsmanCallback success', function () {
+        this.sandbox.stub(eventsProtocol, 'publishHttpResponseUuid').resolves();
+        return helper.request('http://localhost:8091')
+            .post('/api/2.0/wsmanCallback/abcde')
+            .set('Content-Type', 'application/json')
+            .send({options: {defaults: data}})
+            .expect(201)
+            .expect(function(){
+                expect(eventsProtocol.publishHttpResponseUuid).to.be.calledOnce;
+                expect(eventsProtocol.publishHttpResponseUuid).to.be.calledWith('abcde', data);
+            });
+    });
+
+    it('should return a 400 for wsmanCallback failure', function () {
+        this.sandbox.stub(eventsProtocol, 'publishHttpResponseUuid').resolves();
+        return helper.request('http://localhost:8091')
+            .post('/api/2.0/wsmanCallback/abcde')
+            .set('Content-Type', 'application/json')
+            .send(data)
+            .expect(400)
+            .expect(function(){
+                expect(eventsProtocol.publishHttpResponseUuid).to.not.be.calledOnce;
+            });
+    });
+    
+});

--- a/spec/lib/api/2.0/callback-spec.js
+++ b/spec/lib/api/2.0/callback-spec.js
@@ -5,7 +5,7 @@
 
 describe('Http.Api.Callback v2.0', function () {
     var eventsProtocol, Errors;
-    var taskId = "abc";
+    var callbackId = "abc";
     var data = {"data": "test"};
 
     helper.httpServerBefore();
@@ -25,13 +25,13 @@ describe('Http.Api.Callback v2.0', function () {
         this.sandbox.stub(eventsProtocol, 'publishHttpResponseUuid').resolves();
         return helper.request('http://localhost:8091')
             .post('/api/2.0/ucsCallback')
-            .query({taskId: taskId})
+            .query({callbackId: callbackId})
             .set('Content-Type', 'application/json')
             .send(data)
             .expect(200)
             .expect(function(){
                 expect(eventsProtocol.publishHttpResponseUuid).to.be.calledOnce;
-                expect(eventsProtocol.publishHttpResponseUuid).to.be.calledWith(taskId, data);
+                expect(eventsProtocol.publishHttpResponseUuid).to.be.calledWith(callbackId, data);
             });
     });
 

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -274,6 +274,36 @@ paths:
       summary: Async microservice response
       tags:
       - /api/2.0
+  /ucsCallback:
+    x-swagger-router-controller: callback
+    post:
+      operationId: ucsCallbackPost
+      summary: |
+        Callback for UCS nodes
+      description: |
+        Callback for UCS nodes
+      parameters:
+        - name: taskId
+          in: query
+          description: |
+            task id for the data
+          required: true
+          type: string
+      tags: [ "/api/2.0" ]
+      responses:
+        200:
+          description: Data is accepted and sent
+          schema:
+            type: object
+        400:
+          description: |
+            bad request parameter passed
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /swagger:
     x-swagger-pipe: swagger_raw
   /profiles:

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -1,3 +1,5 @@
+# Copyright 2015-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
 swagger: "2.0"
 info:
   version: "0.0.1"

--- a/static/monorail-2.0-sb.yaml
+++ b/static/monorail-2.0-sb.yaml
@@ -285,10 +285,10 @@ paths:
       description: |
         Callback for UCS nodes
       parameters:
-        - name: taskId
+        - name: callbackId 
           in: query
           description: |
-            task id for the data
+            callback id to identify data belongings
           required: true
           type: string
       tags: [ "/api/2.0" ]


### PR DESCRIPTION
*Background*
UCSM http response is slower than RackHD in some cases and will lead to RackHD fails to get data from UCSM via HTTP. Thus in ucs-service we implemented asynchronous API to avoid this and data will be post back to RackHD via a callback API.

*Details*

- A new API /ucsCallback is create with POST method
- Unit test is included.

Paired with: @bbcyyb
@anhou @bbcyyb