### PR TITLE
Port Redfish Secure Boot feature underlying implementation from Racadm to WSMAN

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -4,6 +4,7 @@
 
 var injector = require('../../../index.js').injector;
 var redfish = injector.get('Http.Api.Services.Redfish');
+var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var waterline = injector.get('Services.Waterline');
 var taskProtocol = injector.get('Protocol.Task');
 var Promise = injector.get('Promise');
@@ -12,7 +13,6 @@ var nodeApi = injector.get('Http.Services.Api.Nodes');
 var controller = injector.get('Http.Services.Swagger').controller;
 var Errors = injector.get('Errors');
 var moment = require('moment');
-var racadm = injector.get('JobUtils.RacadmTool');
 var wsman = injector.get('Http.Services.Wsman');
 var configuration = injector.get('Services.Configuration');
 var mktemp = require('mktemp');
@@ -206,19 +206,6 @@ var selTranslator = function(selArray, identifier) {
             origin: selTranslatorOrigin(entry.sensorType, identifier)
         });
     });
-};
-
-var getObmSettings = function(nodeId){
-    return waterline.obms.findByNode(nodeId, 'ipmi-obm-service', true)
-        .then(function (obm) {
-            if (!obm) {
-               return waterline.obms.findByNode(nodeId, 'dell-wsman-obm-service', true);
-            }
-            return obm;
-        })
-        .catch(function(err) {
-            return (err);
-        });
 };
 
 /**
@@ -2021,28 +2008,21 @@ var getSecureBoot = controller(function(req, res)  {
     return wsman.isDellSystem(identifier)
     .then(function(result){
         if(result.isDell){
-            return getObmSettings(identifier)
-                .then(function(obmSettings) {
-                    return racadm.runCommand (
-                        obmSettings.host,
-                        obmSettings.user,
-                        obmSettings.password,
-                        'get bios.SysSecurity.SecureBoot'
-                    );
-                })
-                .then(function(secureBoot) {
-                    var secureBootSetting = _.words(secureBoot, /SecureBoot=[a-zA-Z]*/);
-                    var statusArray = secureBootSetting[0].split('=');
-                    options.SecureBoot = (statusArray[1]);
-                    return redfish.render('redfish.1.0.0.secureboot.1.0.1.json',
-                        'SecureBoot.v1_0_1.json#/definitions/SecureBoot',
-                        options);
-                });
+            return dataFactory(identifier, 'bios').then(function(bios) {
+                return _.get(_.find(bios.data.dcimBIOSEnumerationTypeList, function(attribute) {
+                    return attribute.attributeName.value === 'SecureBoot';
+                }), 'currentValue[0].value');
+            })
+            .then(function(secureBoot) {
+                options.SecureBoot = secureBoot;
+                return redfish.render('redfish.1.0.0.secureboot.1.0.1.json',
+                    'SecureBoot.v1_0_1.json#/definitions/SecureBoot',
+                    options);
+            });
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
     }).catch(function(error) {
-        console.log('%j', error);
         return redfish.handleError(error, res);
     });
 });
@@ -2054,27 +2034,42 @@ var getSecureBoot = controller(function(req, res)  {
  */
 var setSecureBoot = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var command;
+    var secureBootEnable;
     if (req.body.SecureBootEnable) {
-        command = "Enabled";
+        secureBootEnable = "Enabled";
     } else {
-        command = "Disabled";
+        secureBootEnable = "Disabled";
     }
-    return getObmSettings(identifier)
-        .then(function(obmSettings) {
-            return racadm.runCommand (
-                obmSettings.host,
-                obmSettings.user,
-                obmSettings.password,
-                'set bios.SysSecurity.SecureBoot ' + command
-            );
-        })
-        .then(function() {
-            res.status(202).json({"Message": "Successfully Completed Request"});
-        })
-        .catch(function(error) {
-            return redfish.handleError(error, res);
-        });
+    //1 - PowerCycle(cold boot)
+    //2 - Graceful Reboot without forced shutdown
+    //3 - Graceful Reboot with forced shutdown
+    var rebootJobType = 2;
+
+    return wsman.isDellSystem(identifier)
+    .then(function(result){
+        if(result.isDell){
+            return workflowApiService.createAndRunGraph({
+                name: 'Graph.Dell.Wsman.ConfigureBios',
+                options: {
+                    defaults: {
+                        "attributes": [{
+                            "name": "SecureBoot",
+                            "value": secureBootEnable
+                        }],
+                        "rebootJobType": rebootJobType
+                    }
+                }
+            }, identifier)
+            .then(function() {
+                res.status(202).json({"Message": "Successfully Completed Request"});
+            });
+        } else {
+            return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
+        }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
+    });
 });
 
 module.exports = {


### PR DESCRIPTION
**Background**

Based on the preceding investigation work ( https://rackhd.atlassian.net/browse/RAC-6175 ), I could start to port redfish Secure Boot underlying implementation from Racadm (if any) with WSMAN API.
https://rackhd.atlassian.net/browse/RAC-6215

**Done**

Port Redfish Secure Boot feature underlying implementation from Racadm to WSMAN

**Reviewers**
@RackHD/corecommitters @nortonluo @yaolingling 