### PR TITLE
Fix-on-http-unittest-timeout-issue

### DIFF
--- a/lib/api/redfish-1.0/event-service.js
+++ b/lib/api/redfish-1.0/event-service.js
@@ -236,6 +236,7 @@ var testEvent = controller({success: 202},function(req, res) {
             });
         });
     })
+    .all()
     .then(function() {
         res.status(202);
     })

--- a/spec/lib/api/redfish-1.0/event-service-spec.js
+++ b/spec/lib/api/redfish-1.0/event-service-spec.js
@@ -12,6 +12,7 @@ describe('Redfish Event Service', function () {
     var messenger;
     var subscription;
     var identifier;
+    var RedfishTool;
     var eventDestination = {
         Destination: 'http://1.1.1.1:8080',
         EventTypes: [
@@ -51,6 +52,7 @@ describe('Redfish Event Service', function () {
         subscription = new Subscription({},{});
         messenger = helper.injector.get('Services.Messenger');
         tv4 = require('tv4');
+        RedfishTool = helper.injector.get('JobUtils.RedfishTool');
     });
 
     beforeEach('set up mocks', function () {
@@ -58,6 +60,7 @@ describe('Redfish Event Service', function () {
         this.sandbox.spy(redfish, 'render');
         this.sandbox.spy(validator, 'validate');
         this.sandbox.stub(messenger);
+        this.sandbox.stub(RedfishTool.prototype, 'clientRequest').resolves();
         messenger.subscribe = this.sandbox.spy(function(name,exchange,callback) {
             callback(eventDestination);
             return Promise.resolve(subscription);


### PR DESCRIPTION
**Background**
During upgrading node from 4 to 6/8, mocha is required to be updated. With latest mocha, unittest won't finish if there is pending tasks.

**Details**
On-http issue is caused by http request timeout in lib/api/redfish-1.0/event-service.js. The http request is actually sent to a faked address 1.1.1.1:8080 which should never response. Solution is to mock http request.

@mcgG @PengTian0 @anhou 