### PR TITLE
Update the reponse in redfish API for setSecureBoot

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -4,7 +4,6 @@
 
 var injector = require('../../../index.js').injector;
 var redfish = injector.get('Http.Api.Services.Redfish');
-var workflowApiService = injector.get('Http.Services.Api.Workflows');
 var waterline = injector.get('Services.Waterline');
 var taskProtocol = injector.get('Protocol.Task');
 var Promise = injector.get('Promise');
@@ -2034,6 +2033,8 @@ var getSecureBoot = controller(function(req, res)  {
  */
 var setSecureBoot = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
+    var options = redfish.makeOptions(req, res, identifier);
+    var graphName = 'Graph.Dell.Wsman.ConfigureBios';
     var secureBootEnable;
     if (req.body.SecureBootEnable) {
         secureBootEnable = "Enabled";
@@ -2048,20 +2049,25 @@ var setSecureBoot = controller(function(req, res)  {
     return wsman.isDellSystem(identifier)
     .then(function(result){
         if(result.isDell){
-            return workflowApiService.createAndRunGraph({
-                name: 'Graph.Dell.Wsman.ConfigureBios',
-                options: {
-                    defaults: {
-                        "attributes": [{
-                            "name": "SecureBoot",
-                            "value": secureBootEnable
-                        }],
-                        "rebootJobType": rebootJobType
-                    }
+            var graphOptions = {
+                defaults: {
+                    "attributes": [{
+                        "name": "SecureBoot",
+                        "value": secureBootEnable
+                    }],
+                    "rebootJobType": rebootJobType
                 }
+            };
+            return nodeApi.setNodeWorkflowById({
+                name: graphName,
+                options: graphOptions
             }, identifier)
-            .then(function() {
-                res.status(202).json({"Message": "Successfully Completed Request"});
+            .then(function(graph) {
+                var output = {
+                    '@odata.id': options.basepath + '/TaskService/Tasks/' + graph.instanceId
+                };
+                res.setHeader('Location', output['@odata.id']);
+                res.status(202).json(output);
             });
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);


### PR DESCRIPTION
**Backgroud**

The response for `POST /redfish/v1/Systems/{identifier}/SecureBoot` should be
```
{
"@odata.id": "string"
}
```
instead of
```
{
"Message": "Successfully Completed Request"
}
```
**Done**
1) Update the reponse in redfish API for setSecureBoot
2) refine the code

**Reviewers**
@RackHD/corecommitters @nortonluo 