### PR TITLE
update resetSystemBios to use Graph.Dell.Wsman.Reset.Components

### DIFF
--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -531,31 +531,36 @@ var changeSystemBiosPassword = controller({success: 202}, function(req, res)  {
  * @param  {Object}     req
  * @param  {Object}     res
  */
-var resetSystemBios = controller({success: 202}, function(req, res)  {
+var resetSystemBios = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
+    var options = redfish.makeOptions(req, res, identifier);
 
-    redfish.makeOptions(req, res, identifier);
     return wsman.isDellSystem(identifier)
     .then(function(result){
         if(result.isDell){
-            var results = { name: "Graph.Dell.Racadm.ResetComponents", options: {} };
-            return dataFactory(identifier, 'DeviceSummary').then(function(summary) {
-                results.options = {
+            var graph = {
+                name: "Graph.Dell.Wsman.Reset.Components",
+                options: {
                     defaults: {
-                        components: ["bios"],
-                        serverIP: summary.data.id
+                        components: ["bios"]
                     }
-                };
-                return results;
-            });
+                }
+            };
+            return graph;
         } else {
             /* TODO: Not implemented? */
              throw new Errors.NotFoundError(
                 'Reset Bios is not implemented for node ' + identifier
             );
         }
-    }).then(function(results) {
-        return nodeApi.setNodeWorkflowById(results, identifier);
+    }).then(function(graph) {
+        return nodeApi.setNodeWorkflowById(graph, identifier);
+    }).then(function(graph) {
+        var output = {
+            '@odata.id': options.basepath + '/TaskService/Tasks/' + graph.instanceId
+        };
+        res.setHeader('Location', output['@odata.id']);
+        res.status(202).json(output);
     }).catch(function(error) {
         return redfish.handleError(error, res);
     });

--- a/static/redfish.yaml
+++ b/static/redfish.yaml
@@ -387,7 +387,9 @@ paths:
             $ref: "#/definitions/Bios.ResetBios"
       responses:
         202:
-          $ref: "#/responses/status_202"
+          description: Success
+          schema:
+            $ref: "#/definitions/odata.4.0.0_idRef"
         400:
           $ref: "#/responses/status_400"
         401:


### PR DESCRIPTION
**Background**
Based on the previous investigation result, develop to port Graph.Dell.Racadm.ResetComponents and /Systems/{identifier}/Bios.ResetBios to use WSMAN API.
https://rackhd.atlassian.net/browse/RAC-6481

**Done**
update resetSystemBios to use Graph.Dell.Wsman.Reset.Components



@RackHD/corecommitters @nortonluo 