### PR TITLE
Enable node8 unit-test in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ sudo: true
 node_js:
   - "4"
   - "6"
+  - "8"
 
 matrix:
   allow_failures:
    - node_js: "6"
+   - node_js: "8"
 
 addons:
   apt:


### PR DESCRIPTION
Enable node8 unit-test in travis-ci, failure is allowed