### PR TITLE
Adding redfish node for chassis/system combo

### DIFF
--- a/data/views/redfish-1.0/redfish.1.0.0.chassiscollection.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.chassiscollection.json
@@ -8,8 +8,13 @@
     "Members": [
         <% nodes.forEach(function(node, i, arr) { %>
         {
-            "@odata.id": "<%= basepath %>/Chassis/<%= node.id %>"
-        }
+            <% if (node.obms[0] !== undefined && node.obms[0].service === 'redfish-obm-service')
+            {%>
+                "@odata.id": "<%= basepath %>/Chassis/<%= node.identifiers[2] %>"
+            <%} else {%>
+                "@odata.id": "<%= basepath %>/Chassis/<%= node.id %>"
+            <%}%>
+}
         <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
         <% }); %>
     ]

--- a/data/views/redfish-1.0/redfish.1.0.0.computersystemcollection.json
+++ b/data/views/redfish-1.0/redfish.1.0.0.computersystemcollection.json
@@ -8,7 +8,12 @@
     "Members": [
         <% nodes.forEach(function(node, i, arr) { %>
             {
+            <% if (node.obms[0] !== undefined && node.obms[0].service === 'redfish-obm-service')
+            {%>
+                "@odata.id": "<%= basepath %>/Systems/<%= node.identifiers[2] %>"
+            <%} else {%>
                 "@odata.id": "<%= basepath %>/Systems/<%= node.id %>"
+            <%}%>
             }
             <%= ( arr.length > 0 && i < arr.length-1 ) ? ',': '' %>
         <% }); %>

--- a/lib/api/redfish-1.0/chassis.js
+++ b/lib/api/redfish-1.0/chassis.js
@@ -202,7 +202,8 @@ var listChassis = controller(function(req, res) {
     var options = redfish.makeOptions(req, res);
     options.nodes = [];
 
-    return Promise.each(nodeApi.getAllNodes({type: 'enclosure'}), function(node) {
+    return Promise.each(nodeApi.getAllNodes({type: ['enclosure', 'redfish']}), function(node) {
+
         options.nodes.push(node);
 
         return Promise.each(_getEnclosedSystems(node), function(objId) {
@@ -229,7 +230,6 @@ var listChassis = controller(function(req, res) {
 var getChassis = controller(function(req, res) {
     var chassisId = req.swagger.params.identifier.value.split('.')[0];
     var systemId = req.swagger.params.identifier.value.split('.')[1];
-    var options = redfish.makeOptions(req, res, req.swagger.params.identifier.value);
     var typeEnum = [
         "Rack",
         "Blade",
@@ -253,11 +253,16 @@ var getChassis = controller(function(req, res) {
         "Other" ];
     return redfish.getVendorNameById(chassisId)
     .then(function(result) {
+        chassisId = result.node.id;
+        var options = redfish.makeOptions(req, res, req.swagger.params.identifier.value);
         if (result.vendor === 'Redfish') {
-            return nodeApi.getNodeById(chassisId)
-            .then(function(node) {
-                var catalogSource = req.url.replace(chassisId, node.identifiers[0]);
-                return dataFactory(chassisId, catalogSource);
+            var catalogSource = req.url.replace(req.swagger.params.identifier.value, chassisId).replace(/\/$/, "");
+            return dataFactory(chassisId, catalogSource)
+            .then(function(response) {
+                return response.data;
+            })
+            .catch(function() {
+                throw new Errors.NotImplementedError(req.url + ' Is Not Implemented on this Device');
             });
         } else {
             return Promise.all([
@@ -328,22 +333,32 @@ var getChassis = controller(function(req, res) {
                     return redfish.render('redfish.1.0.0.chassis.1.0.0.json',
                                           'Chassis.v1_4_0.json#/definitions/Chassis',
                                            _.merge({}, obj, options));
-                })
-                .catch(function (error) {
-                    return redfish.handleError(error, res);
                 });
         }
+    })
+    .catch(function (error) {
+        return redfish.handleError(error, res);
     });
 });
 
 var getThermal = controller(function(req, res) {
     var chassisId = req.swagger.params.identifier.value.split('.')[0];
     var systemId = req.swagger.params.identifier.value.split('.')[1];
-    var options = redfish.makeOptions(req, res, req.swagger.params.identifier.value);
 
     return redfish.getVendorNameById(chassisId)
     .then(function(result) {
-        if (result.vendor === 'Cisco') {
+        chassisId = result.node.id;
+        var options = redfish.makeOptions(req, res, req.swagger.params.identifier.value);
+        if (result.vendor === 'Redfish') {
+            var catalogSource = req.url.replace(req.swagger.params.identifier.value, chassisId).replace(/\/$/, "");
+            return dataFactory(chassisId, catalogSource)
+            .then(function(response) {
+                return response.data;
+            })
+            .catch(function() {
+                throw new Errors.NotImplementedError(req.url + ' Is Not Implemented on this Device');
+            });
+        } else if (result.vendor === 'Cisco') {
             return dataFactory(chassisId, 'ucsThermal')
             .then(function(thermalData) {
                 var ucsPowerThermalData = thermalData['ucs.powerthermal'];
@@ -370,7 +385,9 @@ var getThermal = controller(function(req, res) {
                         }
                     );
                 });
-                return options;
+                return redfish.render('redfish.1.0.0.thermal.1.0.0.json',
+                'Thermal.v1_2_0.json#/definitions/Thermal',
+                options);
             });
         } else {
             return dataFactory(chassisId, 'system')
@@ -399,14 +416,14 @@ var getThermal = controller(function(req, res) {
                         }
                     }
                 });
-                return options;
+                return redfish.render('redfish.1.0.0.thermal.1.0.0.json',
+                'Thermal.v1_2_0.json#/definitions/Thermal',
+                options);
+
             });
         }
-    }).then(function(options) {
-        return redfish.render('redfish.1.0.0.thermal.1.0.0.json',
-                            'Thermal.v1_2_0.json#/definitions/Thermal',
-                            options);
-    }).catch(function(error) {
+    })
+    .catch(function(error) {
         return redfish.handleError(error, res);
     });
 });
@@ -414,11 +431,21 @@ var getThermal = controller(function(req, res) {
 var getPower = controller(function(req, res) {
     var chassisId = req.swagger.params.identifier.value.split('.')[0];
     var systemId = req.swagger.params.identifier.value.split('.')[1];
-    var options = redfish.makeOptions(req, res, req.swagger.params.identifier.value);
 
     return redfish.getVendorNameById(chassisId)
     .then(function(result) {
-        if (result.vendor === 'Cisco') {
+        chassisId = result.node.id;
+        var options = redfish.makeOptions(req, res, req.swagger.params.identifier.value);
+        if (result.vendor === 'Redfish') {
+            var catalogSource = req.url.replace(req.swagger.params.identifier.value, chassisId).replace(/\/$/, "");
+            return dataFactory(chassisId, catalogSource)
+            .then(function(response) {
+                return response.data;
+            })
+            .catch(function() {
+                throw new Errors.NotImplementedError(req.url + ' Is Not Implemented on this Device');
+            });
+        } else if (result.vendor === 'Cisco') {
             return dataFactory(chassisId, 'ucsPower')
             .then(function(powerData) {
                 var ucsPowerThermalData = powerData['ucs.powerthermal'];
@@ -441,7 +468,9 @@ var getPower = controller(function(req, res) {
                         }
                     );
                 });
-                return options;
+                return redfish.render('redfish.1.0.0.power.1.0.0.json',
+                'Power.v1_2_1.json#/definitions/Power',
+                options);
             });
         } else {
             return dataFactory(chassisId, 'system')
@@ -470,14 +499,13 @@ var getPower = controller(function(req, res) {
                         }
                     }
                 });
-                return options;
+                return redfish.render('redfish.1.0.0.power.1.0.0.json',
+                'Power.v1_2_1.json#/definitions/Power',
+                options);
             });
         }
-    }).then(function(options) {
-            return redfish.render('redfish.1.0.0.power.1.0.0.json',
-                                'Power.v1_2_1.json#/definitions/Power',
-                                options);
-    }).catch(function(error) {
+    })
+    .catch(function(error) {
         return redfish.handleError(error, res);
     });
 });

--- a/lib/api/redfish-1.0/dcimcooling.js
+++ b/lib/api/redfish-1.0/dcimcooling.js
@@ -72,11 +72,7 @@ var listDCIMCoolingTypeCollection = controller(function (req, res) {
 
 var listDCIMCoolingDefault = controller(function (req, res) {
     var identifier = req.swagger.params.identifier.value;
-    return nodeApi.getNodeById(identifier)
-    .then(function(node) {
-        var catalogSource = req.url.replace(identifier, node.identifiers[0]);
-        return nodeApi.getNodeCatalogSourceById(identifier, catalogSource);
-    });
+    return nodeApi.getNodeCatalogSourceById(identifier, req.url);
 });
 
 module.exports = {

--- a/lib/api/redfish-1.0/dcimpower.js
+++ b/lib/api/redfish-1.0/dcimpower.js
@@ -76,11 +76,7 @@ var listDCIMPowerTypeCollection = controller(function (req, res) {
 
 var listDCIMPowerDefault = controller(function (req, res) {
     var identifier = req.swagger.params.identifier.value;
-    return nodeApi.getNodeById(identifier)
-    .then(function(node) {
-        var catalogSource = req.url.replace(identifier, node.identifiers[0]);
-        return nodeApi.getNodeCatalogSourceById(identifier, catalogSource);
-    });
+    return nodeApi.getNodeCatalogSourceById(identifier, req.url);
 });
 
 

--- a/lib/api/redfish-1.0/managers.js
+++ b/lib/api/redfish-1.0/managers.js
@@ -32,9 +32,20 @@ var dnsGetFQDN = function() {
     return os.hostname();
 };
 
+var getRedfishDeviceResponse = function(nodeid, req) {
+    var catalogSource = req.url.replace(req.swagger.params.identifier.value, nodeid);
+    return nodeApi.getNodeCatalogSourceById(nodeid, catalogSource)
+    .then(function(response) {
+        return response.data;
+    })
+    .catch(function() {
+        throw new Errors.NotImplementedError(req.url + ' Is Not Implemented on this Device');
+    });
+};
+
 var listManagers = controller(function(req, res) {
     var options = redfish.makeOptions(req, res);
-    return Promise.map(waterline.nodes.find({type: 'compute'}), function(node) {
+    return Promise.map(waterline.nodes.find({type: ['compute', 'redfishManager']}), function(node) {
         return waterline.nodes.getNodeById(node.id);
     })
     .then(function(nodes) {
@@ -56,90 +67,95 @@ var listManagers = controller(function(req, res) {
 var getManager = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
-
-    return Promise.try(function() {
-        if(identifier === reservedId) {
-            return waterline.nodes.find({type: 'compute'});
-        }
-        return nodeApi.getNodeById(identifier)
-        .then(function(){
-            assert.string(identifier, 'invalid identifier specified: ' + identifier);
-            return waterline.nodes.find({id: identifier});
-        });
-    })
-    .then(function(nodes) {
-        if (!nodes) {
-             throw new Errors.NotFoundError('identifier not found');
-        }
-        return Promise.map(nodes, function(node) {
-            return waterline.nodes.getNodeById(node.id);
-        });
-    })
-    .then(function(node) {
-        options.systems = _.map(node, 'id');
-        options.chassis = _.reduce(node, function(arr,val) {
-            _.forEach(val.relations, function(val) {
-                if(val.relationType === 'enclosedBy')  {
-                    arr.push(val.targets[0]);
+    return redfish.getVendorNameById(identifier)
+    .catch(function() {return{};})
+    .then(function(result) {
+	if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
+            return Promise.try(function() {
+                if(identifier === reservedId) {
+                    return waterline.nodes.find({type: ['compute','redfish']});
                 }
-            });
-            return arr;
-        }, []);
-        var dellFound = false;
-        if (node.length > 0) {
-            node[0].identifiers.forEach(function(ident) {
-                if(/^[0-9|A-Z]{7}$/.test(ident)){
-                    dellFound = true;
+                return nodeApi.getNodeById(identifier)
+                .then(function(){
+                    assert.string(identifier, 'invalid identifier specified: ' + identifier);
+                    return waterline.nodes.find({id: identifier});
+                });
+            })
+            .then(function(nodes) {
+                if (!nodes) {
+                    throw new Errors.NotFoundError('identifier not found');
                 }
-            });
-        }
-        options.noSerial = ((identifier === reservedId) || (dellFound)) ? true : false;
-        options.managerType = identifier === reservedId ? 'ManagementController' : 'BMC';
-        if(identifier !== reservedId) {
-            if(!dellFound) {
-                return nodeApi.getNodeCatalogSourceById(node[0].id, 'ipmi-mc-info')
-                .then(function(mcInfo) {
-                    options.mcInfo = mcInfo.data;
+                return Promise.map(nodes, function(node) {
+                    return waterline.nodes.getNodeById(node.id);
                 });
-            }
-            else {
-                return nodeApi.getNodeCatalogSourceById(node[0].id, 'dmi')
-                .then(function(dmi) {
-                    options.mcInfo = dmi.data['System Information'];
-                });
-            }
-        }
-    })
-    .then(function() {
-        if(identifier === reservedId) {
-            var locations = _.filter(configuration.get('httpEndpoints', []),
-                            _.matches({routers:'northbound-api-router'}));
-            var httpLocation = _.find(locations, {httpsEnabled: false});
-            var httpsLocation = _.find(locations, {httpsEnabled: true});
+            })
+            .then(function(node) {
+                options.systems = _.map(node, 'id');
+                options.chassis = _.reduce(node, function(arr,val) {
+                    if(val.type === 'redfish'){
+                        arr.push(val.id);
+                    }
+                    _.forEach(val.relations, function(val) {
+                        if(val.relationType === 'enclosedBy')  {
+                            arr.push(val.targets[0]);
+                        }
+                    });
+                    return arr;
+                }, []);
 
-            var services = [];
-            if(httpLocation) {
-                services.push({ name: 'HTTP', port: httpLocation.port, enabled: true });
-            }
-            if(httpsLocation) {
-                services.push({ name: 'HTTPS', port: httpsLocation.port, enabled: true });
-            }
-            var enabled = _.find(upnpService.registry, {urn: 'urn:dmtf-org:service:redfish-rest:1.0'}).alive;
-            services.push({ name: 'SSDP', port: 1900, enabled: enabled });
-            return Promise.props({
-                hostname: os.hostname(),
-                fqdn: dnsGetFQDN(),
-                services: services
+                var dellFound = (result.vendor === 'Dell');
+
+                options.noSerial = ((identifier === reservedId) || (dellFound)) ? true : false;
+                options.managerType = identifier === reservedId ? 'ManagementController' : 'BMC';
+                if (identifier !== reservedId) {
+                    if(!dellFound) {
+                        return nodeApi.getNodeCatalogSourceById(node[0].id, 'ipmi-mc-info')
+                        .then(function(mcInfo) {
+                            options.mcInfo = mcInfo.data;
+                        });
+                    }
+                    else {
+                        return nodeApi.getNodeCatalogSourceById(node[0].id, 'dmi')
+                        .then(function(dmi) {
+                            options.mcInfo = dmi.data['System Information'];
+                        });
+                    }
+                }
+            })
+            .then(function() {
+                if(identifier === reservedId) {
+                    var locations = _.filter(configuration.get('httpEndpoints', []),
+                                    _.matches({routers:'northbound-api-router'}));
+                    var httpLocation = _.find(locations, {httpsEnabled: false});
+                    var httpsLocation = _.find(locations, {httpsEnabled: true});
+
+                    var services = [];
+                    if(httpLocation) {
+                        services.push({ name: 'HTTP', port: httpLocation.port, enabled: true });
+                    }
+                    if(httpsLocation) {
+                        services.push({ name: 'HTTPS', port: httpsLocation.port, enabled: true });
+                    }
+                    var enabled = _.find(upnpService.registry, {urn: 'urn:dmtf-org:service:redfish-rest:1.0'}).alive;
+                    services.push({ name: 'SSDP', port: 1900, enabled: enabled });
+                    return Promise.props({
+                        hostname: os.hostname(),
+                        fqdn: dnsGetFQDN(),
+                        services: services
+                    });
+                }
+            })
+            .then(function(networkProtocol) {
+                if(networkProtocol) {
+                    options.networkProtocol = networkProtocol;
+                }
+                return redfish.render('redfish.1.0.0.manager.1.0.0.json',
+                                    'Manager.v1_3_0.json#/definitions/Manager',
+                                    options);
             });
         }
-    })
-    .then(function(networkProtocol) {
-        if(networkProtocol) {
-            options.networkProtocol = networkProtocol;
-        }
-        return redfish.render('redfish.1.0.0.manager.1.0.0.json',
-                            'Manager.v1_3_0.json#/definitions/Manager',
-                            options);
     })
     .catch(function(error) {
         if(error.name === 'AssertionError') {
@@ -152,80 +168,81 @@ var getManager = controller(function(req, res) {
 var listManagerNetworkProtocol = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
-    return Promise.try(function() {
-        if(identifier === reservedId){
-            var services = [];
-            var locations = _.filter(configuration.get('httpEndpoints', []),
-                            _.matches({routers:'northbound-api-router'}));
-            var httpLocation = _.find(locations, {httpsEnabled: false});
-            var httpsLocation = _.find(locations, {httpsEnabled: true});
-            if(httpLocation) {
-                services.push({ name: 'HTTP', port: httpLocation.port, enabled: true });
-            }
-            if(httpsLocation) {
-                services.push({ name: 'HTTPS', port: httpsLocation.port, enabled: true });
-            }
-            var enabled = _.find(upnpService.registry, {urn: 'urn:dmtf-org:service:redfish-rest:1.0'}).alive;
-            services.push({ name: 'SSDP', port: 1900, enabled: enabled });
-            return Promise.props({
-                hostname: os.hostname(),
-                fqdn: dnsGetFQDN(),
-                services: services
-            })
-            .then(function(networkProtocol) {
-                if(networkProtocol) {
-                    options.networkProtocol = networkProtocol;
-                }
-                return redfish.render('redfish.1.0.0.managernetworkprotocol.1.0.0.json',
-                                      'ManagerNetworkProtocol.v1_1_0.json#/definitions/ManagerNetworkProtocol',
-                                      options);
-            })
-            .catch(function(error) {
-                if(error.name === 'AssertionError') {
-                    error = new Errors.NotFoundError('invalid resource: ' + error.message);
-                }
-            return redfish.handleError(error, res);
-            });
-        }
-        else{
+
+    return redfish.getVendorNameById(identifier)
+    .catch(function() {return{};})
+    .then(function(result) {
+	if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
             return Promise.try(function() {
-                assert.string(identifier, 'invalid identifier specified: ' + identifier);
-                return waterline.nodes.needByIdentifier(identifier);
-            })
-            .then(function(node) {
-                if (!node) {
-                    throw new Errors.NotFoundError('identifier not found');
+                if(identifier === reservedId){
+                    var services = [];
+                    var locations = _.filter(configuration.get('httpEndpoints', []),
+                                    _.matches({routers:'northbound-api-router'}));
+                    var httpLocation = _.find(locations, {httpsEnabled: false});
+                    var httpsLocation = _.find(locations, {httpsEnabled: true});
+                    if(httpLocation) {
+                        services.push({ name: 'HTTP', port: httpLocation.port, enabled: true });
+                    }
+                    if(httpsLocation) {
+                        services.push({ name: 'HTTPS', port: httpsLocation.port, enabled: true });
+                    }
+                    var enabled = _.find(upnpService.registry, {urn: 'urn:dmtf-org:service:redfish-rest:1.0'}).alive;
+                    services.push({ name: 'SSDP', port: 1900, enabled: enabled });
+                    return Promise.props({
+                        hostname: os.hostname(),
+                        fqdn: dnsGetFQDN(),
+                        services: services
+                    })
+                    .then(function(networkProtocol) {
+                        if(networkProtocol) {
+                            options.networkProtocol = networkProtocol;
+                        }
+                        return redfish.render('redfish.1.0.0.managernetworkprotocol.1.0.0.json',
+                                            'ManagerNetworkProtocol.v1_1_0.json#/definitions/ManagerNetworkProtocol',
+                                            options);
+                    })
+                    .catch(function(error) {
+                        if(error.name === 'AssertionError') {
+                            error = new Errors.NotFoundError('invalid resource: ' + error.message);
+                        }
+                    return redfish.handleError(error, res);
+                    });
                 }
-                return waterline.nodes.getNodeById(node.id);
-            })
-            .then(function(node) {
-                assert.ok(_.isArray(node.obms), 'invalid obmSettings');
-                assert.ok(node.obms.length > 0, 'invalid obmSetting');
-                // TODO: dell & not dell handled the same for now.
-                var dellFound = false;
-                node.identifiers.forEach(function(ident) {
-                if(/^[0-9|A-Z]{7}$/.test(ident)){
-                    dellFound = true;
+                else{
+                    return Promise.try(function() {
+                        assert.string(identifier, 'invalid identifier specified: ' + identifier);
+                        return waterline.nodes.needByIdentifier(identifier);
+                    })
+                    .then(function(node) {
+                        if (!node) {
+                            throw new Errors.NotFoundError('identifier not found');
+                        }
+                        return waterline.nodes.getNodeById(node.id);
+                    })
+                    .then(function(node) {
+                        assert.ok(_.isArray(node.obms), 'invalid obmSettings');
+                        assert.ok(node.obms.length > 0, 'invalid obmSetting');
+                        options.networkProtocol = "";
+                        return redfish.render('redfish.1.0.0.managernetworkprotocol.1.0.0.json',
+                                            'ManagerNetworkProtocol.v1_1_0.json#/definitions/ManagerNetworkProtocol',
+                                            options);
+                    });
                 }
-                });
-                options.networkProtocol = "";
-                return redfish.render('redfish.1.0.0.managernetworkprotocol.1.0.0.json',
-                                      'ManagerNetworkProtocol.v1_1_0.json#/definitions/ManagerNetworkProtocol',
-                                      options);
-             })
-            .catch(function(error) {
-                if(error.name === 'AssertionError') {
-                    error = new Errors.NotFoundError('invalid resource: ' + error.message);
-                }
-                return redfish.handleError(error, res);
             });
         }
+    })
+    .catch(function(error) {
+        if(error.name === 'AssertionError') {
+            error = new Errors.NotFoundError('invalid resource: ' + error.message);
+        }
+        return redfish.handleError(error, res);
     });
 });
 
 var patchManager = controller({success: 204}, function(req, res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
 
     return Promise.try(function() {
@@ -267,22 +284,29 @@ var listManagerEthernetInterfaces = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return Promise.try(function() {
-        assert.string(identifier, 'invalid identifier specified: ' + identifier);
-        return waterline.nodes.needByIdentifier(identifier);
-    })
-    .then(function(node) {
-        return waterline.nodes.getNodeById(node.id);
-    })
-    .then(function(node) {
-        assert.ok(_.isArray(node.obms), 'invalid obmSettings');
-        assert.ok(node.obms.length > 0, 'invalid obmSetting');
-        options.name = "Manager Ethernet Interface Collection";
-        options.net = [ '0' ];  // there is only one host per obmsetting
-        options.baseprofile = 'Managers';
-        return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
-                            'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
-                            options);
+    return redfish.getVendorNameById(identifier)
+    .then(function(result) {
+	if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
+            return Promise.try(function() {
+                assert.string(identifier, 'invalid identifier specified: ' + identifier);
+                return waterline.nodes.needByIdentifier(identifier);
+            })
+            .then(function(node) {
+                return waterline.nodes.getNodeById(node.id);
+            })
+            .then(function(node) {
+                assert.ok(_.isArray(node.obms), 'invalid obmSettings');
+                assert.ok(node.obms.length > 0, 'invalid obmSetting');
+                options.name = "Manager Ethernet Interface Collection";
+                options.net = [ '0' ];  // there is only one host per obmsetting
+                options.baseprofile = 'Managers';
+                return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
+                                    'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
+                                    options);
+            });
+        }
     })
     .catch(function(error) {
         if(error.name === 'AssertionError') {
@@ -297,38 +321,45 @@ var getManagerEthernetInterface = controller(function(req, res) {
     var index = req.swagger.params.index.value;
     var options = redfish.makeOptions(req, res, identifier);
 
-    return Promise.try(function() {
-        assert.string(identifier, 'invalid identifier specified: ' + identifier);
-        return waterline.nodes.needByIdentifier(identifier);
-    })
-    .then(function(node) {
-        return waterline.nodes.getNodeById(node.id);
-    })
-    .then(function(node) {
-        assert.ok(_.isArray(node.obms), 'invalid obmSettings');
-        assert.ok(node.obms.length > 0, 'invalid obmSetting');
-        return nodeApi.getNodeCatalogSourceById(node.id, 'bmc');
-    })
-    .then(function(data) {
-        options.name = "Manager Ethernet Interface";
-        options.baseprofile = 'Managers';
-        options.index = index;
-        options.permanentmacaddress = data.data['MAC Address'];
-        options.macaddress = data.data['MAC Address'];
-        if(data.data['802_1q VLAN ID'] !== 'Disabled') {
-            options.vlan = data.data['802_1q VLAN ID'];
+    return redfish.getVendorNameById(identifier)
+    .then(function(result) {
+	if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
+            return Promise.try(function() {
+                assert.string(identifier, 'invalid identifier specified: ' + identifier);
+                return waterline.nodes.needByIdentifier(identifier);
+            })
+            .then(function(node) {
+                return waterline.nodes.getNodeById(node.id);
+            })
+            .then(function(node) {
+                assert.ok(_.isArray(node.obms), 'invalid obmSettings');
+                assert.ok(node.obms.length > 0, 'invalid obmSetting');
+                return nodeApi.getNodeCatalogSourceById(node.id, 'bmc');
+            })
+            .then(function(data) {
+                options.name = "Manager Ethernet Interface";
+                options.baseprofile = 'Managers';
+                options.index = index;
+                options.permanentmacaddress = data.data['MAC Address'];
+                options.macaddress = data.data['MAC Address'];
+                if(data.data['802_1q VLAN ID'] !== 'Disabled') {
+                    options.vlan = data.data['802_1q VLAN ID'];
+                }
+                options.ipv4 = [
+                    {
+                        ipaddr: data.data['IP Address'],
+                        ipsubnet: data.data['Subnet Mask'],
+                        ipgateway: data.data['Default Gateway IP'],
+                        ipsrc: _.includes(data.data['IP Address Source'], 'DHCP') ? 'DHCP' : 'Static'
+                    }
+                ];
+                return redfish.render('redfish.1.0.0.ethernetinterface.1.0.0.json',
+                                    'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
+                                    options);
+            });
         }
-        options.ipv4 = [
-            {
-                ipaddr: data.data['IP Address'],
-                ipsubnet: data.data['Subnet Mask'],
-                ipgateway: data.data['Default Gateway IP'],
-                ipsrc: _.includes(data.data['IP Address Source'], 'DHCP') ? 'DHCP' : 'Static'
-            }
-        ];
-        return redfish.render('redfish.1.0.0.ethernetinterface.1.0.0.json',
-                            'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
-                            options);
     })
     .catch(function(error) {
         if(error.name === 'AssertionError') {
@@ -362,35 +393,34 @@ var listLocalEthernetInterfaces = controller(function(req, res) {
 var getLocalEthernetInterface = controller(function(req, res) {
     var options = redfish.makeOptions(req, res);
     var index = req.swagger.params.index.value;
-
     return Promise.try(function() {
-        var net = _.get(os.networkInterfaces(), index);
-        if(!net) {
-            throw new Errors.NotFoundError('invalid resource');
-        }
+    var net = _.get(os.networkInterfaces(), index);
+    if(!net) {
+        throw new Errors.NotFoundError('invalid resource');
+    }
 
-        options.name = "Manager Ethernet Interface";
-        options.baseprofile = 'Managers';
-        options.index = index;
-        options.ipv4 = _.reduce(net, function(arr, val) {
-            if(!val.internal && val.family === 'IPv4') {
-                var obj = {
-                    ipaddr: val.address
-                };
-                if(val.netmask) {  // not available in node 0.10
-                    obj.ipsubnet = val.netmask;
-                }
-                if(val.mac) { // not available in node 0.10
-                    options.permanentmacaddress = val.mac;
-                    options.macaddress = val.mac;
-                }
-                arr.push(obj);
+    options.name = "Manager Ethernet Interface";
+    options.baseprofile = 'Managers';
+    options.index = index;
+    options.ipv4 = _.reduce(net, function(arr, val) {
+        if(!val.internal && val.family === 'IPv4') {
+            var obj = {
+                ipaddr: val.address
+            };
+            if(val.netmask) {  // not available in node 0.10
+                obj.ipsubnet = val.netmask;
             }
-            return arr;
-        }, []);
-        return redfish.render('redfish.1.0.0.ethernetinterface.1.0.0.json',
-                              'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
-                              options);
+            if(val.mac) { // not available in node 0.10
+                options.permanentmacaddress = val.mac;
+                options.macaddress = val.mac;
+            }
+            arr.push(obj);
+        }
+        return arr;
+    }, []);
+    return redfish.render('redfish.1.0.0.ethernetinterface.1.0.0.json',
+                          'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
+                          options);
     })
     .catch(function(error) {
         return redfish.handleError(error, res);
@@ -400,42 +430,45 @@ var getLocalEthernetInterface = controller(function(req, res) {
 var listManagerSerialInterfaces = controller(function (req, res) {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
-    return Promise.try(function() {
-        if(identifier === reservedId){
-            throw new Errors.NotFoundError();
-        }
-        return waterline.nodes.getNodeById(identifier);
-    })
-    .then(function(node) {
-        var dellFound = false;
-        node.identifiers.forEach(function(ident) {
-            if(/^[0-9|A-Z]{7}$/.test(ident)){
-                dellFound = true;
-            }
-        });
-        if(dellFound){
-            throw new Errors.NotFoundError();
-        }
-        return nodeApi.getNodeCatalogSourceById(identifier, 'dmi');
-    })
-    .then(function (catalog) {
-        var  arr = [];
-        if (catalog.length !== 0) {
-             _.forEach(catalog.data['Port Connector Information'], function (item) {
-                if (item['Port Type'].match(/Serial/i)) {
-                    item['External Reference Designator'] = item['External Reference Designator'].replace(/ /g, '');
-                    arr.push(item);
+
+    return redfish.getVendorNameById(identifier)
+    .catch(function() {return{};})
+    .then(function(result) {
+	if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
+            return Promise.try(function() {
+                if(identifier === reservedId){
+                    throw new Errors.NotFoundError();
                 }
-             });
+                return waterline.nodes.getNodeById(identifier);
+            })
+            .then(function() {
+                if(result.vendor === 'Dell'){
+                    throw new Errors.NotFoundError();
+                }
+                return nodeApi.getNodeCatalogSourceById(identifier, 'dmi');
+            })
+            .then(function (catalog) {
+                var  arr = [];
+                if (catalog.length !== 0) {
+                    _.forEach(catalog.data['Port Connector Information'], function (item) {
+                        if (item['Port Type'].match(/Serial/i)) {
+                            item['External Reference Designator'] = item['External Reference Designator'].replace(/ /g, '');
+                            arr.push(item);
+                        }
+                    });
+                }
+                return arr;
+            }).then(function (interfaces) {
+                options.interface = interfaces;
+                options.name = "Manager Ethernet Interface Collection";
+                options.baseprofile = 'Managers';
+                return redfish.render('redfish.1.0.0.serialinterfacecollection.json',
+                                    'SerialInterfaceCollection.json#/definitions/SerialInterfaceCollection',
+                                    options);
+            });
         }
-        return arr;
-    }).then(function (interfaces) {
-        options.interface = interfaces;
-        options.name = "Manager Ethernet Interface Collection";
-        options.baseprofile = 'Managers';
-        return redfish.render('redfish.1.0.0.serialinterfacecollection.json',
-                              'SerialInterfaceCollection.json#/definitions/SerialInterfaceCollection',
-                              options);
     })
     .catch(function (error) {
         return redfish.handleError(error, res);
@@ -446,45 +479,47 @@ var getManagerSerialInterface = controller(function (req, res) {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res);
     var index = req.swagger.params.index.raw;
-    return Promise.try(function () {
-        if(identifier === reservedId){
-            throw new Errors.NotFoundError();
-        }
-        return waterline.nodes.getNodeById(identifier);
-    })
-    .then(function(node) {
-        var dellFound = false;
-        node.identifiers.forEach(function(ident) {
-            if(/^[0-9|A-Z]{7}$/.test(ident)){
-                dellFound = true;
-            }
-        });
-        if(dellFound){
-            throw new Errors.NotFoundError();
-        }
-        return nodeApi.getNodeCatalogSourceById(identifier, 'dmi');
-    })
-    .then(function (catalog) {
-        var  arr = [];
-        assert.ok(catalog.length !== 0, 'Catalog not found');
-        _.forEach(catalog.data['Port Connector Information'], function (item) {
-            if (item['Port Type'].match(/Serial/i) && item['External Reference Designator'].replace(/ /g, '') === index) {
-                item['External Reference Designator'] = item['External Reference Designator'].replace(/ /g, '');
-                arr.push(item);
-                options.name = "Managed Serial Interface";
-                options.description = item['Port Type'];
-                options.Id = index;
-                options.baseprofile = 'Managers';
-                options.interfaceEnabled = true;
-                if (item['External Connector Type'] === "DB-9 male") {
-                    options.connectorType = "DB9 Male."; // Currently the schema checks for this exact entry
+
+    return redfish.getVendorNameById(identifier)
+    .catch(function() {return{};})
+    .then(function(result) {
+	    if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
+            return Promise.try(function () {
+                if(identifier === reservedId){
+                    throw new Errors.NotFoundError();
                 }
-            }
-        });
-        return redfish.render('redfish.1.0.0.serialinterface.1.0.0.json',
-                              'SerialInterface.v1_0_3.json#/definitions/SerialInterface',
-                              options);
- 
+                return waterline.nodes.getNodeById(identifier);
+            })
+            .then(function() {
+                if(result.vendor === 'Dell') {
+                    throw new Errors.NotFoundError();
+                }
+                return nodeApi.getNodeCatalogSourceById(identifier, 'dmi');
+            })
+            .then(function (catalog) {
+                var  arr = [];
+                assert.ok(catalog.length !== 0, 'Catalog not found');
+                _.forEach(catalog.data['Port Connector Information'], function (item) {
+                    if (item['Port Type'].match(/Serial/i) && item['External Reference Designator'].replace(/ /g, '') === index) {
+                        item['External Reference Designator'] = item['External Reference Designator'].replace(/ /g, '');
+                        arr.push(item);
+                        options.name = "Managed Serial Interface";
+                        options.description = item['Port Type'];
+                        options.Id = index;
+                        options.baseprofile = 'Managers';
+                        options.interfaceEnabled = true;
+                        if (item['External Connector Type'] === "DB-9 male") {
+                            options.connectorType = "DB9 Male."; // Currently the schema checks for this exact entry
+                        }
+                    }
+                });
+                return redfish.render('redfish.1.0.0.serialinterface.1.0.0.json',
+                                    'SerialInterface.v1_0_3.json#/definitions/SerialInterface',
+                                    options);
+            });
+        }
     })
     .catch(function (error) {
         return redfish.handleError(error, res);

--- a/lib/api/redfish-1.0/networks.js
+++ b/lib/api/redfish-1.0/networks.js
@@ -34,15 +34,16 @@ var listNetworks = controller(function(req, res) {
  * @param  {Object}     res
  */
 var getNetwork = controller(function(req, res) {
-    var redfishId = redfish.isRedfish(req.swagger.params.identifier.value);
-    var identifier = redfishId.identifier;
-    var options = redfish.makeOptions(req, res, identifier);
-    options.systemType = 'Physical';
+    //var redfishId = redfish.isRedfish(req.swagger.params.identifier.value);
+    var identifier = req.swagger.params.identifier.value;
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
         .then(function(result){
             var node = result.node;
-            if(result.isDell){
+            identifier = node.id;
+            var options = redfish.makeOptions(req, res, identifier);
+            options.systemType = 'Physical';
+            if(result.vendor === 'Dell'){
                 return Promise.props({
                     hardware: systems.dataFactory(identifier, 'hardware'),
                     boot: systems.dataFactory(identifier, 'boot'),
@@ -65,8 +66,8 @@ var getNetwork = controller(function(req, res) {
                 }).catch(function(error) {
                     return redfish.handleError(error, res);
                 });
-            } else if (redfishId.isRedfish) {
-                return redfish.getRedfishCatalog(req, res);
+            } else if (result.vendor === 'Redfish') {
+                return systems.getRedfishDeviceResponse(identifier, req);
             } else {
                 return Promise.props({
                     catData: systems.dataFactory(identifier, 'catData'),

--- a/lib/api/redfish-1.0/systems.js
+++ b/lib/api/redfish-1.0/systems.js
@@ -17,6 +17,7 @@ var configuration = injector.get('Services.Configuration');
 var mktemp = require('mktemp');
 var lookup = injector.get('Services.Lookup');
 var fs = require('fs');
+var encryption = injector.get('Services.Encryption');
 
 var dataFactory = function(identifier, dataName) {
     switch(dataName)  {
@@ -27,7 +28,7 @@ var dataFactory = function(identifier, dataName) {
                     return catData;
                 });
         case 'chassis':
-            return nodeApi.getNodeById(identifier)
+            return nodeApi.getNodeByIdentifier(identifier)
             .then(function(node) {
                 return _.filter(node.relations, function(relation) {
                     return relation.relationType === 'enclosedBy';
@@ -35,8 +36,6 @@ var dataFactory = function(identifier, dataName) {
                     return relation.targets[0];
                 });
             });
-        case 'Redfish':
-            return waterline.catalogs.find({ "node": identifier, "source": dataName });
         case 'chassisData':
             return nodeApi.getPollersByNodeId(identifier)
             .filter(function(poller) {
@@ -207,6 +206,36 @@ var selTranslator = function(selArray, identifier) {
     });
 };
 
+var getObmSettings = function(nodeId){
+    return waterline.obms.findByNode(nodeId, 'ipmi-obm-service', true)
+        .then(function (obm) {
+            if (!obm) {
+               return waterline.obms.findByNode(nodeId, 'dell-wsman-obm-service', true)
+               .then(function (obm2) {
+                   if (!obm2) {
+                       return waterline.obms.findByNode(nodeId, 'redfish-obm-service', true);
+                   }
+                   return obm2;
+               });
+            }
+            return obm;
+        })
+        .catch(function(err) {
+            return (err);
+        });
+};
+
+var getRedfishDeviceResponse = function(nodeid, req) {
+    var catalogSource = req.url.replace(req.swagger.params.identifier.value, nodeid).replace(/\/$/, "");
+    return dataFactory(nodeid,catalogSource)
+    .then(function(response) {
+        return response.data;
+    })
+    .catch(function() {
+        throw new Errors.NotImplementedError(req.url + ' Is Not Implemented on this Device');
+    });
+};
+
 /**
  * Generate a list of systems managed by RackHD
  * @param  {Object}     req
@@ -214,7 +243,7 @@ var selTranslator = function(selArray, identifier) {
  */
 var listSystems = controller(function(req, res) {
     var options = redfish.makeOptions(req, res);
-    return waterline.nodes.find({type: 'compute'}).then(function(nodes) {
+    return nodeApi.getAllNodes({type: ['compute','redfish']}).then(function(nodes) {
         options.nodes = nodes;
         return redfish.render('redfish.1.0.0.computersystemcollection.json',
                             'ComputerSystemCollection.json#/definitions/ComputerSystemCollection',
@@ -231,12 +260,12 @@ var listSystems = controller(function(req, res) {
  */
 var getSystem = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
-    options.systemType = 'Physical';
-
     return redfish.getVendorNameById(identifier)
     .then(function(result){
         var node = result.node;
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.systemType = 'Physical';
         if(result.vendor === 'Dell'){
             return Promise.props({
                 hardware: dataFactory(identifier, 'hardware'),
@@ -249,8 +278,6 @@ var getSystem = controller(function(req, res) {
                 return redfish.render('redfish.2016.3.computersystem.1.3.0.json',
                                 'ComputerSystem.v1_3_0.json#/definitions/ComputerSystem',
                                 _.merge(options, data));
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         } else if(result.vendor === 'Cisco'){
             return Promise.props({
@@ -270,13 +297,10 @@ var getSystem = controller(function(req, res) {
                 return redfish.render('ucs.1.0.0.computersystem.1.3.0.json',
                                 'ComputerSystem.v1_3_0.json#/definitions/ComputerSystem',
                                 _.merge(options, data));
-            }).catch(function(error){
-                return redfish.handleError(error, res);
             });
-	} else if (result.vendor === 'Redfish') {
-            var catalogSource = req.url.replace(identifier, node.identifiers[0]);
-            return dataFactory(identifier, catalogSource);
-        }else {
+	    } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
             return Promise.props({
                 catData: dataFactory(identifier, 'catData'),
                 chassis: dataFactory(identifier, 'chassis'),
@@ -287,8 +311,6 @@ var getSystem = controller(function(req, res) {
                 return redfish.render('redfish.1.0.0.computersystem.1.1.0.json',
                                 'ComputerSystem.v1_3_0.json#/definitions/ComputerSystem',
                                 _.merge(options, data));
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         }
     }).catch(function(error) {
@@ -304,12 +326,14 @@ var getSystem = controller(function(req, res) {
  */
 var listSystemBios = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
-
-    return wsman.isDellSystem(identifier)
-    .then(function(result){
-        if(result.isDell){
-            return dataFactory(identifier, 'bios').then(function(bios) {
+    return redfish.getVendorNameById(identifier)
+    .then(function(result) {
+        var node = result.node;
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if (result.vendor === 'Dell') {
+            return dataFactory(identifier, 'bios')
+            .then(function(bios) {
                 options.bios = bios;
                 bios.attributes = [];
                 var key;
@@ -326,15 +350,19 @@ var listSystemBios = controller(function(req, res) {
                     }
                 }
                 return options;
+            })
+            .then(function(options) {
+                return redfish.render('redfish.1.0.0.bios.1.0.0.json',
+                    'Bios.v1_0_1.json#/definitions/Bios',
+                    options);
             });
+	    } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             throw new Errors.NotFoundError('No BIOS found for node ' + identifier);
         }
-    }).then(function(options) {
-        return redfish.render('redfish.1.0.0.bios.1.0.0.json',
-            'Bios.v1_0_1.json#/definitions/Bios',
-            options);
-    }).catch(function(error) {
+    })
+    .catch(function(error) {
         return redfish.handleError(error, res);
     });
 });
@@ -346,11 +374,12 @@ var listSystemBios = controller(function(req, res) {
  */
 var listSystemBiosSettings = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if (result.vendor === 'Dell') {
             return dataFactory(identifier, 'bios').then(function(bios) {
                 options.bios = bios;
                 bios.attributes = [];
@@ -372,18 +401,18 @@ var listSystemBiosSettings = controller(function(req, res)  {
                         bios.attributes[key].currentValue[0] = {"value": null};
                     }
                 }
-                return options;
+                return redfish.render('redfish.1.0.0.bios.1.0.0.settings.json',
+                                      'Bios.v1_0_1.json#/definitions/Bios',
+                                      options);
             });
+	} else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             /* TODO: Not implemented? */
                throw new Errors.NotFoundError(
                     'No BIOS found for node ' + identifier
             );
         }
-    }).then(function(options) {
-        return redfish.render('redfish.1.0.0.bios.1.0.0.settings.json',
-                              'Bios.v1_0_1.json#/definitions/Bios',
-                              options);
     }).catch(function(error) {
         return redfish.handleError(error, res);
     });
@@ -397,15 +426,16 @@ var listSystemBiosSettings = controller(function(req, res)  {
 var patchSystemBiosSettings = controller({success: 202}, function(req, res)  {
 
     var identifier = req.swagger.params.identifier.value;
-    redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
 
     var southboundApiRouter = _.filter(configuration.get('httpEndpoints', []),
                                        _.matches({routers:'southbound-api-router'}))[0];
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        redfish.makeOptions(req, res, identifier);
+        if (result.vendor === 'Dell') {
             var results = { name: "Graph.Dell.Wsman.UpdateSystemComponents", options: {} };
 
             return dataFactory(identifier, 'DeviceSummary').then(function(summary) {
@@ -432,6 +462,29 @@ var patchSystemBiosSettings = controller({success: 202}, function(req, res)  {
                 }
                 return results;
             });
+        } else if(result.vendor === 'Redfish'){
+            return getObmSettings(identifier)
+            .then(function(obm) {
+
+                var results = { name: "Graph.Run.Rest.Command", options: {} };
+                results.options = {
+                    defaults: {
+                        url: {
+                            protocol: obm.config.protocol,
+                            host: obm.config.host,
+                            port: obm.config.port,
+                            path: req.url.replace(req.swagger.params.identifier.value, result.node.identifiers[0])
+                        },
+                        credential: {username: obm.config.username, password: encryption.decrypt(obm.config.password)},
+                        method: 'PATCH',
+                        headers: {},
+                        data: payload,
+                        verifySSL: obm.config.verifySSL,
+                        recvTimeoutMs: 360000
+                    }
+               };
+               return results;
+           });
         } else {
             /* TODO: Not implemented? */
              throw new Errors.NotFoundError(
@@ -453,7 +506,6 @@ var patchSystemBiosSettings = controller({success: 202}, function(req, res)  {
 var changeSystemBiosPassword = controller({success: 202}, function(req, res)  {
 
     var identifier = req.swagger.params.identifier.value;
-    redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
 
     var southboundApiRouter = _.filter(configuration.get('httpEndpoints', []),
@@ -467,9 +519,10 @@ var changeSystemBiosPassword = controller({success: 202}, function(req, res)  {
 
 </SystemConfiguration>`;
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        if (result.vendor === 'Dell') {
 
             var results = { name: "Graph.Dell.Wsman.UpdateSystemComponents", options: {} };
             return mktemp
@@ -513,6 +566,30 @@ var changeSystemBiosPassword = controller({success: 202}, function(req, res)  {
                         return results;
                     });
                 });
+         } else if(result.vendor === 'Redfish'){
+            return getObmSettings(identifier)
+            .then(function(obm) {
+
+                var results = { name: "Graph.Run.Rest.Command", options: {} };
+                results.options = {
+                    defaults: {
+                        url: {
+                            protocol: obm.config.protocol,
+                            host: obm.config.host,
+                            port: obm.config.port,
+                            path: req.url.replace(req.swagger.params.identifier.value, result.node.identifiers[0])
+                        },
+                        credential: {username: obm.config.username, password: encryption.decrypt(obm.config.password)},
+                        method: 'POST',
+                        headers: {},
+                        data: payload,
+                        verifySSL: obm.config.verifySSL,
+                        recvTimeoutMs: 360000
+                    }
+               };
+               return results;
+           });
+
         } else {
             /* TODO: Not implemented? */
              throw new Errors.NotFoundError(
@@ -534,10 +611,12 @@ var changeSystemBiosPassword = controller({success: 202}, function(req, res)  {
 var resetSystemBios = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
+    var payload = req.swagger.params.payload.value;
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        if (result.vendor === 'Dell') {
             var graph = {
                 name: "Graph.Dell.Wsman.Reset.Components",
                 options: {
@@ -547,6 +626,29 @@ var resetSystemBios = controller(function(req, res)  {
                 }
             };
             return graph;
+        } else if(result.vendor === 'Redfish') {
+            return getObmSettings(identifier)
+            .then(function(obm) {
+
+                var results = { name: "Graph.Run.Rest.Command", options: {} };
+                results.options = {
+                    defaults: {
+                        url: {
+                            protocol: obm.config.protocol,
+                            host: obm.config.host,
+                            port: obm.config.port,
+                            path: req.url.replace(req.swagger.params.identifier.value, result.node.identifiers[0])
+                        },
+                        credential: {username: obm.config.username, password: encryption.decrypt(obm.config.password)},
+                        method: 'POST',
+                        headers: {},
+                        data: payload,
+                        verifySSL: obm.config.verifySSL,
+                        recvTimeoutMs: 360000
+                    }
+               };
+               return results;
+           });
         } else {
             /* TODO: Not implemented? */
              throw new Errors.NotFoundError(
@@ -573,10 +675,11 @@ var resetSystemBios = controller(function(req, res)  {
  */
 var listSystemProcessors = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
     return redfish.getVendorNameById(identifier)
     .then(function(result){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
         if(result.vendor === 'Dell'){
             return dataFactory(identifier, 'hardware')
             .then(function(hardware) {
@@ -601,6 +704,8 @@ var listSystemProcessors = controller(function(req, res)  {
                     options
                 );
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return dataFactory(identifier, 'dmi').then(function(dmi) {
                 options.dmi = dmi;
@@ -629,10 +734,11 @@ var listSystemProcessors = controller(function(req, res)  {
  */
 var getSystemProcessor = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
     return redfish.getVendorNameById(identifier)
     .then(function(result) {
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
         if(result.vendor === 'Dell'){
             return Promise.props({
                 socketId: req.swagger.params.socket.value,
@@ -664,6 +770,8 @@ var getSystemProcessor = controller(function(req, res)  {
             }).catch(function(error) {
                 return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return Promise.props({
                 socketId: req.swagger.params.socket.value,
@@ -691,10 +799,11 @@ var getSystemProcessor = controller(function(req, res)  {
  */
 var listSimpleStorage = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
     return redfish.getVendorNameById(identifier)
     .then(function(result){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
         if(result.vendor === 'Dell'){
             return dataFactory(identifier, 'hardware')
             .then(function(hardware) {
@@ -734,9 +843,9 @@ var listSimpleStorage = controller(function(req, res)  {
                 return redfish.render('redfish.1.0.0.simplestoragecollection.json',
                                 'SimpleStorageCollection.json#/definitions/SimpleStorageCollection',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return Promise.all([ dataFactory(identifier, 'dmi'),
                                  dataFactory(identifier, 'smart') ])
@@ -755,9 +864,7 @@ var listSimpleStorage = controller(function(req, res)  {
                 return redfish.render('redfish.1.0.0.simplestoragecollection.json',
                             'SimpleStorageCollection.json#/definitions/SimpleStorageCollection',
                             options);
-           }).catch(function(error) {
-               return redfish.handleError(error, res);
-           });
+            });
         }
     }).catch(function(error) {
         return redfish.handleError(error, res);
@@ -772,12 +879,12 @@ var listSimpleStorage = controller(function(req, res)  {
 var getSimpleStorage = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var index = req.swagger.params.index.value;
-    var options = redfish.makeOptions(req, res, identifier);
-
-    options.index = index;
 
     return redfish.getVendorNameById(identifier)
     .then(function(result){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.index = index;
         if(result.vendor === 'Dell'){
             return Promise.resolve(dataFactory(identifier, 'hardware'))
             .then(function(hardware) {
@@ -803,8 +910,6 @@ var getSimpleStorage = controller(function(req, res)  {
                 return redfish.render('wsman.1.0.0.simplestorage.1.0.0.json',
                                 'SimpleStorage.v1_1_1.json#/definitions/SimpleStorage',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         } else if(result.vendor === 'Cisco'){
             return dataFactory(identifier, 'UCS:board')
@@ -813,6 +918,7 @@ var getSimpleStorage = controller(function(req, res)  {
                     if(catalogsData.data.children[controllerId] === undefined){
                         return Promise.reject(new Errors.NotFoundError('simplestorage contorller not found'));
                     }
+                    //_.forEach(catalogsData.data.children[controllerRedfishId], function(ele){
                     _.forEach(catalogsData.data.children[controllerId], function(ele){
                         var newIndex = index.split('_')[0] + "_" + ele.pci_addr.replace(/[:.]/g, '_')
                                         + "_" + ele.id;
@@ -828,8 +934,9 @@ var getSimpleStorage = controller(function(req, res)  {
                 }).catch(function(error){
                     return redfish.handleError(error, res);
                 });
-        }
-        else{
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
             return Promise.all([ dataFactory(identifier, 'dmi'),
                           dataFactory(identifier, 'smart') ])
                 .spread(function(dmi, smart) {
@@ -856,8 +963,6 @@ var getSimpleStorage = controller(function(req, res)  {
                 return redfish.render('redfish.1.0.0.simplestorage.1.0.0.json',
                             'SimpleStorage.v1_1_1.json#/definitions/SimpleStorage',
                             options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         }
     }).catch(function(error) {
@@ -872,89 +977,73 @@ var getSimpleStorage = controller(function(req, res)  {
  */
 var listStorage = controller(function (req, res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
-    return wsman.isDellSystem(identifier)
-        .then(function (result) {
-            if (result.isDell) {
-                return Promise.resolve(dataFactory(identifier, 'hardware'))
-                    .then(function (hardware) {
-                        options.hardware = hardware;
+    return redfish.getVendorNameById(identifier)
+    .then(function (result) {
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Dell'){
+            return Promise.resolve(dataFactory(identifier, 'hardware'))
+            .then(function (hardware) {
+                options.hardware = hardware;
 
-                        var controllers = {};
-                        _.forEach(hardware.data.storage.controllers, function (ele) {
-                            var id = ele.fQDD.replace(/[:.]/g, '_');  // jshint ignore: line
-                            if (!(id in controllers)) {
-                                controllers[id] = [];
-                            }
-                            controllers[id].push(ele);
-                        });
+                var controllers = {};
+                _.forEach(hardware.data.storage.controllers, function (ele) {
+                    var id = ele.fQDD.replace(/[:.]/g, '_');  // jshint ignore: line
+                    if (!(id in controllers)) {
+                        controllers[id] = [];
+                    }
+                    controllers[id].push(ele);
+                });
 
-                        var ids = [];
-                        _.forOwn(controllers, function (val, key) {
-                            ids.push(key);
-                        });
-                        options.controllers = ids;
+                var ids = [];
+                _.forOwn(controllers, function (val, key) {
+                    ids.push(key);
+                });
+                options.controllers = ids;
 
-                        return redfish.render('redfish.1.0.0.storagecollection.json',
-                            'SimpleStorageCollection.json#/definitions/SimpleStorageCollection',
-                            options);
-                    }).catch(function (error) {
-                        return redfish.handleError(error, res);
-                    });
-            } else {
-                return Promise.resolve(dataFactory(identifier, 'Redfish'))
-                    .then(function (redfishCatalog) {
-                        if (redfishCatalog === undefined || redfishCatalog.length === 0) {
-                            return Promise.all([dataFactory(identifier, 'dmi'),
-                                dataFactory(identifier, 'smart')])
-                                .spread(function (dmi, smart) {
-                                    if (dmi === undefined && smart === undefined) {
-                                        return;
-                                    }
-                                    options.dmi = dmi;
+                return redfish.render('redfish.1.0.0.storagecollection.json',
+                    'SimpleStorageCollection.json#/definitions/SimpleStorageCollection',
+                    options);
+            });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
+            return Promise.all([dataFactory(identifier, 'dmi'),
+                                (identifier, 'smart')])
+            .spread(function (dmi, smart) {
+                // TODO: should this be an 'or'
+                if (dmi === undefined && smart === undefined){
+                    return;
+                }
+                options.dmi = dmi;
 
-                                    var controllers = {};
-                                    _.forEach(smart.data, function (ele) {
-                                        if (typeof ele.Controller.controller_PCI_BDF !== 'undefined') {
-                                            var id = ele.Controller.controller_PCI_BDF.replace(/[:.]/g, '_');
-                                            if (!(id in controllers)) {
-                                                controllers[id] = [];
-                                            }
-                                            controllers[id].push(ele);
-                                        }
-                                    });
-
-                                    var ids = [];
-                                    _.forOwn(controllers, function (val, key) {
-                                        ids.push(key);
-                                    });
-                                    options.controllers = ids;
-
-                                    return redfish.render('redfish.1.0.0.storagecollection.json',
-                                        'SimpleStorageCollection.json#/definitions/SimpleStorageCollection',
-                                        options);
-                                }).catch(function (error) {
-                                    return redfish.handleError(error, res);
-                                });
+                var controllers = {};
+                _.forEach(smart.data, function (ele) {
+                    if (typeof ele.Controller.controller_PCI_BDF !== 'undefined') {
+                        var id = ele.Controller.controller_PCI_BDF.replace(/[:.]/g, '_');
+                        if (!(id in controllers)) {
+                            controllers[id] = [];
                         }
+                        controllers[id].push(ele);
+                    }
+                });
 
-                        var controllers = [];
-                        _.forEach(redfishCatalog, function (ele) {
-                            if (ele.data.Description === "Simple Storage Controller") {
-                                controllers.push(ele.data.Id);
-                            }
+                var ids = [];
+                _.forOwn(controllers, function (val, key) {
+                    ids.push(key);
+                });
+                options.controllers = ids;
 
-                        });
-                        options.controllers = controllers;
-                        return redfish.render('redfish.1.0.0.storagecollection.json',
-                            'StorageCollection.json#/definitions/StorageCollection',
-                            options);
-                    }).catch(function (error) {
-                        return redfish.handleError(error, res);
-                    });
+                return redfish.render('redfish.1.0.0.storagecollection.json',
+                    'SimpleStorageCollection.json#/definitions/SimpleStorageCollection',
+                    options);
+            });
+        }
+    })
+    .catch(function (error) {
+        return redfish.handleError(error, res);
+    });
 
-            }
-        });
 });
 
 /**
@@ -965,109 +1054,90 @@ var listStorage = controller(function (req, res) {
 var getStorage = controller(function (req, res) {
     var identifier = req.swagger.params.identifier.value;
     var index = req.swagger.params.index.value;
-    var options = redfish.makeOptions(req, res, identifier);
-    options.system = identifier;
 
-    options.index = index;
-
-    return wsman.isDellSystem(identifier)
-        .then(function (result) {
-            if (result.isDell) {
-                return Promise.resolve(dataFactory(identifier, 'hardware'))
-                    .then(function (hardware) {
-                        options.hardware = hardware;
-                        var controllers = {};
-                        _.forEach(hardware.data.storage.controllers, function (ele) {
-                            var id = ele.fQDD.replace(/[:.]/g, '_'); // jshint ignore: line
-                            if (!(id in controllers)) {
-                                controllers[id] = [];
-                            }
-                            controllers[id].push(ele);
-                        });
-                        options.controllers = [];
-                        _.forEach(hardware.data.storage.controllers, function (ele) {
-                            var speed = ele.possibleSpeed; //possibleSpeed format is X_X_GBS or X_GBS, convert to decimal
-                            var speedInDecimal;
-                            if (speed) {
-                                speed = speed.split('_');
-                                speed.splice(speed.length - 1, 1);
-                                speedInDecimal = speed[0];
-                                if (speed.length > 1) {
-                                    speedInDecimal += "." + speed[1];
-                                }
-                            }
-                            else {
-                                speedInDecimal = 0;
-                            }
-                            ele.possibleSpeed = speedInDecimal;
-                            options.controllers.push(ele);
-                        });
-
-                        options.drives = [];
-                        _.forEach(hardware.data.storage.physicalDisks, function (ele) {
-                            options.drives.push(ele);
-                        });
-
-                        return redfish.render('redfish.2016.3.storage.1.1.1.json',
-                            'Storage.v1_1_1.json#/definitions/Storage',
-                            options);
-                    }).catch(function (error) {
-                        return redfish.handleError(error, res);
-                    });
-            } else {
-                return Promise.resolve(dataFactory(identifier, 'Redfish'))
-                    .then(function (redfishCatalog) {
-                        if (redfishCatalog === undefined || redfishCatalog.length === 0) {
-                            return Promise.all([dataFactory(identifier, 'dmi'),
-                                dataFactory(identifier, 'smart')])
-                                .spread(function (dmi, smart) {
-                                    options.dmi = dmi;
-                                    var controllers = {};
-                                    _.forEach(smart.data, function (ele) {
-                                        if (typeof ele.Controller.controller_PCI_BDF !== 'undefined') {
-                                            var id = ele.Controller.controller_PCI_BDF.replace(/[:.]/g, '_');
-                                            if (!(id in controllers)) {
-                                                controllers[id] = [];
-                                            }
-                                            controllers[id].push(ele);
-                                        }
-                                    });
-
-                                    //It is assumed to have one controller per storage subsystem
-                                    options.controllerArr = [controllers[index][0].Controller];
-
-                                    options.devices = [];
-                                    _.forEach(controllers[index], function (ele) {
-                                        if (ele.SMART.Identity) {
-                                            options.devices.push(ele.SMART);
-                                        }
-                                    });
-                                    return redfish.render('redfish.1.0.0.storage.1.0.0.json',
-                                        'Storage.v1_1_1.json#/definitions/Storage',
-                                        options);
-                                }).catch(function (error) {
-                                    return redfish.handleError(error, res);
-                                });
-
+    return redfish.getVendorNameById(identifier)
+    .then(function (result) {
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.system = identifier;
+        options.index = index;
+        if(result.vendor === 'Dell'){
+            return Promise.resolve(dataFactory(identifier, 'hardware'))
+            .then(function (hardware) {
+                options.hardware = hardware;
+                var controllers = {};
+                _.forEach(hardware.data.storage.controllers, function (ele) {
+                    var id = ele.fQDD.replace(/[:.]/g, '_'); // jshint ignore: line
+                    if (!(id in controllers)) {
+                        controllers[id] = [];
+                    }
+                    controllers[id].push(ele);
+                });
+                options.controllers = [];
+                _.forEach(hardware.data.storage.controllers, function (ele) {
+                    var speed = ele.possibleSpeed; //possibleSpeed format is X_X_GBS or X_GBS, convert to decimal
+                    var speedInDecimal;
+                    if (speed) {
+                        speed = speed.split('_');
+                        speed.splice(speed.length - 1, 1);
+                        speedInDecimal = speed[0];
+                        if (speed.length > 1) {
+                            speedInDecimal += "." + speed[1];
                         }
-                        var controllers = [];
-                        _.forEach(redfishCatalog, function (ele) {
-                            if (ele.data.Id === options.index) {
-                                controllers.push(ele.data);
-                                options.devices = ele.data.Devices.slice(0);
-                            }
+                    }
+                    else {
+                        speedInDecimal = 0;
+                    }
+                    ele.possibleSpeed = speedInDecimal;
+                    options.controllers.push(ele);
+                });
 
-                        });
-                        options.controllers = controllers;
-                        return redfish.render('redfish.1.0.0.redfishstorage.1.0.0.json',
-                            'Storage.v1_1_1.json#/definitions/Storage',
-                            options);
-                    }).catch(function (error) {
-                        return redfish.handleError(error, res);
-                    });
-            }
+                options.drives = [];
+                _.forEach(hardware.data.storage.physicalDisks, function (ele) {
+                    options.drives.push(ele);
+                });
 
-        });
+                return redfish.render('redfish.2016.3.storage.1.1.1.json',
+                    'Storage.v1_1_1.json#/definitions/Storage',
+                    options);
+            });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        } else {
+            return Promise.all([dataFactory(identifier, 'dmi'),
+                                dataFactory(identifier, 'smart')])
+            .spread(function (dmi, smart) {
+                options.dmi = dmi;
+                var controllers = {};
+                _.forEach(smart.data, function (ele) {
+                    if (typeof ele.Controller.controller_PCI_BDF !== 'undefined') {
+                        var id = ele.Controller.controller_PCI_BDF.replace(/[:.]/g, '_');
+                        if (!(id in controllers)) {
+                            controllers[id] = [];
+                        }
+                        controllers[id].push(ele);
+                    }
+                });
+                options.dmi = dmi;
+                //It is assumed to have one controller per storage subsystem
+                options.controllerArr = [controllers[index][0].Controller];
+
+                options.devices = [];
+                _.forEach(controllers[index], function (ele) {
+                    if (ele.SMART.Identity) {
+                        options.devices.push(ele.SMART);
+                    }
+                });
+
+                return redfish.render('redfish.1.0.0.storage.1.0.0.json',
+                    'Storage.v1_1_1.json#/definitions/Storage',
+                    options);
+            });
+        }
+    })
+    .catch(function (error) {
+        return redfish.handleError(error, res);
+    });
 });
 
 /**
@@ -1079,15 +1149,15 @@ var getDrive = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var index = req.swagger.params.index.value;
     var driveIndex = req.swagger.params.driveIndex.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    options.driveIndex = driveIndex;
-    options.identifier = identifier;
-    options.index = index;
-
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.driveIndex = driveIndex;
+        options.identifier = identifier;
+        options.index = index;
+        if(result.vendor === 'Dell'){
             return Promise.resolve(dataFactory(identifier, 'hardware'))
             .then(function(hardware) {
                 options.hardware = hardware;
@@ -1103,9 +1173,9 @@ var getDrive = controller(function(req, res)  {
                 return redfish.render('redfish.2016.3.drive.1.1.1.json',
                                 'Drive.v1_1_1.json#/definitions/Drive',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return Promise.resolve(dataFactory(identifier, 'smart'))
             .then(function(smart) {
@@ -1136,23 +1206,25 @@ var getDrive = controller(function(req, res)  {
                                       'Drive.v1_1_1.json#/definitions/Drive',
                                       options);
 
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
 var listVolume = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var index = req.swagger.params.index.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    options.identifier = identifier;
-    options.index = index;
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.identifier = identifier;
+        options.index = index;
+        if(result.vendor === 'Dell'){
             return Promise.resolve(dataFactory(identifier, 'hardware'))
             .then(function(hardware) {
                 options.hardware = hardware;
@@ -1163,12 +1235,15 @@ var listVolume = controller(function(req, res)  {
                 return redfish.render('redfish.2016.3.volumecollection.json',
                                 'VolumeCollection.json#/definitions/VolumeCollection',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return redfish.handleError("Not supported for non-Dell hardware.", res, null, 404);
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1181,15 +1256,15 @@ var getVolume = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var index = req.swagger.params.index.value;
     var volumeIndex = req.swagger.params.volumeIndex.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    options.volumeIndex = volumeIndex;
-    options.identifier = identifier;
-    options.index = index;
-
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.volumeIndex = volumeIndex;
+        options.identifier = identifier;
+        options.index = index;
+        if(result.vendor === 'Dell'){
             return Promise.resolve(dataFactory(identifier, 'hardware'))
             .then(function(hardware) {
                 options.hardware = hardware;
@@ -1207,12 +1282,15 @@ var getVolume = controller(function(req, res)  {
                 return redfish.render('redfish.2016.3.volume.1.0.2.json',
                                 'Volume.v1_0_2.json#/definitions/Volume',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return redfish.handleError("Not supported for non-Dell hardware.", res, null, 404);
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1223,21 +1301,26 @@ var getVolume = controller(function(req, res)  {
  */
 var listLogService = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
-            options.logSource = ['SEL', 'lc'];
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
-            options.logSource = ['SEL'];
+            if(result.vendor === 'Dell'){
+                options.logSource = ['SEL', 'lc'];
+            } else {
+                options.logSource = ['SEL'];
+            }
+            return redfish.render('redfish.1.0.0.logservicecollection.json',
+                        'LogServiceCollection.json#/definitions/LogServiceCollection',
+                        options);
         }
-        return redfish.render('redfish.1.0.0.logservicecollection.json',
-                    'LogServiceCollection.json#/definitions/LogServiceCollection',
-                    options)
-        .catch(function(error) {
-            return redfish.handleError(error, res);
-        });
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1248,12 +1331,13 @@ var listLogService = controller(function(req, res)  {
  */
 var getSelLogService = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
         var node = result.node;
-        if(result.isDell){
+        if(result.vendor === 'Dell'){
             options.type = 'SEL';
             options.description = 'iDRAC System Event Log';
             options.name = 'idrac-sel-information';
@@ -1266,9 +1350,9 @@ var getSelLogService = controller(function(req, res)  {
                 return redfish.render('redfish.1.0.0.logservice.1.0.0.json',
                                 'LogService.v1_0_3.json#/definitions/LogService',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             options.type = 'SEL';
             options.description = 'IPMI System Event Log';
@@ -1285,10 +1369,11 @@ var getSelLogService = controller(function(req, res)  {
                     return redfish.render('redfish.1.0.0.logservice.1.0.0.json',
                                     'LogService.v1_0_3.json#/definitions/LogService',
                                     options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1299,23 +1384,23 @@ var getSelLogService = controller(function(req, res)  {
  */
 var listSelLogServiceEntries = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    options.type = 'SEL';
-
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
         var node = result.node;
-        if(result.isDell){
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.type = 'SEL';
+        if(result.vendor === 'Dell'){
             return wsman.getLog(node, options.type)
             .then(function(selData) {
                 options.logEntries = selData;
                 return redfish.render('wsman.1.0.0.logentrycollection.json',
                                 'LogEntryCollection.json#/definitions/LogEntryCollection',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return dataFactory(identifier, 'selData')
             .then(function(selData) {
@@ -1329,10 +1414,11 @@ var listSelLogServiceEntries = controller(function(req, res) {
                 return redfish.render('redfish.1.0.0.logentrycollection.json',
                                 'LogEntryCollection.json#/definitions/LogEntryCollection',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1344,17 +1430,18 @@ var listSelLogServiceEntries = controller(function(req, res) {
 var getSelLogServiceEntry = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var entryId = req.swagger.params.entryId.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    options.type = 'SEL';
-    options.description = 'IPMI System Event Log';
-    options.name = 'ipmi-sel-information';
-    options.log = {};
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
         var node = result.node;
-        if(result.isDell){
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.type = 'SEL';
+        options.description = 'IPMI System Event Log';
+        options.name = 'ipmi-sel-information';
+        options.log = {};
+        if(result.vendor === 'Dell'){
             return wsman.getLog(node, options.type)
             .then(function(selData) {
                 options.entries = _.filter(selData, function(entry) {
@@ -1367,9 +1454,9 @@ var getSelLogServiceEntry = controller(function(req, res)  {
                 return redfish.render('wsman.1.0.0.logentry.1.0.0.json',
                             'LogEntry.v1_1_1.json#/definitions/LogEntry',
                             options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return dataFactory(identifier, 'selData')
             .then(function(selData) {
@@ -1387,10 +1474,11 @@ var getSelLogServiceEntry = controller(function(req, res)  {
                 return redfish.render('redfish.1.0.0.logentry.1.0.0.json',
                                 'LogEntry.v1_1_1.json#/definitions/LogEntry',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1401,12 +1489,13 @@ var getSelLogServiceEntry = controller(function(req, res)  {
  */
 var getLcLogService = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
         var node = result.node;
-        if(result.isDell){
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Dell'){
             options.type = 'LC';
             options.description = 'iDRAC Lifecycle Controller Log';
             options.name = 'idrac-lc-information';
@@ -1419,12 +1508,15 @@ var getLcLogService = controller(function(req, res)  {
                 return redfish.render('redfish.1.0.0.logservice.1.0.0.json',
                                 'LogService.v1_0_3.json#/definitions/LogService',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1435,26 +1527,29 @@ var getLcLogService = controller(function(req, res)  {
  */
 var listLcLogServiceEntries = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    options.type = 'LC';
-
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
         var node = result.node;
-        if(result.isDell){
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.type = 'LC';
+        if(result.vendor === 'Dell'){
             return wsman.getLog(node, options.type)
             .then(function(lcData) {
                 options.logEntries = lcData;
                 return redfish.render('wsman.1.0.0.lclogentrycollection.json',
                                 'LogEntryCollection.json#/definitions/LogEntryCollection',
                                 options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1466,17 +1561,17 @@ var listLcLogServiceEntries = controller(function(req, res)  {
 var getLcLogServiceEntry = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
     var entryId = req.swagger.params.entryId.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    options.type = 'LC';
-    options.description = 'Lifecycle Controller Log';
-    options.name = 'wsman-lc-information';
-    options.log = {};
-
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
         var node = result.node;
-        if(result.isDell){
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        options.type = 'LC';
+        options.description = 'Lifecycle Controller Log';
+        options.name = 'wsman-lc-information';
+        options.log = {};
+        if(result.vendor === 'Dell'){
             return wsman.getLog(node, options.type)
             .then(function(lcData) {
                 var id = parseInt(entryId);
@@ -1490,12 +1585,15 @@ var getLcLogServiceEntry = controller(function(req, res)  {
                 return redfish.render('wsman.1.0.0.lclogentry.1.0.0.json',
                             'LogEntry.v1_1_1.json#/definitions/LogEntry',
                             options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
+    })
+    .catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
@@ -1506,14 +1604,17 @@ var getLcLogServiceEntry = controller(function(req, res)  {
  */
 var listResetTypes = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
-
-    return nodeApi.getNodeById(identifier)
-    .then(function(node) {
+    return redfish.getVendorNameById(identifier)
+    .then(function(result) {
+        var node = result.node;
         if(!node) {
             throw new Errors.NotFoundError('identifier not found');
         }
-
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
+        }
         return redfish.get('redfish.1.0.0.rackhd.reset.actions.json', options);
     })
     .catch(function(error) {
@@ -1527,19 +1628,48 @@ var listResetTypes = controller(function(req, res) {
  * @param  {Object}     res
  */
 var doReset = controller(function(req,res) {
+    //TODO Fix for node types
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
-
-    return nodeApi.getNodeById(identifier)
-    .then(function(node) {
+    var options;
+    return redfish.getVendorNameById(identifier)
+    .then(function(result) {
+        var node = result.node;
         if(!node) {
             throw new Errors.NotFoundError('identifier not found');
         }
-
+        identifier = node.id;
+        options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Redfish') {
+            return result;
+        }
         return redfish.validateSchema(payload, 'RackHD.ResetAction.json#/definitions/ResetAction');
     })
     .then(function(result) {
+        if (result.vendor === 'Redfish') {
+            return getObmSettings(identifier)
+            .then(function(obm) {
+
+                var results = { name: "Graph.Run.Rest.Command", options: {} };
+                results.options = {
+                    defaults: {
+                        url: {
+                            protocol: obm.config.protocol,
+                            host: obm.config.host,
+                            port: obm.config.port,
+                            path: req.url.replace(req.swagger.params.identifier.value, result.node.identifiers[0])
+                        },
+                        credential: {username: obm.config.username, password: encryption.decrypt(obm.config.password)},
+                        method: 'PATCH',
+                        headers: {},
+                        data: payload,
+                        verifySSL: obm.config.verifySSL,
+                        recvTimeoutMs: 360000
+                    }
+                };
+                return  nodeApi.setNodeWorkflowById(results, identifier);
+            });
+        }
         var map = {
             On: 'Graph.PowerOn.Node',
             ForceOff: 'Graph.PowerOff.Node',
@@ -1582,36 +1712,43 @@ var doReset = controller(function(req,res) {
  */
 var listSystemEthernetInterfaces = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
         options.name = "Systems Ethernet Interface Collection";
-        if(result.isDell){
-            return dataFactory(identifier, 'nics').then(function(nics) {
-                options.baseprofile = 'Systems';
-                options.net = [];
-
-                _.forEach(nics.data, (function(data) {
-                    options.net.push(data.fqdd);
-                }));
-                return options;
-            });
+        if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
-            return dataFactory(identifier, 'ohai').then(function(ohai) {
-                options.baseprofile = 'Systems';
-                options.net = [];
+            if(result.vendor === 'Dell'){
+                return dataFactory(identifier, 'nics')
+                .then(function(nics) {
+                    options.baseprofile = 'Systems';
+                    options.net = [];
 
-                _.forEach(Object.keys(ohai.data.network.interfaces), (function(key) {
-                    options.net.push(key);
-                }));
-                return options;
-            });
+                    _.forEach(nics.data, (function(data) {
+                        options.net.push(data.fqdd);
+                    }));
+                    return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
+                    'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
+                        options);
+                });
+            } else {
+                return dataFactory(identifier, 'ohai')
+                .then(function(ohai) {
+                    options.baseprofile = 'Systems';
+                    options.net = [];
+
+                    _.forEach(Object.keys(ohai.data.network.interfaces), (function(key) {
+                        options.net.push(key);
+                    }));
+                    return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
+                    'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
+                        options);
+                });
+            }
         }
-    }).then(function(options) {
-        return redfish.render('redfish.1.0.0.ethernetinterfacecollection.json',
-                              'EthernetInterfaceCollection.json#/definitions/EthernetInterfaceCollection',
-                              options);
     }).catch(function(error) {
         return redfish.handleError(error, res);
     });
@@ -1625,12 +1762,13 @@ var listSystemEthernetInterfaces = controller(function(req, res)  {
  */
 var listSystemEthernetInterfacesById = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
     var index = req.swagger.params.index.value;
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Dell'){
             return dataFactory(identifier, 'nics')
             .then(function(nics) {
                 options.baseprofile = 'Systems';
@@ -1672,6 +1810,8 @@ var listSystemEthernetInterfacesById = controller(function(req, res)  {
                     'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
                     options);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return dataFactory(identifier, 'ohai')
             .then(function(ohai) {
@@ -1756,8 +1896,6 @@ var listSystemEthernetInterfacesById = controller(function(req, res)  {
                 return redfish.render('redfish.1.0.0.ethernetinterface.1.0.0.json',
                     'EthernetInterface.v1_2_0.json#/definitions/EthernetInterface',
                      options);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
             });
         }
     }).catch(function(error) {
@@ -1773,9 +1911,13 @@ var listSystemEthernetInterfacesById = controller(function(req, res)  {
  */
 var listBootImage = controller(function(req, res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
+    return nodeApi.getNodeByIdentifier(identifier)
+    .then(function(node) {
+        identifier = node.id;
+    	var options = redfish.makeOptions(req, res, identifier);
 
-    return redfish.get('redfish.1.0.0.rackhd.bootimage.json', options)
+    	return redfish.get('redfish.1.0.0.rackhd.bootimage.json', options);
+    })
     .catch(function(error) {
         return redfish.handleError(error, res);
     });
@@ -1788,41 +1930,106 @@ var listBootImage = controller(function(req, res) {
  */
 var doBootImage = controller(function(req,res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
 
-    return redfish.validateSchema(payload, 'RackHD.BootImage.json#/definitions/BootImage')
-    .then(function validatePayload(result) {
-        if(result.error) {
-            throw new Error(result.error);
-        }
+    return nodeApi.getNodeByIdentifier(identifier)
+    .then(function(node) {
+        identifier = node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        return redfish.validateSchema(payload, 'RackHD.BootImage.json#/definitions/BootImage')
+        .then(function validatePayload(result) {
+            if(result.error) {
+                throw new Error(result.error);
+            }
 
-        var graphOptions = {
-            defaults: payload
-        };
+            var graphOptions = {
+                defaults: payload
+            };
 
-        if( payload.osName.indexOf('+KVM') !== -1)  {
-            graphOptions.defaults.kvm = true;
-        }
+            if( payload.osName.indexOf('+KVM') !== -1)  {
+                graphOptions.defaults.kvm = true;
+            }
 
-        var graphName = '';
-        if( payload.osName.indexOf('CentOS') !== -1)  {
-            graphName = 'Graph.InstallCentOS';
-            graphOptions.defaults.osName = 'CentOS';
-        } else if(payload.osName.indexOf('ESXi') !== -1) {
-            graphName = 'Graph.InstallESXi';
-            graphOptions.defaults.osName = 'ESXi';
-        } else if(payload.osName.indexOf('RHEL') !== -1) {
-            graphName = 'Graph.InstallRHEL';
-            graphOptions.defaults.osName = 'RHEL';
+            var graphName = '';
+            if( payload.osName.indexOf('CentOS') !== -1)  {
+                graphName = 'Graph.InstallCentOS';
+                graphOptions.defaults.osName = 'CentOS';
+            } else if(payload.osName.indexOf('ESXi') !== -1) {
+                graphName = 'Graph.InstallESXi';
+                graphOptions.defaults.osName = 'ESXi';
+            } else if(payload.osName.indexOf('RHEL') !== -1) {
+                graphName = 'Graph.InstallRHEL';
+                graphOptions.defaults.osName = 'RHEL';
+            } else {
+                throw new Error('invalid osName');
+            }
+
+            return [ graphName, graphOptions ];
+        }).spread(function launchTask(name, graphOptions) {
+            return nodeApi.setNodeWorkflowById({ name: name, options: graphOptions }, node.id);
+
+        }).then(function reportTask(data) {
+            return {
+                '@odata.id': options.basepath + '/TaskService/Tasks/' + data.instanceId
+            };
+        }).then(function(output) {
+            res.setHeader('Location', output['@odata.id']);
+            res.status(202).json(output);
+        }).catch(function(error) {
+            return redfish.handleError(error, res);
+        });
+    });
+});
+
+var deleteVolume = controller(function(req,res) {
+    var identifier = req.swagger.params.identifier.value;
+    var volumeIndex = req.swagger.params.volumeIndex.value;
+    var payload = req.swagger.params.payload.value;
+    var graphName = 'Graph.Dell.Wsman.Delete.Volume';
+    var graphOptions = {
+        defaults: payload
+    };
+    var options;
+    return redfish.getVendorNameById(identifier)
+    .then(function(result){
+        identifier = result.node.id;
+        options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Dell'){
+            return Promise.resolve(dataFactory(identifier, 'hardware'))
+            .then(function(hardware) {
+                graphOptions.defaults.volumeId = hardware.data.storage.virtualDisks[volumeIndex].fqdd;
+                graphOptions.defaults.ipAddress = hardware.data.id;
+                return { name: graphName, options: graphOptions };
+            });
+        } else if(result.vendor === 'Redfish'){
+            return getObmSettings(identifier)
+            .then(function(obm) {
+
+                var results = { name: "Graph.Run.Rest.Command", options: {} };
+                results.options = {
+                    defaults: {
+                        url: {
+                            protocol: obm.config.protocol,
+                            host: obm.config.host,
+                            port: obm.config.port,
+                            path: req.url.replace(req.swagger.params.identifier.value, result.node.identifiers[0])
+                        },
+                        credential: {username: obm.config.username, password: encryption.decrypt(obm.config.password)},
+                        method: 'POST',
+                        headers: {},
+                        data: payload,
+                        verifySSL: obm.config.verifySSL,
+                        recvTimeoutMs: 360000
+                    }
+               };
+               return results;
+           });
         } else {
-            throw new Error('invalid osName');
+            return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
-
-        return [ graphName, graphOptions ];
-    }).spread(function launchTask(name, graphOptions) {
-        return nodeApi.setNodeWorkflowById({ name: name, options: graphOptions }, identifier);
-    }).then(function reportTask(data) {
+     }).then(function(results){
+        return  nodeApi.setNodeWorkflowById(results, identifier);
+     }).then(function reportTask(data) {
         return {
             '@odata.id': options.basepath + '/TaskService/Tasks/' + data.instanceId
         };
@@ -1834,43 +2041,8 @@ var doBootImage = controller(function(req,res) {
     });
 });
 
-var deleteVolume = controller(function(req,res) {
-    var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
-    var volumeIndex = req.swagger.params.volumeIndex.value;
-    var payload = req.swagger.params.payload.value;
-    var graphName = 'Graph.Dell.Wsman.Delete.Volume';
-    var graphOptions = {
-        defaults: payload
-    };
-    return wsman.isDellSystem(identifier)
-    .then(function(result){
-        if(result.isDell){
-            return Promise.resolve(dataFactory(identifier, 'hardware'))
-            .then(function(hardware) {
-                graphOptions.defaults.volumeId = hardware.data.storage.virtualDisks[volumeIndex].fqdd;
-                graphOptions.defaults.ipAddress = hardware.data.id;
-            }).then(function(){
-                return nodeApi.setNodeWorkflowById({ name: graphName, options: graphOptions }, identifier);
-            }).then(function reportTask(data) {
-                return {
-                    '@odata.id': options.basepath + '/TaskService/Tasks/' + data.instanceId
-                };
-            }).then(function(output) {
-                res.setHeader('Location', output['@odata.id']);
-                res.status(202).json(output);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
-            });
-        } else {
-            return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
-        }
-    });
-});
-
 var addVolume = controller(function(req,res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
     var payload = req.swagger.params.payload.value;
     var graphName = 'Graph.Dell.Wsman.Add.Volume';
     var graphOptions = {
@@ -1879,10 +2051,13 @@ var addVolume = controller(function(req,res) {
             password: payload.password
         }
     };
+    var options;
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Dell'){
             return Promise.resolve(dataFactory(identifier, 'hardware'))
             .then(function(hardware) {
                 var driveIndices = [];
@@ -1933,27 +2108,48 @@ var addVolume = controller(function(req,res) {
                     default:
                         throw "Invalid Raid Level for creating volume";
                 }
-            }).then(function(){
-                return nodeApi.setNodeWorkflowById({ name: graphName, options: graphOptions }, identifier);
-            }).then(function reportTask(data) {
-                return {
-                    '@odata.id': options.basepath + '/TaskService/Tasks/' + data.instanceId
-                };
-            }).then(function(output) {
-                res.setHeader('Location', output['@odata.id']);
-                res.status(202).json(output);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
+                return { name: graphName, options: graphOptions };
+            });
+        } else if(result.vendor === 'Redfish'){
+            return getObmSettings(identifier)
+            .then(function(obm) {
+
+                var results = { name: "Graph.Run.Rest.Command", options: {} };
+                results.options = {
+                    defaults: {
+                        url: {
+                            protocol: obm.config.protocol,
+                            host: obm.config.host,
+                            port: obm.config.port,
+                            path: req.url.replace(req.swagger.params.identifier.value, result.node.identifiers[0])
+                        },
+                        credential: {username: obm.config.username, password: encryption.decrypt(obm.config.password)},
+                        method: 'POST',
+                        headers: {},
+                        data: payload,
+                        verifySSL: obm.config.verifySSL,
+                        recvTimeoutMs: 360000
+                    }
+               };
+               return results;
             });
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
+     }).then(function(results){
+        return  nodeApi.setNodeWorkflowById(results, identifier);
+     }).then(function reportTask(data) {
+        return {'@odata.id': options.basepath + '/TaskService/Tasks/' + data.instanceId};
+    }).then(function(output) {
+        res.setHeader('Location', output['@odata.id']);
+        res.status(202).json(output);
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
 var addHotspare = controller(function(req,res) {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
     var driveIndex = req.swagger.params.driveIndex.value;
     var payload = req.swagger.params.payload.value;
     /*
@@ -1969,9 +2165,12 @@ var addHotspare = controller(function(req,res) {
     var graphOptions = {
         defaults: payload
     };
-    return wsman.isDellSystem(identifier)
+    var options;
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Dell'){
             return Promise.resolve(dataFactory(identifier, 'hardware'))
             .then(function(hardware) {
                 graphOptions.defaults.driveId = hardware.data.storage.physicalDisks[driveIndex].fqdd;
@@ -1985,31 +2184,53 @@ var addHotspare = controller(function(req,res) {
                     }
                     graphOptions.defaults.volumeId = hardware.data.storage.virtualDisks[volumeIndex].fqdd;
                 }
-            }).then(function(){
-                return nodeApi.setNodeWorkflowById({ name: graphName, options: graphOptions }, identifier);
-            }).then(function reportTask(data) {
-                return {
-                    '@odata.id': options.basepath + '/TaskService/Tasks/' + data.instanceId
-                };
-            }).then(function(output) {
-                res.setHeader('Location', output['@odata.id']);
-                res.status(202).json(output);
-            }).catch(function(error) {
-                return redfish.handleError(error, res);
+                return { name: graphName, options: graphOptions };
             });
+        } else if(result.vendor === 'Redfish'){
+            return getObmSettings(identifier)
+            .then(function(obm) {
+
+                var results = { name: "Graph.Run.Rest.Command", options: {} };
+                results.options = {
+                    defaults: {
+                        url: {
+                            protocol: obm.config.protocol,
+                            host: obm.config.host,
+                            port: obm.config.port,
+                            path: req.url.replace(req.swagger.params.identifier.value, result.node.identifiers[0])
+                        },
+                        credential: {username: obm.config.username, password: encryption.decrypt(obm.config.password)},
+                        method: 'POST',
+                        headers: {},
+                        data: payload,
+                        verifySSL: obm.config.verifySSL,
+                        recvTimeoutMs: 360000
+                    }
+               };
+               return results;
+           });
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
+    }).then(function(results){
+        return  nodeApi.setNodeWorkflowById(results, identifier);
+    }).then(function reportTask(data) {
+        return {'@odata.id': options.basepath + '/TaskService/Tasks/' + data.instanceId};
+    }).then(function(output) {
+        res.setHeader('Location', output['@odata.id']);
+        res.status(202).json(output);
+    }).catch(function(error) {
+        return redfish.handleError(error, res);
     });
 });
 
 var getSecureBoot = controller(function(req, res)  {
     var identifier = req.swagger.params.identifier.value;
-    var options = redfish.makeOptions(req, res, identifier);
-
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        var options = redfish.makeOptions(req, res, identifier);
+        if(result.vendor === 'Dell'){
             return dataFactory(identifier, 'bios').then(function(bios) {
                 return _.get(_.find(bios.data.dcimBIOSEnumerationTypeList, function(attribute) {
                     return attribute.attributeName.value === 'SecureBoot';
@@ -2021,6 +2242,8 @@ var getSecureBoot = controller(function(req, res)  {
                     'SecureBoot.v1_0_1.json#/definitions/SecureBoot',
                     options);
             });
+        } else if (result.vendor === 'Redfish') {
+            return getRedfishDeviceResponse(identifier, req);
         } else {
             return redfish.handleError("Not implemented for non-Dell hardware.", res, null, 501);
         }
@@ -2035,6 +2258,7 @@ var getSecureBoot = controller(function(req, res)  {
  * @param  {Object}     res
  */
 var setSecureBoot = controller(function(req, res)  {
+    //TODO Write logic for non racadm
     var identifier = req.swagger.params.identifier.value;
     var options = redfish.makeOptions(req, res, identifier);
     var graphName = 'Graph.Dell.Wsman.ConfigureBios';
@@ -2049,9 +2273,10 @@ var setSecureBoot = controller(function(req, res)  {
     //3 - Graceful Reboot with forced shutdown
     var rebootJobType = 2;
 
-    return wsman.isDellSystem(identifier)
+    return redfish.getVendorNameById(identifier)
     .then(function(result){
-        if(result.isDell){
+        identifier = result.node.id;
+        if(result.vendor === 'Dell'){
             var graphOptions = {
                 defaults: {
                     "attributes": [{
@@ -2066,9 +2291,7 @@ var setSecureBoot = controller(function(req, res)  {
                 options: graphOptions
             }, identifier)
             .then(function(graph) {
-                var output = {
-                    '@odata.id': options.basepath + '/TaskService/Tasks/' + graph.instanceId
-                };
+                var output = {'@odata.id': options.basepath + '/TaskService/Tasks/' + graph.instanceId};
                 res.setHeader('Location', output['@odata.id']);
                 res.status(202).json(output);
             });
@@ -2078,6 +2301,24 @@ var setSecureBoot = controller(function(req, res)  {
     })
     .catch(function(error) {
         return redfish.handleError(error, res);
+//    return nodeApi.getNodeByIdentifier(identifier)
+//    .then(function(node) {
+//        identifier = node.id;
+//        return getObmSettings(identifier)
+//        .then(function(obmSettings) {
+//            return racadm.runCommand (
+//                obmSettings.host,
+//                obmSettings.user,
+//                obmSettings.password,
+//                'set bios.SysSecurity.SecureBoot ' + command
+//            );
+//        })
+//        .then(function() {
+//            res.status(202).json({"Message": "Successfully Completed Request"});
+//        })
+//        .catch(function(error) {
+//            return redfish.handleError(error, res);
+//        });
     });
 });
 

--- a/lib/services/redfish-api-service.js
+++ b/lib/services/redfish-api-service.js
@@ -224,7 +224,7 @@ function redfishApiServiceFactory(
     * @return {Object}: Object contains node vendor name and node info retrieved from database.
     */
     RedfishApiService.prototype.getVendorNameById = function(id) {
-        return waterline.nodes.getNodeById(id)
+        return nodeApi.getNodeByIdentifier(id)
         .then(function(node){
             if(!node){
                 throw new Errors.NotFoundError('invalid node id.');
@@ -237,7 +237,7 @@ function redfishApiServiceFactory(
     };
 
     function _getVendorNameByIdentifiers(_identifiers){
-        var vendor;
+        var vendor = "Other";
         var ucsDnFormat = /^(sys|org-root)(\/[\w-]+)+$/;
         var dellFormat = /^[0-9|A-Z]{7}$/;
         _.forEach(_identifiers, function(_identifier){

--- a/lib/services/wsman-service.js
+++ b/lib/services/wsman-service.js
@@ -12,7 +12,8 @@ di.annotate(wsmanServiceFactory,
         'Services.Encryption',
         'Services.Configuration',
         'JobUtils.WsmanTool',
-        'Errors'
+        'Errors',
+        'Http.Services.Api.Nodes'
     )
 );
 function wsmanServiceFactory(
@@ -20,7 +21,8 @@ function wsmanServiceFactory(
     encryption,
     configuration,
     WsmanTool,
-    errors
+    errors,
+    nodeApi
 ) {
 
     //var logger = Logger.initialize(wsmanServiceFactory);
@@ -76,7 +78,7 @@ function wsmanServiceFactory(
 
      WsmanService.prototype.isDellSystem = function(identifier) {
         var result = {node: undefined, isDell: false, isRedfishCapable: false};
-        return waterline.nodes.getNodeById(identifier)
+        return nodeApi.getNodeByIdentifier(identifier)
         .then(function(node){
             if(!node){
                 throw new errors.NotFoundError('invalid node id.');

--- a/spec/lib/api/redfish-1.0/managers-spec.js
+++ b/spec/lib/api/redfish-1.0/managers-spec.js
@@ -13,68 +13,7 @@ describe('Redfish Managers', function () {
     var fs;
     var Errors;
 
-    // Skip reading the entry from Mongo and return the entry directly
-    function redirectGet(entry) {
-        return fs.readFileAsync(__dirname + '/../../../../data/views/redfish-1.0/' + entry, 'utf-8')
-            .then(function(contents) {
-                return { contents: contents };
-            });
-    }
 
-    helper.httpServerBefore();
-
-    before(function () {
-        view = helper.injector.get('Views');
-        redfish = helper.injector.get('Http.Api.Services.Redfish');
-        validator = helper.injector.get('Http.Api.Services.Schema');
-        waterline = helper.injector.get('Services.Waterline');
-        Promise = helper.injector.get('Promise');
-        Errors = helper.injector.get('Errors');
-        var nodeFs = helper.injector.get('fs');
-        fs = Promise.promisifyAll(nodeFs);
-        tv4 = require('tv4');
-    });
-
-    beforeEach('set up mocks', function () {
-        this.sandbox.spy(tv4, "validate");
-        this.sandbox.stub(view, "get", redirectGet);
-        this.sandbox.spy(redfish, 'render');
-        this.sandbox.spy(validator, 'validate');
-        this.sandbox.stub(waterline.nodes);
-        this.sandbox.stub(waterline.catalogs);
-
-        waterline.nodes.needByIdentifier.withArgs('1234abcd1234abcd1234abcd')
-        .resolves(Promise.resolve({
-            id: '1234abcd1234abcd1234abcd',
-            name: '1234abcd1234abcd1234abcd'
-        }));
-
-        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd')
-        .resolves(Promise.resolve({
-            id: '1234abcd1234abcd1234abcd',
-            name: '1234abcd1234abcd1234abcd',
-            identifiers: ['1234']
-        }));
-
-        waterline.nodes.getNodeById.withArgs('DELLabcd1234abcd1234abcd')
-        .resolves(Promise.resolve({
-            id: 'DELLabcd1234abcd1234abcd',
-            name: 'DELLabcd1234abcd1234abcd',
-            identifiers: ['ABCDEFG']
-        }));
-
-        waterline.nodes.needByIdentifier.withArgs('DELLabcd1234abcd1234abcd')
-        .resolves(Promise.resolve({
-            id: 'DELLabcd1234abcd1234abcd',
-            name: 'DELLabcd1234abcd1234abcd'
-        }));
-
-        waterline.nodes.needByIdentifier.rejects(new Errors.NotFoundError('Not Found'));
-        waterline.nodes.getNodeById.resolves([]);
-        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
-    });
-
-    helper.httpServerAfter();
 
     var node = {
         id: '1234abcd1234abcd1234abcd',
@@ -122,6 +61,114 @@ describe('Redfish Managers', function () {
         ]
     };
 
+    var redfishManager = {
+        autoDiscover: false,
+        catalogs: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f89/catalogs",
+        ibms: [],
+        id: "5a09dadfcd6a2a01006f4f89",
+        identifiers: [
+            "iDRAC.Embedded.1",
+            "http://172.23.0.1:8000/redfish/v1/Managers/iDRAC.Embedded.1"
+        ],
+        name: "Manager",
+        obms: [
+            {
+                ref: "/api/2.0/obms/5a09dadfcd6a2a01006f4f8a",
+                service: "redfish-obm-service"
+            }
+        ],
+        pollers: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f89/pollers",
+        relations: [
+            {
+                info: null,
+                relationType: "manages",
+                targets: [
+                    "5a09dadfcd6a2a01006f4f87"
+                ]
+            }
+        ],
+        tags: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f89/tags",
+        type: "redfishManager",
+        workflows: "/api/2.0/nodes/5a09dadfcd6a2a01006f4f89/workflows"
+    };
+
+    // Skip reading the entry from Mongo and return the entry directly
+    function redirectGet(entry) {
+        return fs.readFileAsync(__dirname + '/../../../../data/views/redfish-1.0/' + entry, 'utf-8')
+            .then(function(contents) {
+                return { contents: contents };
+            });
+    }
+
+    helper.httpServerBefore();
+
+    before(function () {
+        view = helper.injector.get('Views');
+        redfish = helper.injector.get('Http.Api.Services.Redfish');
+        validator = helper.injector.get('Http.Api.Services.Schema');
+        waterline = helper.injector.get('Services.Waterline');
+        Promise = helper.injector.get('Promise');
+        Errors = helper.injector.get('Errors');
+        var nodeFs = helper.injector.get('fs');
+        fs = Promise.promisifyAll(nodeFs);
+        tv4 = require('tv4');
+    });
+
+    beforeEach('set up mocks', function () {
+        this.sandbox.spy(tv4, "validate");
+        this.sandbox.stub(view, "get", redirectGet);
+        this.sandbox.spy(redfish, 'render');
+        //this.sandbox.stub(redfish, 'getVendorNameById');
+        this.sandbox.spy(validator, 'validate');
+        this.sandbox.stub(waterline.nodes);
+        this.sandbox.stub(waterline.catalogs);
+
+        waterline.nodes.needByIdentifier.withArgs(node.id)
+        .resolves(Promise.resolve(node));
+        waterline.nodes.findByIdentifier.withArgs(node.id)
+        .resolves(Promise.resolve(node));
+
+        waterline.nodes.getNodeById.withArgs(node.id)
+        .resolves(Promise.resolve(node));
+
+        waterline.nodes.getNodeById.withArgs(dellNode.id)
+        .resolves(Promise.resolve(dellNode));
+
+        waterline.nodes.needByIdentifier.withArgs(dellNode.id)
+        .resolves(Promise.resolve(dellNode));
+        waterline.nodes.findByIdentifier.withArgs(dellNode.id)
+        .resolves(Promise.resolve(dellNode));
+
+        waterline.nodes.needByIdentifier.withArgs(redfishManager.id)
+        .resolves(Promise.resolve(redfishManager));
+        waterline.nodes.findByIdentifier.withArgs(redfishManager.id)
+        .resolves(Promise.resolve(redfishManager));
+
+        waterline.nodes.getNodeById.withArgs(redfishManager.id)
+        .resolves(Promise.resolve(redfishManager));
+
+        waterline.nodes.needByIdentifier.withArgs('invalid')
+        .resolves(Promise.resolve(undefined));
+        waterline.nodes.findByIdentifier.withArgs('invalid')
+        .resolves(Promise.resolve(undefined));
+
+        waterline.nodes.getNodeById.withArgs('invalid')
+        .resolves(Promise.resolve(undefined));
+
+        waterline.nodes.needByIdentifier.withArgs('RackHD')
+        .resolves(Promise.resolve(undefined));
+        waterline.nodes.findByIdentifier.withArgs('RackHD')
+        .resolves(Promise.resolve(undefined));
+
+        waterline.nodes.getNodeById.withArgs('RackHD')
+        .resolves(Promise.resolve(undefined));
+
+        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
+    });
+
+    helper.httpServerAfter();
+
+
 
     var catalogData = {
         'IP Address Source' : 'DHCP Address',
@@ -164,7 +211,7 @@ describe('Redfish Managers', function () {
 
 
     it('should return a valid manager root', function () {
-        waterline.nodes.find.resolves([node]);
+        waterline.nodes.find.resolves([node,redfishManager]);
         return helper.request().get('/redfish/v1/Managers')
             .expect('Content-Type', /^application\/json/)
             .expect(200)
@@ -177,8 +224,6 @@ describe('Redfish Managers', function () {
 
     it('should return a valid manager', function() {
         waterline.nodes.find.resolves([node]);
-        waterline.nodes.needByIdentifier.withArgs('1234abcd1234abcd1234abcd').resolves(node);
-        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(node);
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: '1234abcd1234abcd1234abcd',
             source: 'dummysource',
@@ -194,19 +239,41 @@ describe('Redfish Managers', function () {
                 expect(redfish.render.called).to.be.true;
             });
     });
-    
+
+    it('should return a valid manager for redfish catalog', function() {
+        waterline.nodes.find.resolves([redfishManager]);
+        waterline.catalogs.findLatestCatalogOfSource.resolves({
+            node: redfishManager.id,
+            source: 'dummysource',
+            data: {}
+        });
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id )
+            .expect(200)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return 501 for redfish manager with no catalog', function () {
+        waterline.nodes.find.resolves([redfishManager]);
+        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id)
+            .expect(501)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+
     it('should return a valid idrac manager', function() {
-        waterline.nodes.needByIdentifier.withArgs('DELLabcd1234abcd1234abcd').resolves(dellNode);
-        waterline.nodes.getNodeById.withArgs('DELLabcd1234abcd1234abcd').resolves(dellNode);
         waterline.nodes.find.resolves([dellNode]);
+
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: 'DELLabcd1234abcd1234abcd',
             source: 'dummysource',
             data: catalogData
         }));
         return helper.request().get('/redfish/v1/Managers/' + dellNode.id)
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
@@ -215,30 +282,48 @@ describe('Redfish Managers', function () {
     });
 
     it('should return a valid network protocol for idrac manager', function() {
-        waterline.nodes.needByIdentifier.withArgs('DELLabcd1234abcd1234abcd').resolves(dellNode);
-        waterline.nodes.getNodeById.withArgs('DELLabcd1234abcd1234abcd').resolves(dellNode);
-        waterline.nodes.find.resolves([dellNode]);
 
         return helper.request().get('/redfish/v1/Managers/' + dellNode.id + '/NetworkProtocol')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
                 expect(redfish.render.called).to.be.true;
             });
     });
+    it('should return a valid manager network protocol for redfish catalog', function() {
+
+        waterline.catalogs.findLatestCatalogOfSource.resolves({
+            node: redfishManager.id,
+            source: 'dummysource',
+            data: {}
+        });
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id + '/NetworkProtocol')
+            .expect(200)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return 501 for redfish manager network protocol with no catalog', function () {
+
+        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id+ '/NetworkProtocol')
+            .expect(501)
+            .expect('Content-Type', /^application\/json/);
+    });
 
 
     it('should 404 an invalid manager', function() {
         return helper.request().get('/redfish/v1/Managers/invalid')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404);
+            .expect(404)
+            .expect('Content-Type', /^application\/json/);
+
     });
 
     it('should return a valid manager ethernet interface collection', function() {
-        waterline.nodes.needByIdentifier.withArgs('1234abcd1234abcd1234abcd').resolves(node);
-        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(node);
+
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: '1234abcd1234abcd1234abcd',
             source: 'dummysource',
@@ -246,22 +331,20 @@ describe('Redfish Managers', function () {
         }));
 
         return helper.request().get('/redfish/v1/Managers/' + node.id + '/EthernetInterfaces')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
                 expect(redfish.render.called).to.be.true;
             });
     });
-    
+
     it('should return a valid manager network protocol', function() {
-        waterline.nodes.needByIdentifier.withArgs('1234abcd1234abcd1234abcd').resolves(node);
-        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(node);
 
         return helper.request().get('/redfish/v1/Managers/' + node.id + '/NetworkProtocol')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
@@ -270,14 +353,14 @@ describe('Redfish Managers', function () {
     });
 
     it('should 404 an invalid manager ethernet interface collection', function() {
-        return helper.request().get('/redfish/v1/Managers/invalid.0/EthernetInterfaces')
+
+        return helper.request().get('/redfish/v1/Managers/invalid/EthernetInterfaces')
+            .expect(404)
             .expect('Content-Type', /^application\/json/)
-            .expect(404);
     });
 
     it('should return a valid manager ethernet interface', function() {
-        waterline.nodes.needByIdentifier.withArgs('1234abcd1234abcd1234abcd').resolves(node);
-        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(node);
+
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: '1234abcd1234abcd1234abcd',
             source: 'dummysource',
@@ -285,26 +368,72 @@ describe('Redfish Managers', function () {
         }));
 
         return helper.request().get('/redfish/v1/Managers/' + node.id + '/EthernetInterfaces/0')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
                 expect(redfish.render.called).to.be.true;
             });
     });
-    
+
     it('should 404 an invalid manager ethernet interface', function() {
-        return helper.request().get('/redfish/v1/Managers/invalid.0/EthernetInterfaces/0')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404);
+
+        return helper.request().get('/redfish/v1/Managers/invalid/EthernetInterfaces/0')
+            .expect(404)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return a valid manager ethernet interface collection for redfish catalog', function() {
+
+        waterline.catalogs.findLatestCatalogOfSource.resolves({
+            node: redfishManager.id,
+            source: 'dummysource',
+            data: {}
+        });
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id + '/EthernetInterfaces')
+            .expect(200)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return 501 for redfish manager ethernet interface collection with no catalog', function () {
+
+        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id+ '/EthernetInterfaces')
+            .expect(501)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return a valid manager ethernet interface for redfish catalog', function() {
+
+        waterline.catalogs.findLatestCatalogOfSource.resolves({
+            node: redfishManager.id,
+            source: 'dummysource',
+            data: {}
+        });
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id + '/EthernetInterfaces/0')
+            .expect(200)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return 501 for redfish manager ethernet interface with no catalog', function () {
+
+        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id+ '/EthernetInterfaces/0')
+            .expect(501)
+            .expect('Content-Type', /^application\/json/);
     });
 
     it('should return the RackHD manager', function() {
         waterline.nodes.find.resolves([node]);
+
         return helper.request().get('/redfish/v1/Managers/RackHD')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
@@ -314,9 +443,10 @@ describe('Redfish Managers', function () {
 
     it('should return the RackHD manager with no relations', function() {
         waterline.nodes.find.resolves([]);
+
         return helper.request().get('/redfish/v1/Managers/RackHD')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
@@ -325,6 +455,7 @@ describe('Redfish Managers', function () {
     });
 
     it('should patch the RackHD manager', function() {
+
         waterline.nodes.find.resolves([node]);
         return helper.request().patch('/redfish/v1/Managers/RackHD')
             .send({ NetworkProtocol: { SSDP: { ProtocolEnabled: false }}})
@@ -333,15 +464,15 @@ describe('Redfish Managers', function () {
 
     it('should 405 a patch when it is not the RackHD manager', function() {
         return helper.request().patch('/redfish/v1/Managers/RackHD1')
-            .expect('Content-Type', /^application\/json/)
             .send({ NetworkProtocol: { SSDP: { ProtocolEnabled: false }}})
-            .expect(405);
+            .expect(405)
+            .expect('Content-Type', /^application\/json/);
     });
 
     it('should return the RackHD manager ethernet interface collection', function() {
         return helper.request().get('/redfish/v1/Managers/RackHD/EthernetInterfaces')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
@@ -350,9 +481,10 @@ describe('Redfish Managers', function () {
     });
 
     it('should return the RackHD manager network protocol', function() {
+
         return helper.request().get('/redfish/v1/Managers/RackHD/NetworkProtocol')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function() {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
@@ -361,18 +493,19 @@ describe('Redfish Managers', function () {
     });
 
     it('should return the RackHD manager ethernet interface', function() {
+
         return helper.request().get('/redfish/v1/Managers/RackHD/EthernetInterfaces')
         .then(function(res) {
             return Promise.map(res.body.Members, function(member) {
                 return helper.request().get(member['@odata.id'])
-                    .expect('Content-Type', /^application\/json/)
-                    .expect(200);
+                    .expect(200)
+                    .expect('Content-Type', /^application\/json/);
             });
         });
     });
 
     it('should return 200 for non-DELL manager serial interface', function () {
-        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(node);
+
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: '1234abcd1234abcd1234abcd',
             source: 'dummysource',
@@ -380,25 +513,68 @@ describe('Redfish Managers', function () {
         }));
 
         return helper.request().get('/redfish/v1/Managers/' + node.id + '/SerialInterfaces')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function () {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
                 expect(redfish.render.called).to.be.true;
             });
     });
- 
+    it('should return a valid manager serial interface collection for redfish catalog', function() {
+
+        waterline.catalogs.findLatestCatalogOfSource.resolves({
+            node: redfishManager.id,
+            source: 'dummysource',
+            data: {}
+        });
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id + '/SerialInterfaces')
+            .expect(200)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return 501 for redfish manager serial interface collection with no catalog', function () {
+
+        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id+ '/SerialInterfaces')
+            .expect(501)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return a valid manager serial interface for redfish catalog', function() {
+
+        waterline.catalogs.findLatestCatalogOfSource.resolves({
+            node: redfishManager.id,
+            source: 'dummysource',
+            data: {}
+        });
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id + '/SerialInterfaces/J21-COMA')
+            .expect(200)
+            .expect('Content-Type', /^application\/json/);
+    });
+
+    it('should return 501 for redfish manager serial interface with no catalog', function () {
+
+        waterline.catalogs.findLatestCatalogOfSource.rejects(new Errors.NotFoundError());
+
+        return helper.request().get('/redfish/v1/Managers/' + redfishManager.id+ '/SerialInterfaces/J21-COMA')
+            .expect(501)
+            .expect('Content-Type', /^application\/json/);
+    });
+
     it('should return 200 for non-DELL manager serial interface with index', function () {
-        waterline.nodes.getNodeById.withArgs('1234abcd1234abcd1234abcd').resolves(node);
+
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: '1234abcd1234abcd1234abcd',
             data: dmiCatalogData
         }));
 
         return helper.request().get('/redfish/v1/Managers/' + node.id + '/SerialInterfaces/J21-COMA')
-            .expect('Content-Type', /^application\/json/)
             .expect(200)
+            .expect('Content-Type', /^application\/json/)
             .expect(function () {
                 expect(tv4.validate.called).to.be.true;
                 expect(validator.validate.called).to.be.true;
@@ -406,8 +582,8 @@ describe('Redfish Managers', function () {
             });
     });
 
-    it('should retrun 404 for Dell manager serial interface', function() {
-        waterline.nodes.getNodeById.withArgs('DELLabcd1234abcd1234abcd').resolves(dellNode);
+    it('should return 404 for Dell manager serial interface', function() {
+
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: 'DELLabcd1234abcd1234abcd',
             source: 'dummysource',
@@ -415,12 +591,12 @@ describe('Redfish Managers', function () {
         }));
 
         return helper.request().get('/redfish/v1/Managers/' + dellNode.id + '/SerialInterfaces')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404);
+            .expect(404)
+            .expect('Content-Type', /^application\/json/);
     });
 
     it('should return 404 for Dell node manager serial interface with index', function() {
-        waterline.nodes.getNodeById.withArgs('DELLabcd1234abcd1234abcd').resolves(dellNode);
+
         waterline.catalogs.findLatestCatalogOfSource.resolves(Promise.resolve({
             node: 'DELLabcd1234abcd1234abcd',
             source: 'dummysource',
@@ -428,28 +604,30 @@ describe('Redfish Managers', function () {
         }));
 
         return helper.request().get('/redfish/v1/Managers/' + dellNode.id + '/SerialInterfaces/J21-COMA')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404);
+            .expect(404)
+            .expect('Content-Type', /^application\/json/);
     });
 
     it('should return 404 for RackHD manager serial interface', function() {
+
         waterline.catalogs.find.resolves(Promise.resolve({
             data: dmiCatalogData
         }));
 
         return helper.request().get('/redfish/v1/Managers/RackHD/SerialInterfaces')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404);
+            .expect(404)
+            .expect('Content-Type', /^application\/json/);
     });
 
     it('should return 404 for RackHD manager serial interface with index', function() {
+
         waterline.catalogs.find.resolves(Promise.resolve({
             data: dmiCatalogData
         }));
 
         return helper.request().get('/redfish/v1/Managers/RackHD/SerialInterfaces/J21-COMA')
-            .expect('Content-Type', /^application\/json/)
-            .expect(404);
+            .expect(404)
+            .expect('Content-Type', /^application\/json/);
     });
 
 });

--- a/spec/lib/services/redfish-api-service-spec.js
+++ b/spec/lib/services/redfish-api-service-spec.js
@@ -10,6 +10,7 @@ describe("Redfish Api Service", function() {
     var _;
     var env;
     var waterline;
+    var nodeApi;
     var testObj = {
         '@odata.context': '/redfish/v1/$metadata#Systems',
         '@odata.id': '/redfish/v1/Systems/',
@@ -43,12 +44,12 @@ describe("Redfish Api Service", function() {
 
         env = helper.injector.get('Services.Environment');
         waterline = helper.injector.get('Services.Waterline');
+        nodeApi = helper.injector.get('Http.Services.Api.Nodes'); 
         sinon.stub(env, "get").resolves();
 
         sinon.stub(view, "get").resolves({contents: JSON.stringify(testObj)});
-        waterline.nodes = {
-            getNodeById: sinon.stub()
-        };
+       
+        sinon.stub(nodeApi, 'getNodeByIdentifier');
     });
 
     beforeEach(function() {
@@ -77,7 +78,7 @@ describe("Redfish Api Service", function() {
     describe("getVendorNameById", function() {
 
         beforeEach('getVendorNameById beforeEach', function(){
-            waterline.nodes.getNodeById.reset();
+            nodeApi.getNodeByIdentifier.reset();
         });
 
         it('should get Cisco vendor name by identifier', function() {
@@ -89,13 +90,13 @@ describe("Redfish Api Service", function() {
                 ]
             };
 
-            waterline.nodes.getNodeById.resolves(sampleDataInfo);
+            nodeApi.getNodeByIdentifier.resolves(sampleDataInfo);
             return redfish.getVendorNameById(id)
                 .then(function(result){
                     expect(result.vendor).to.equal("Cisco");
                     expect(result.node).to.deep.equal(sampleDataInfo);
-                    expect(waterline.nodes.getNodeById).to.be.calledOnce;
-                    expect(waterline.nodes.getNodeById).to.be
+                    expect(nodeApi.getNodeByIdentifier).to.be.calledOnce;
+                    expect(nodeApi.getNodeByIdentifier).to.be
                         .calledWith("599337d6ff99ed24305bc58a");
                 });
         });
@@ -109,13 +110,13 @@ describe("Redfish Api Service", function() {
                 ]
             };
 
-            waterline.nodes.getNodeById.resolves(sampleDataInfo);
+            nodeApi.getNodeByIdentifier.resolves(sampleDataInfo);
             return redfish.getVendorNameById(id)
                 .then(function(result){
                     expect(result.vendor).to.equal("Dell");
                     expect(result.node).to.deep.equal(sampleDataInfo);
-                    expect(waterline.nodes.getNodeById).to.be.calledOnce;
-                    expect(waterline.nodes.getNodeById).to.be.calledWith("5bc58a");
+                    expect(nodeApi.getNodeByIdentifier).to.be.calledOnce;
+                    expect(nodeApi.getNodeByIdentifier).to.be.calledWith("5bc58a");
                 });
         });
 
@@ -128,19 +129,19 @@ describe("Redfish Api Service", function() {
                 ]
             };
 
-            waterline.nodes.getNodeById.resolves(sampleDataInfo);
+            nodeApi.getNodeByIdentifier.resolves(sampleDataInfo);
             return redfish.getVendorNameById(id)
                 .then(function(result){
-                    expect(result.vendor).to.equal(undefined);
+                    expect(result.vendor).to.equal('Other');
                     expect(result.node).to.deep.equal(sampleDataInfo);
-                    expect(waterline.nodes.getNodeById).to.be.calledOnce;
-                    expect(waterline.nodes.getNodeById).to.be.calledWith("5bc58a");
+                    expect(nodeApi.getNodeByIdentifier).to.be.calledOnce;
+                    expect(nodeApi.getNodeByIdentifier).to.be.calledWith("5bc58a");
                 });
         });
 
         it('should not get vendor name by Identifier', function() {
             var id = "testid";
-            waterline.nodes.getNodeById.resolves(null);
+            nodeApi.getNodeByIdentifier.resolves(null);
             return redfish.getVendorNameById(id)
                 .then(function(){
                     throw new Error("Test should be failed in this case.");


### PR DESCRIPTION
Updating redfish to work with identifier in addition to mongo id

Correct Managers GET REST interfaces

Correct chassis GET REST interfaces

Correct systems GET REST interfaces

Adding put/post actions for redfish devices

Adding and fixing spec tests

************
Part of Changes in on-core, on-http, on-tasks, on-taskgraph
The combination of these changes is to fully implement redfish device discovery. This includes the fillowing items:
1) The implementation of unique device identifiers in place of the RackHD GUID identifers.
    a) These ids provide the user the ability to know which node they are looking at. This is usefull for
       aggregation.
    b) All RackHD Redfish calls can use either the new id or the original RackHD GUID. The RackHD api still can
       only use the GUID.
    c) Currently this id is made with a combination of the serial number and sku from the redfish discovery.
2) Creation of redfish and redfishManager node types.
    a) redfish nodes are combination of systems and chassis in one node. This is because some redfish implementations
       report system and chassis as one object.
    b) redfishManagers are a node object to store information about the managers discovered durring redfish discovery.
    c) Maintains support with /Chassis /Systems and /Managers Redfish calls.
3) Dynamic modification of redfish catalogs.
    a) injection of the unique device id into the discovered redfish catalogs.
    b) catalog names and id use the unique device id.
    c) stored in only the relavent node with the source as the odata.id of the call that got the info.
       ie. /Systems/{identifier}/...
4) Implemented support for redfish discovered devices in the redfish API (GET, PATCH, and POST).
    a) GETs returned the stored catalogs from discovery
    b) PUTs and POSTs start a wrokflow that does the Redfish call on the discovered device with the provide payload
5) Modified spec test to support redfish devices.
    a) Changed from nodeApi stubbing to waterline stubbing in system and chassis spec tests.
6) Implementation of general purpose REST API workflow.
    a) Currently used for doing redfish calls but can be run with any REST calls.
7) RackHD Redfish API only works for calls which the device '@odata.id's match the RackHD Redfish implementation
    a) not all devices follow this implementation due to the opaque nature of the Redfish odata links
    b) To support all would require work to interpret all data during discovery and dynamically store it.

Reddish Discovery allows for the aggregation of Redfish complaint devices. The discovery creates node objects for compute, enclosure, redfish, and redfishManager nodes. The redfish nodes are a combination of a system and chassis and the redfishManager is for storing the manager objects discovered.
Add Comment Collapse



