### PR TITLE
[RAC-6366] Port Firmware Update Redfish API to use WSMAN graph

### DIFF
--- a/lib/api/redfish-1.0/update-service.js
+++ b/lib/api/redfish-1.0/update-service.js
@@ -140,12 +140,10 @@ var updateFirmware = controller({success: 201}, function (req, res) {
                 .then(function () {
                     return workflow.createAndRunGraph(
                         {
-                            name: 'Graph.Dell.Racadm.Update.Firmware',
+                            name: 'Graph.Dell.Wsman.Simple.Update.Firmware',
                             options: {
                                 defaults: {
-                                    serverUsername: '',
-                                    serverPassword: '',
-                                    serverFilePath: payload.ImageURI
+                                    imageURI: payload.ImageURI
                                 }
                             }
                         },

--- a/spec/lib/api/redfish-1.0/update-service-spec.js
+++ b/spec/lib/api/redfish-1.0/update-service-spec.js
@@ -20,7 +20,7 @@ describe('Redfish Update Service', function () {
     ];
     var badPayload = {"junk": "junk"};
     var goodPayload = {
-        "ImageURI": "/home/rackhd/tmp/installer.exe",
+        "ImageURI": "http://192.111.111.111/installer.exe",
         "Targets": ["58a4799ebaaafbe005dd0bc6"]
     };
     var mockNode = {id: '58a4799ebaaafbe005dd0bc6', type: 'compute'};


### PR DESCRIPTION
**Background**
Our target is to replace all the RACADM dependencies with WSMAN in RackHD features. This task aims to replace RACADM with WSMAN graph to update single firmware.

**Details**
In on-http repo, now we call WSMAN single firmware update graph instead of RACADM, and ImageURI in payload should be assigned with http/https web URI.
1. Replaced RACADM reference with WSMAN in update-service.js.
2. Fixed UT according to modifications.
depends on: https://github.com/RackHD/on-taskgraph/pull/336 https://github.com/RackHD/on-tasks/pull/561

**Reviewer**
@lanchongyizu @yaolingling @nortonluo @leoyjchang 