### PR TITLE
Unit test fix for mocha update

### DIFF
--- a/spec/lib/services/hooks-api-service-spec.js
+++ b/spec/lib/services/hooks-api-service-spec.js
@@ -9,7 +9,7 @@ describe('Http.Services.Api.Hooks', function () {
     var body = {url: '0.0.0.0', filters: [{nodeId: 'nodeId'}]};
     var hook = {url: '0.0.0.0', id: 'hookId'};
     var _;
-    
+
     before('Http.Services.Api.Hooks before', function() {
         this.sandbox = sinon.sandbox.create();
         helper.setupInjector([
@@ -68,7 +68,7 @@ describe('Http.Services.Api.Hooks', function () {
     });
 
     it('should throw error if hook url string is not a url', function (done) {
-        return hooksApiService.createHook({url: 'abcd'})
+        hooksApiService.createHook({url: 'abcd'})
         .then(function() {
             done(new Error('Test should fail'));
         })
@@ -81,7 +81,7 @@ describe('Http.Services.Api.Hooks', function () {
     it('should throw errors if hook exists', function (done) {
         var existingHook = _.defaults(body, {id: 'test'});
         this.sandbox.stub(waterline.hooks, 'findOne').resolves(existingHook);
-        return hooksApiService.createHook(body)
+        hooksApiService.createHook(body)
         .then(function(){
             done(new Error("test should fail"));
         })
@@ -94,7 +94,7 @@ describe('Http.Services.Api.Hooks', function () {
             done();
         });
     });
-    
+
     it('should delete hook by id', function () {
         var id = 'testId';
         this.sandbox.stub(waterline.hooks, 'destroyByIdentifier').resolves();
@@ -104,7 +104,7 @@ describe('Http.Services.Api.Hooks', function () {
             expect(waterline.hooks.destroyByIdentifier).to.be.calledWith(id);
         });
     });
-    
+
     it('should delete update hook by id', function () {
         var id = 'testId';
         this.sandbox.stub(waterline.hooks, 'updateByIdentifier').resolves(hook);

--- a/spec/lib/services/notification-api-service-spec.js
+++ b/spec/lib/services/notification-api-service-spec.js
@@ -280,7 +280,7 @@ describe('Http.Api.Notification', function () {
             this.sandbox.restore();
             waterline.catalogs.findMostRecent.onCall(0).resolves(undefined);
             waterline.obms.findOne.onCall(0).resolves(undefined);
-            return notificationApiService.redfishAlertProcessing(req)
+            notificationApiService.redfishAlertProcessing(req)
                 .then(function(){
                     done(new Error('should NOT have posted the alert!'));
                 })
@@ -300,7 +300,7 @@ describe('Http.Api.Notification', function () {
             this.sandbox.restore();
             waterline.catalogs.findMostRecent.onCall(0).resolves(bmc);
             waterline.obms.findOne.onCall(0).resolves(deviceInfoCatalog);
-            return notificationApiService.redfishAlertProcessing(badReq)
+            notificationApiService.redfishAlertProcessing(badReq)
                 .then(function(){
                     done(new Error('should NOT have posted the alert!'));
                 })


### PR DESCRIPTION
RAC:  [https://rackhd.atlassian.net/browse/RAC-5743](https://rackhd.atlassian.net/browse/RAC-5743)
----
Paired with @PengTian0 

Using both `return promise` and `done()` in async unit test case will cause following error:
`Resolution method is overspecified. Specify a callback *or* return a Promise; not both.`

According to Mocha's [official site](http://mochajs.org/):
`In Mocha v3.0.0 and newer, returning a Promise and calling done() will result in an exception`

**Solution**
----
Only call done() instead of return a promise in all async unit test cases.


@PengTian0 @pengz1 @anhou @iceiilin @bbcyyb 