### PR TITLE
[RAC-6681] Lock down NPM modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Copyright 2015-2018, Dell EMC, Inc.
+
 language: node_js
 sudo: true
 node_js:
@@ -19,6 +21,9 @@ addons:
 services:
  - mongodb
  - rabbitmq
+
+before_install:
+ - npm i -g npm@5.6.0
 
 script:
  - mongo --version

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,18801 @@
+{
+  "//": "Copyright 2018, Dell EMC, Inc.",
+  "name": "on-http",
+  "version": "2.54.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@mapbox/geojsonhint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-2.0.1.tgz",
+      "integrity": "sha1-MtrHMA8Es+uux0tbqYU9+0JTI1Q=",
+      "requires": {
+        "concat-stream": "1.5.2",
+        "jsonlint-lines": "1.7.1",
+        "minimist": "1.2.0",
+        "vfile": "2.0.0",
+        "vfile-reporter": "3.0.0"
+      }
+    },
+    "@sailshq/lodash": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.2.tgz",
+      "integrity": "sha1-FWfUc0U2TCwuIHe8ETSHsd/mIVQ="
+    },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "acl": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/acl/-/acl-0.4.9.tgz",
+      "integrity": "sha1-3HLiGzRIU567ggG66ehUqY/VmDs=",
+      "requires": {
+        "async": "1.4.2",
+        "bluebird": "2.11.0",
+        "lodash": "3.10.1",
+        "mongodb": "2.2.9",
+        "redis": "2.6.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs="
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        },
+        "mongodb": {
+          "version": "2.2.9",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.9.tgz",
+          "integrity": "sha1-GAiFu3rdio2/4jQIm8vvhkFfbUQ=",
+          "requires": {
+            "es6-promise": "3.2.1",
+            "mongodb-core": "2.0.11",
+            "readable-stream": "2.1.5"
+          },
+          "dependencies": {
+            "es6-promise": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+              "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
+            },
+            "mongodb-core": {
+              "version": "2.0.11",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.0.11.tgz",
+              "integrity": "sha1-UNWTwcIO7DGGimRYjKwUtm9BzXc=",
+              "requires": {
+                "bson": "0.5.4",
+                "require_optional": "1.0.0"
+              },
+              "dependencies": {
+                "bson": {
+                  "version": "0.5.4",
+                  "resolved": "https://registry.npmjs.org/bson/-/bson-0.5.4.tgz",
+                  "integrity": "sha1-ViPXwmcPaHJY4X+5lJnZ/mxOH8U="
+                },
+                "require_optional": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+                  "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8=",
+                  "requires": {
+                    "resolve-from": "2.0.0",
+                    "semver": "5.3.0"
+                  },
+                  "dependencies": {
+                    "resolve-from": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+                    },
+                    "semver": {
+                      "version": "5.3.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
+              "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                }
+              }
+            }
+          }
+        },
+        "redis": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.2.tgz",
+          "integrity": "sha1-fMqwVjATrGGefdhMZRK4HT2FJXk=",
+          "requires": {
+            "double-ended-queue": "2.1.0-0",
+            "redis-commands": "1.2.0",
+            "redis-parser": "2.0.4"
+          },
+          "dependencies": {
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            },
+            "redis-commands": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.2.0.tgz",
+              "integrity": "sha1-SAjnoPyx02Cb7FbuzDUy2surmBw="
+            },
+            "redis-parser": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.0.4.tgz",
+              "integrity": "sha1-cMu7PO+L9BoxU4iv4UkEplp6ECg="
+            }
+          }
+        }
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "always-tail": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/always-tail/-/always-tail-0.2.0.tgz",
+      "integrity": "sha1-M5sa9E1QJQqgeg6H7Mw6JOxET/4=",
+      "requires": {
+        "debug": "0.7.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        }
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "amqp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/amqp/-/amqp-0.2.3.tgz",
+      "integrity": "sha1-Ja+9hRrXhPjmBvIr/jTF+D5P51w=",
+      "requires": {
+        "lodash": "1.3.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+          "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+        }
+      }
+    },
+    "anchor": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/anchor/-/anchor-0.10.5.tgz",
+      "integrity": "sha1-H54EMjowh/q53ufYilEJm35fsLU=",
+      "requires": {
+        "geojsonhint": "1.1.0",
+        "lodash": "3.9.3",
+        "validator": "3.41.2"
+      },
+      "dependencies": {
+        "geojsonhint": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "colors": "0.6.2",
+            "concat-stream": "1.4.10",
+            "jsonlint-lines": "1.6.0",
+            "minimist": "1.1.1",
+            "optimist": "0.6.1"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "bundled": true
+            },
+            "concat-stream": {
+              "version": "1.4.10",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "readable-stream": "1.1.13",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.1",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    }
+                  }
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "jsonlint-lines": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "JSV": "4.0.2",
+                "nomnom": "1.8.1"
+              },
+              "dependencies": {
+                "JSV": {
+                  "version": "4.0.2",
+                  "bundled": true
+                },
+                "nomnom": {
+                  "version": "1.8.1",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "0.4.0",
+                    "underscore": "1.6.0"
+                  },
+                  "dependencies": {
+                    "chalk": {
+                      "version": "0.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "1.0.0",
+                        "has-color": "0.1.7",
+                        "strip-ansi": "0.1.1"
+                      },
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "has-color": {
+                          "version": "0.1.7",
+                          "bundled": true
+                        },
+                        "strip-ansi": {
+                          "version": "0.1.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "underscore": {
+                      "version": "1.6.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "bundled": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "bundled": true
+        },
+        "validator": {
+          "version": "3.41.2",
+          "bundled": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+    },
+    "apidoc": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.12.3.tgz",
+      "integrity": "sha1-DyW0XMPzCZCI0eTpk+idR5rWSU4=",
+      "dev": true,
+      "requires": {
+        "apidoc-core": "0.3.2",
+        "fs-extra": "0.18.4",
+        "lodash": "3.6.0",
+        "marked": "0.3.6",
+        "nomnom": "1.8.1",
+        "winston": "1.0.2"
+      },
+      "dependencies": {
+        "apidoc-core": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/apidoc-core/-/apidoc-core-0.3.2.tgz",
+          "integrity": "sha1-O3SFlcuiyIiN/ROb4YoqtHya7kY=",
+          "dev": true,
+          "requires": {
+            "lodash": "3.6.0",
+            "semver": "4.3.6",
+            "wrench": "1.5.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "4.3.6",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+              "dev": true
+            },
+            "wrench": {
+              "version": "1.5.9",
+              "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
+              "integrity": "sha1-QRaRxjqbJTGxcAJnJ5veyiOyFCo=",
+              "dev": true
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "0.18.4",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.4.tgz",
+          "integrity": "sha1-fyBXUtbTlZyWdTPjRUAWGns43DY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "3.0.11",
+            "jsonfile": "2.3.1",
+            "rimraf": "2.5.4"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+              "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+              "dev": true,
+              "requires": {
+                "natives": "1.1.0"
+              },
+              "dependencies": {
+                "natives": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+                  "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+                  "dev": true
+                }
+              }
+            },
+            "jsonfile": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
+              "integrity": "sha1-KLyynFlrW3qv005mKjKbpizYQvw=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz",
+          "integrity": "sha1-Umao9J3Zib5Pn2gbbyoMVShdDZo=",
+          "dev": true
+        },
+        "marked": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+          "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+          "dev": true
+        },
+        "nomnom": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+          "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+          "dev": true,
+          "requires": {
+            "chalk": "0.4.0",
+            "underscore": "1.6.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "1.0.0",
+                "has-color": "0.1.7",
+                "strip-ansi": "0.1.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+                  "dev": true
+                },
+                "has-color": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                  "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+                  "dev": true
+                }
+              }
+            },
+            "underscore": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+              "dev": true
+            }
+          }
+        },
+        "winston": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/winston/-/winston-1.0.2.tgz",
+          "integrity": "sha1-NRxY4jI/ikyimkUZWqmqO0w1128=",
+          "dev": true,
+          "requires": {
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "pkginfo": "0.3.1",
+            "stack-trace": "0.0.9"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+              "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+              "dev": true
+            },
+            "colors": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+              "dev": true
+            },
+            "cycle": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+              "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+              "dev": true
+            },
+            "eyes": {
+              "version": "0.1.8",
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true
+            },
+            "pkginfo": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+              "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+              "dev": true
+            },
+            "stack-trace": {
+              "version": "0.0.9",
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "arguejs": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/arguejs/-/arguejs-0.2.3.tgz",
+      "integrity": "sha1-tvk59f4OPNHz+T4qqSYkJL8xKvc="
+    },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "requires": {
+        "colour": "0.7.1",
+        "optjs": "3.2.2"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "requires": {
+        "readable-stream": "2.3.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "body-parser": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+      "integrity": "sha1-11eM9PHRHV9uqATO813Hp/9trmc=",
+      "requires": {
+        "bytes": "2.4.0",
+        "content-type": "1.0.2",
+        "debug": "2.2.0",
+        "depd": "1.1.0",
+        "http-errors": "1.5.0",
+        "iconv-lite": "0.4.13",
+        "on-finished": "2.3.0",
+        "qs": "6.2.0",
+        "raw-body": "2.1.7",
+        "type-is": "1.6.13"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+          "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+        },
+        "depd": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        },
+        "http-errors": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+          "integrity": "sha1-scs9gmD9jiOGytMYkEWUM3LUghE=",
+          "requires": {
+            "inherits": "2.0.1",
+            "setprototypeof": "1.0.1",
+            "statuses": "1.3.0"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "setprototypeof": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+              "integrity": "sha1-UgCbJ4iMTcSPWRlJwKgnWDTByn4="
+            },
+            "statuses": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+              "integrity": "sha1-jlV1jLIOdoLB9Pzo3KswvwHR4Ho="
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+        },
+        "qs": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+          "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs="
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+          "requires": {
+            "bytes": "2.4.0",
+            "iconv-lite": "0.4.13",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "unpipe": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            }
+          }
+        },
+        "type-is": {
+          "version": "1.6.13",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "integrity": "sha1-boO6e8MM0zp7sLf7AHN6IIW/nQg=",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.11"
+          },
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+              "requires": {
+                "mime-db": "1.23.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "bootprint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bootprint/-/bootprint-1.0.0.tgz",
+      "integrity": "sha1-lZjshGik0llA/S8eMmeeWBM0LrI=",
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "customize-engine-handlebars": "1.0.1",
+        "customize-engine-less": "1.0.1",
+        "customize-engine-uglify": "1.0.0",
+        "customize-watch": "1.0.0",
+        "customize-write-files": "1.1.0",
+        "debug": "2.2.0",
+        "get-promise": "1.4.0",
+        "js-yaml": "3.6.1",
+        "live-server": "0.8.2",
+        "lodash": "3.10.1",
+        "q": "1.5.0",
+        "trace-and-clarify-if-possible": "1.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          },
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+              "dev": true
+            }
+          }
+        },
+        "customize": {
+          "version": "https://registry.npmjs.org/customize/-/customize-1.1.0.tgz",
+          "integrity": "sha1-jn3hMVqxV336ISTqmQbs6oijyS0=",
+          "requires": {
+            "debug": "2.2.0",
+            "deep-aplus": "1.0.4",
+            "jsonschema": "1.1.1",
+            "jsonschema-extra": "1.2.0",
+            "lodash": "3.10.1",
+            "m-io": "0.3.1",
+            "minimatch": "3.0.3",
+            "q": "1.5.0"
+          },
+          "dependencies": {
+            "deep-aplus": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/deep-aplus/-/deep-aplus-1.0.4.tgz",
+              "integrity": "sha1-4exMEKALUEa1ng3dBRnRAa4xXo8=",
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              },
+              "dependencies": {
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+                }
+              }
+            },
+            "jsonschema": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.1.1.tgz",
+              "integrity": "sha1-PO3o4+QR03eHLu+8n98mODy8Ptk="
+            },
+            "jsonschema-extra": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/jsonschema-extra/-/jsonschema-extra-1.2.0.tgz",
+              "integrity": "sha1-52eGotlQdb4ja5izuAUrD2wVTXs=",
+              "requires": {
+                "js-quantities": "1.6.6",
+                "lodash.isplainobject": "2.4.1"
+              },
+              "dependencies": {
+                "js-quantities": {
+                  "version": "1.6.6",
+                  "resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.6.6.tgz",
+                  "integrity": "sha1-dyLTAzDnbEbSwpzWY78Kpy1hXSw="
+                },
+                "lodash.isplainobject": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-2.4.1.tgz",
+                  "integrity": "sha1-rHOF4uqawDIfMNw7gDKm0iMagBE=",
+                  "requires": {
+                    "lodash._isnative": "2.4.1",
+                    "lodash._shimisplainobject": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                    },
+                    "lodash._shimisplainobject": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._shimisplainobject/-/lodash._shimisplainobject-2.4.1.tgz",
+                      "integrity": "sha1-AeyTsu5j5Z8aqDiZrG+gkFrHWW8=",
+                      "requires": {
+                        "lodash.forin": "2.4.1",
+                        "lodash.isfunction": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash.forin": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-2.4.1.tgz",
+                          "integrity": "sha1-gInq7X0lsIZyt8Zv0HrFXQYjIOs=",
+                          "requires": {
+                            "lodash._basecreatecallback": "2.4.1",
+                            "lodash._objecttypes": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._basecreatecallback": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                              "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
+                              "requires": {
+                                "lodash._setbinddata": "2.4.1",
+                                "lodash.bind": "2.4.1",
+                                "lodash.identity": "2.4.1",
+                                "lodash.support": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._setbinddata": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                                  "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
+                                  "requires": {
+                                    "lodash._isnative": "2.4.1",
+                                    "lodash.noop": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash.noop": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
+                                    }
+                                  }
+                                },
+                                "lodash.bind": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                                  "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
+                                  "requires": {
+                                    "lodash._createwrapper": "2.4.1",
+                                    "lodash._slice": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._createwrapper": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                                      "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
+                                      "requires": {
+                                        "lodash._basebind": "2.4.1",
+                                        "lodash._basecreatewrapper": "2.4.1",
+                                        "lodash._slice": "2.4.1",
+                                        "lodash.isfunction": "2.4.1"
+                                      },
+                                      "dependencies": {
+                                        "lodash._basebind": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                                          "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
+                                          "requires": {
+                                            "lodash._basecreate": "2.4.1",
+                                            "lodash._setbinddata": "2.4.1",
+                                            "lodash._slice": "2.4.1",
+                                            "lodash.isobject": "2.4.1"
+                                          },
+                                          "dependencies": {
+                                            "lodash._basecreate": {
+                                              "version": "2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                              "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                              "requires": {
+                                                "lodash._isnative": "2.4.1",
+                                                "lodash.isobject": "2.4.1",
+                                                "lodash.noop": "2.4.1"
+                                              },
+                                              "dependencies": {
+                                                "lodash.noop": {
+                                                  "version": "2.4.1",
+                                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                                  "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
+                                                }
+                                              }
+                                            },
+                                            "lodash.isobject": {
+                                              "version": "2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                              "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                              "requires": {
+                                                "lodash._objecttypes": "2.4.1"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "lodash._basecreatewrapper": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                                          "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
+                                          "requires": {
+                                            "lodash._basecreate": "2.4.1",
+                                            "lodash._setbinddata": "2.4.1",
+                                            "lodash._slice": "2.4.1",
+                                            "lodash.isobject": "2.4.1"
+                                          },
+                                          "dependencies": {
+                                            "lodash._basecreate": {
+                                              "version": "2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                              "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                              "requires": {
+                                                "lodash._isnative": "2.4.1",
+                                                "lodash.isobject": "2.4.1",
+                                                "lodash.noop": "2.4.1"
+                                              },
+                                              "dependencies": {
+                                                "lodash.noop": {
+                                                  "version": "2.4.1",
+                                                  "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                                  "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
+                                                }
+                                              }
+                                            },
+                                            "lodash.isobject": {
+                                              "version": "2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                              "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                              "requires": {
+                                                "lodash._objecttypes": "2.4.1"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "lodash._slice": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                                      "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8="
+                                    }
+                                  }
+                                },
+                                "lodash.identity": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                                  "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE="
+                                },
+                                "lodash.support": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                                  "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
+                                  "requires": {
+                                    "lodash._isnative": "2.4.1"
+                                  }
+                                }
+                              }
+                            },
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                              "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                            }
+                          }
+                        },
+                        "lodash.isfunction": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                          "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "m-io": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/m-io/-/m-io-0.3.1.tgz",
+              "integrity": "sha1-SgeSJG9oGfdFyLxdlzzeiC8NHvs=",
+              "requires": {
+                "mkdirp": "0.5.1",
+                "q": "1.5.0",
+                "rimraf": "2.5.4"
+              },
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "requires": {
+                "brace-expansion": "1.1.7"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                  "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "customize-engine-handlebars": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/customize-engine-handlebars/-/customize-engine-handlebars-1.0.1.tgz",
+          "integrity": "sha1-SAElQInR6IRi4/1vIXMpk6p7+ZY=",
+          "dev": true,
+          "requires": {
+            "debug": "2.2.0",
+            "handlebars": "3.0.3",
+            "lodash": "3.10.1",
+            "m-io": "0.3.1",
+            "promised-handlebars": "1.0.6",
+            "q": "1.5.0",
+            "q-deep": "1.0.3"
+          },
+          "dependencies": {
+            "handlebars": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+              "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
+              "dev": true,
+              "requires": {
+                "optimist": "0.6.1",
+                "source-map": "0.1.43",
+                "uglify-js": "2.3.6"
+              },
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                      "dev": true
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.1"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+                      "dev": true
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "async": "0.2.10",
+                    "optimist": "0.3.7",
+                    "source-map": "0.1.43"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "wordwrap": "0.0.3"
+                      },
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "m-io": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/m-io/-/m-io-0.3.1.tgz",
+              "integrity": "sha1-SgeSJG9oGfdFyLxdlzzeiC8NHvs=",
+              "dev": true,
+              "requires": {
+                "mkdirp": "0.5.1",
+                "q": "1.5.0",
+                "rimraf": "2.5.4"
+              },
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "promised-handlebars": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/promised-handlebars/-/promised-handlebars-1.0.6.tgz",
+              "integrity": "sha1-2ZfglDsD9j/oL/I8uQSyes/AUNg=",
+              "dev": true,
+              "requires": {
+                "deep-aplus": "1.0.4",
+                "q": "1.5.0"
+              },
+              "dependencies": {
+                "deep-aplus": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/deep-aplus/-/deep-aplus-1.0.4.tgz",
+                  "integrity": "sha1-4exMEKALUEa1ng3dBRnRAa4xXo8=",
+                  "dev": true,
+                  "requires": {
+                    "lodash.isplainobject": "4.0.6"
+                  },
+                  "dependencies": {
+                    "lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "q-deep": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/q-deep/-/q-deep-1.0.3.tgz",
+              "integrity": "sha1-zQcD2irMuuZXDmAMaKVt5mEHkMs=",
+              "dev": true,
+              "requires": {
+                "deep-aplus": "1.0.4",
+                "q": "1.5.0"
+              },
+              "dependencies": {
+                "deep-aplus": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/deep-aplus/-/deep-aplus-1.0.4.tgz",
+                  "integrity": "sha1-4exMEKALUEa1ng3dBRnRAa4xXo8=",
+                  "dev": true,
+                  "requires": {
+                    "lodash.isplainobject": "4.0.6"
+                  },
+                  "dependencies": {
+                    "lodash.isplainobject": {
+                      "version": "4.0.6",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "customize-engine-less": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/customize-engine-less/-/customize-engine-less-1.0.1.tgz",
+          "integrity": "sha1-rl//DPOSgGx9Dx1NqPfUsuZRCSk=",
+          "dev": true,
+          "requires": {
+            "less": "2.7.2",
+            "lodash": "3.10.1",
+            "q": "1.5.0"
+          },
+          "dependencies": {
+            "less": {
+              "version": "2.7.2",
+              "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
+              "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
+              "dev": true,
+              "requires": {
+                "errno": "0.1.4",
+                "graceful-fs": "4.1.11",
+                "image-size": "0.5.1",
+                "mime": "1.3.4",
+                "mkdirp": "0.5.1",
+                "promise": "7.1.1",
+                "request": "2.81.0",
+                "source-map": "0.5.6"
+              },
+              "dependencies": {
+                "errno": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "prr": "0.0.0"
+                  },
+                  "dependencies": {
+                    "prr": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+                      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                  "dev": true,
+                  "optional": true
+                },
+                "image-size": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.1.tgz",
+                  "integrity": "sha1-KO6oVIpLFENIDd3cHgg65UZSQ58=",
+                  "dev": true,
+                  "optional": true
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+                  "dev": true,
+                  "optional": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "promise": {
+                  "version": "7.1.1",
+                  "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+                  "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "asap": "2.0.5"
+                  },
+                  "dependencies": {
+                    "asap": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
+                      "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                  "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.6.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.5",
+                    "extend": "3.0.0",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.15",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.0.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.2",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.0.1"
+                  },
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "aws4": {
+                      "version": "1.6.0",
+                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "caseless": {
+                      "version": "0.12.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                      "dev": true,
+                      "requires": {
+                        "delayed-stream": "1.0.0"
+                      },
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "form-data": {
+                      "version": "2.1.4",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                      },
+                      "dependencies": {
+                        "asynckit": {
+                          "version": "0.4.0",
+                          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "ajv": "4.11.6",
+                        "har-schema": "1.0.5"
+                      },
+                      "dependencies": {
+                        "ajv": {
+                          "version": "4.11.6",
+                          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz",
+                          "integrity": "sha1-lH6TBJeQlCsqLWCoKJsokk05+Yc=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "co": "4.6.0",
+                            "json-stable-stringify": "1.0.1"
+                          },
+                          "dependencies": {
+                            "co": {
+                              "version": "4.6.0",
+                              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "json-stable-stringify": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "jsonify": "0.0.0"
+                              },
+                              "dependencies": {
+                                "jsonify": {
+                                  "version": "0.0.0",
+                                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                                  "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "har-schema": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                      },
+                      "dependencies": {
+                        "boom": {
+                          "version": "2.10.1",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                          "dev": true,
+                          "requires": {
+                            "hoek": "2.16.3"
+                          }
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "boom": "2.10.1"
+                          }
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                          "dev": true
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "hoek": "2.16.3"
+                          }
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "jsprim": {
+                          "version": "1.4.0",
+                          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "1.0.0",
+                            "extsprintf": "1.0.2",
+                            "json-schema": "0.2.3",
+                            "verror": "1.3.6"
+                          },
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "extsprintf": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                              "dev": true
+                            },
+                            "json-schema": {
+                              "version": "0.2.3",
+                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "verror": {
+                              "version": "1.3.6",
+                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "extsprintf": "1.0.2"
+                              }
+                            }
+                          }
+                        },
+                        "sshpk": {
+                          "version": "1.13.0",
+                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "asn1": "0.2.3",
+                            "assert-plus": "1.0.0",
+                            "bcrypt-pbkdf": "1.0.1",
+                            "dashdash": "1.14.1",
+                            "ecc-jsbn": "0.1.1",
+                            "getpass": "0.1.6",
+                            "jodid25519": "1.0.2",
+                            "jsbn": "0.1.1",
+                            "tweetnacl": "0.14.5"
+                          },
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3",
+                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                              "dev": true
+                            },
+                            "bcrypt-pbkdf": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "tweetnacl": "0.14.5"
+                              }
+                            },
+                            "dashdash": {
+                              "version": "1.14.1",
+                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "jsbn": "0.1.1"
+                              }
+                            },
+                            "getpass": {
+                              "version": "0.1.6",
+                              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                              "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "assert-plus": "1.0.0"
+                              }
+                            },
+                            "jodid25519": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "jsbn": "0.1.1"
+                              }
+                            },
+                            "jsbn": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                              "dev": true,
+                              "optional": true
+                            },
+                            "tweetnacl": {
+                              "version": "0.14.5",
+                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "mime-types": {
+                      "version": "2.1.15",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                      "dev": true,
+                      "requires": {
+                        "mime-db": "1.27.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.27.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "performance-now": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "qs": {
+                      "version": "6.4.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "safe-buffer": {
+                      "version": "5.0.1",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+                      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+                      "dev": true
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tough-cookie": {
+                      "version": "2.3.2",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "punycode": "1.4.1"
+                      },
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.4.1",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.6.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "safe-buffer": "5.0.1"
+                      }
+                    },
+                    "uuid": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
+          }
+        },
+        "customize-engine-uglify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/customize-engine-uglify/-/customize-engine-uglify-1.0.0.tgz",
+          "integrity": "sha1-Eb3Mqslhn4zHCZHHGtB2K0cB+ug=",
+          "dev": true,
+          "requires": {
+            "lodash": "3.10.1",
+            "q": "1.5.0",
+            "uglify-js": "2.8.22"
+          },
+          "dependencies": {
+            "uglify-js": {
+              "version": "2.8.22",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
+              "integrity": "sha1-1Uk0d4qNoUkD+imjJvskwKtRoaA=",
+              "dev": true,
+              "requires": {
+                "source-map": "0.5.6",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.6",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                  "dev": true
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                  "dev": true,
+                  "optional": true
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "dev": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                      "dev": true
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "dev": true,
+                      "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                          "dev": true,
+                          "requires": {
+                            "align-text": "0.1.4",
+                            "lazy-cache": "1.0.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "requires": {
+                                "kind-of": "3.1.0",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.6.1"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.1.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+                                  "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.5"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "dev": true,
+                          "requires": {
+                            "align-text": "0.1.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "requires": {
+                                "kind-of": "3.1.0",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.6.1"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.1.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+                                  "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.5"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                                      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+                                      "dev": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "customize-watch": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/customize-watch/-/customize-watch-1.0.0.tgz",
+          "integrity": "sha1-D6nLpHG+/6Kb+U5lVN8FwN7A9YA=",
+          "dev": true,
+          "requires": {
+            "chokidar": "1.6.1",
+            "customize": "1.1.0",
+            "debug": "2.2.0",
+            "deep-aplus": "1.0.4",
+            "lodash": "3.10.1",
+            "m-io": "0.3.1",
+            "q": "1.5.0"
+          },
+          "dependencies": {
+            "chokidar": {
+              "version": "1.6.1",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+              "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
+              "dev": true,
+              "requires": {
+                "anymatch": "1.3.0",
+                "async-each": "1.0.1",
+                "fsevents": "1.1.3",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
+              },
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+                  "dev": true,
+                  "requires": {
+                    "arrify": "1.0.1",
+                    "micromatch": "2.3.11"
+                  },
+                  "dependencies": {
+                    "arrify": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                      "dev": true
+                    },
+                    "micromatch": {
+                      "version": "2.3.11",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                      "dev": true,
+                      "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.0",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.1.0",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.3"
+                      },
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                          "dev": true,
+                          "requires": {
+                            "arr-flatten": "1.0.1"
+                          },
+                          "dependencies": {
+                            "arr-flatten": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                              "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "array-unique": {
+                          "version": "0.2.1",
+                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+                          "dev": true
+                        },
+                        "braces": {
+                          "version": "1.8.5",
+                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                          "dev": true,
+                          "requires": {
+                            "expand-range": "1.8.2",
+                            "preserve": "0.2.0",
+                            "repeat-element": "1.1.2"
+                          },
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.2",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                              "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                              "dev": true,
+                              "requires": {
+                                "fill-range": "2.2.3"
+                              },
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.3",
+                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                                  "dev": true,
+                                  "requires": {
+                                    "is-number": "2.1.0",
+                                    "isobject": "2.1.0",
+                                    "randomatic": "1.1.6",
+                                    "repeat-element": "1.1.2",
+                                    "repeat-string": "1.6.1"
+                                  },
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                                      "dev": true,
+                                      "requires": {
+                                        "kind-of": "3.1.0"
+                                      }
+                                    },
+                                    "isobject": {
+                                      "version": "2.1.0",
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                                      "dev": true,
+                                      "requires": {
+                                        "isarray": "1.0.0"
+                                      },
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "1.0.0",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                                          "dev": true
+                                        }
+                                      }
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.6",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+                                      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+                                      "dev": true,
+                                      "requires": {
+                                        "is-number": "2.1.0",
+                                        "kind-of": "3.1.0"
+                                      }
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.6.1",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                                      "dev": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                              "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+                              "dev": true
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                              "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                          "dev": true,
+                          "requires": {
+                            "is-posix-bracket": "0.1.1"
+                          },
+                          "dependencies": {
+                            "is-posix-bracket": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                              "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "extglob": {
+                          "version": "0.3.2",
+                          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                          "dev": true,
+                          "requires": {
+                            "is-extglob": "1.0.0"
+                          }
+                        },
+                        "filename-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                          "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+                          "dev": true
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                          "dev": true
+                        },
+                        "kind-of": {
+                          "version": "3.1.0",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+                          "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+                          "dev": true,
+                          "requires": {
+                            "is-buffer": "1.1.5"
+                          },
+                          "dependencies": {
+                            "is-buffer": {
+                              "version": "1.1.5",
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+                              "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "normalize-path": {
+                          "version": "2.1.1",
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                          "dev": true,
+                          "requires": {
+                            "remove-trailing-separator": "1.0.1"
+                          },
+                          "dependencies": {
+                            "remove-trailing-separator": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
+                              "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "object.omit": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+                          "dev": true,
+                          "requires": {
+                            "for-own": "0.1.5",
+                            "is-extendable": "0.1.1"
+                          },
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                              "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                              "dev": true,
+                              "requires": {
+                                "for-in": "1.0.2"
+                              },
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+                                  "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                              "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.4",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+                          "dev": true,
+                          "requires": {
+                            "glob-base": "0.3.0",
+                            "is-dotfile": "1.0.2",
+                            "is-extglob": "1.0.0",
+                            "is-glob": "2.0.1"
+                          },
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.3.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                              "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                              "dev": true,
+                              "requires": {
+                                "glob-parent": "2.0.0",
+                                "is-glob": "2.0.1"
+                              }
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                              "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.3",
+                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+                          "dev": true,
+                          "requires": {
+                            "is-equal-shallow": "0.1.3",
+                            "is-primitive": "2.0.0"
+                          },
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.3",
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                              "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                              "dev": true,
+                              "requires": {
+                                "is-primitive": "2.0.0"
+                              }
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                              "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+                  "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+                  "dev": true
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                  "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                  "dev": true,
+                  "requires": {
+                    "is-glob": "2.0.1"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                  "dev": true
+                },
+                "is-binary-path": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                  "dev": true,
+                  "requires": {
+                    "binary-extensions": "1.8.0"
+                  },
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.8.0",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
+                      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "1.0.0"
+                  },
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                      "dev": true
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                  "dev": true
+                },
+                "readdirp": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+                  "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "minimatch": "3.0.3",
+                    "readable-stream": "2.2.9",
+                    "set-immediate-shim": "1.0.1"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                      "dev": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "dev": true,
+                      "requires": {
+                        "brace-expansion": "1.1.7"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.7",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                          "dev": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                              "dev": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.2.9",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+                      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                      "dev": true,
+                      "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.0",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+                          "dev": true
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "dev": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+                          "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+                          "dev": true,
+                          "requires": {
+                            "buffer-shims": "1.0.0"
+                          }
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "set-immediate-shim": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "customize": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/customize/-/customize-1.1.0.tgz",
+              "integrity": "sha1-jn3hMVqxV336ISTqmQbs6oijyS0=",
+              "dev": true,
+              "requires": {
+                "debug": "2.2.0",
+                "deep-aplus": "1.0.4",
+                "jsonschema": "1.1.1",
+                "jsonschema-extra": "1.2.0",
+                "lodash": "3.10.1",
+                "m-io": "0.3.1",
+                "minimatch": "3.0.3",
+                "q": "1.5.0"
+              },
+              "dependencies": {
+                "jsonschema": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.1.1.tgz",
+                  "integrity": "sha1-PO3o4+QR03eHLu+8n98mODy8Ptk=",
+                  "dev": true
+                },
+                "jsonschema-extra": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/jsonschema-extra/-/jsonschema-extra-1.2.0.tgz",
+                  "integrity": "sha1-52eGotlQdb4ja5izuAUrD2wVTXs=",
+                  "dev": true,
+                  "requires": {
+                    "js-quantities": "1.6.6",
+                    "lodash.isplainobject": "2.4.1"
+                  },
+                  "dependencies": {
+                    "js-quantities": {
+                      "version": "1.6.6",
+                      "resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.6.6.tgz",
+                      "integrity": "sha1-dyLTAzDnbEbSwpzWY78Kpy1hXSw=",
+                      "dev": true
+                    },
+                    "lodash.isplainobject": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-2.4.1.tgz",
+                      "integrity": "sha1-rHOF4uqawDIfMNw7gDKm0iMagBE=",
+                      "dev": true,
+                      "requires": {
+                        "lodash._isnative": "2.4.1",
+                        "lodash._shimisplainobject": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
+                          "dev": true
+                        },
+                        "lodash._shimisplainobject": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._shimisplainobject/-/lodash._shimisplainobject-2.4.1.tgz",
+                          "integrity": "sha1-AeyTsu5j5Z8aqDiZrG+gkFrHWW8=",
+                          "dev": true,
+                          "requires": {
+                            "lodash.forin": "2.4.1",
+                            "lodash.isfunction": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash.forin": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-2.4.1.tgz",
+                              "integrity": "sha1-gInq7X0lsIZyt8Zv0HrFXQYjIOs=",
+                              "dev": true,
+                              "requires": {
+                                "lodash._basecreatecallback": "2.4.1",
+                                "lodash._objecttypes": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._basecreatecallback": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                                  "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
+                                  "dev": true,
+                                  "requires": {
+                                    "lodash._setbinddata": "2.4.1",
+                                    "lodash.bind": "2.4.1",
+                                    "lodash.identity": "2.4.1",
+                                    "lodash.support": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._setbinddata": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                                      "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._isnative": "2.4.1",
+                                        "lodash.noop": "2.4.1"
+                                      },
+                                      "dependencies": {
+                                        "lodash.noop": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                          "dev": true
+                                        }
+                                      }
+                                    },
+                                    "lodash.bind": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                                      "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._createwrapper": "2.4.1",
+                                        "lodash._slice": "2.4.1"
+                                      },
+                                      "dependencies": {
+                                        "lodash._createwrapper": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                                          "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
+                                          "dev": true,
+                                          "requires": {
+                                            "lodash._basebind": "2.4.1",
+                                            "lodash._basecreatewrapper": "2.4.1",
+                                            "lodash._slice": "2.4.1",
+                                            "lodash.isfunction": "2.4.1"
+                                          },
+                                          "dependencies": {
+                                            "lodash._basebind": {
+                                              "version": "2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                                              "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
+                                              "dev": true,
+                                              "requires": {
+                                                "lodash._basecreate": "2.4.1",
+                                                "lodash._setbinddata": "2.4.1",
+                                                "lodash._slice": "2.4.1",
+                                                "lodash.isobject": "2.4.1"
+                                              },
+                                              "dependencies": {
+                                                "lodash._basecreate": {
+                                                  "version": "2.4.1",
+                                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                                  "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                                  "dev": true,
+                                                  "requires": {
+                                                    "lodash._isnative": "2.4.1",
+                                                    "lodash.isobject": "2.4.1",
+                                                    "lodash.noop": "2.4.1"
+                                                  },
+                                                  "dependencies": {
+                                                    "lodash.noop": {
+                                                      "version": "2.4.1",
+                                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                                      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                                      "dev": true
+                                                    }
+                                                  }
+                                                },
+                                                "lodash.isobject": {
+                                                  "version": "2.4.1",
+                                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                                  "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                                  "dev": true,
+                                                  "requires": {
+                                                    "lodash._objecttypes": "2.4.1"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "lodash._basecreatewrapper": {
+                                              "version": "2.4.1",
+                                              "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                                              "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
+                                              "dev": true,
+                                              "requires": {
+                                                "lodash._basecreate": "2.4.1",
+                                                "lodash._setbinddata": "2.4.1",
+                                                "lodash._slice": "2.4.1",
+                                                "lodash.isobject": "2.4.1"
+                                              },
+                                              "dependencies": {
+                                                "lodash._basecreate": {
+                                                  "version": "2.4.1",
+                                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                                  "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                                  "dev": true,
+                                                  "requires": {
+                                                    "lodash._isnative": "2.4.1",
+                                                    "lodash.isobject": "2.4.1",
+                                                    "lodash.noop": "2.4.1"
+                                                  },
+                                                  "dependencies": {
+                                                    "lodash.noop": {
+                                                      "version": "2.4.1",
+                                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                                      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=",
+                                                      "dev": true
+                                                    }
+                                                  }
+                                                },
+                                                "lodash.isobject": {
+                                                  "version": "2.4.1",
+                                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                                  "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                                  "dev": true,
+                                                  "requires": {
+                                                    "lodash._objecttypes": "2.4.1"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "lodash._slice": {
+                                          "version": "2.4.1",
+                                          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                                          "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8=",
+                                          "dev": true
+                                        }
+                                      }
+                                    },
+                                    "lodash.identity": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                                      "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE=",
+                                      "dev": true
+                                    },
+                                    "lodash.support": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                                      "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
+                                      "dev": true,
+                                      "requires": {
+                                        "lodash._isnative": "2.4.1"
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash._objecttypes": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                                  "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "lodash.isfunction": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                              "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.7"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.7",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+                      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "deep-aplus": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/deep-aplus/-/deep-aplus-1.0.4.tgz",
+              "integrity": "sha1-4exMEKALUEa1ng3dBRnRAa4xXo8=",
+              "dev": true,
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              },
+              "dependencies": {
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+                  "dev": true
+                }
+              }
+            },
+            "m-io": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/m-io/-/m-io-0.3.1.tgz",
+              "integrity": "sha1-SgeSJG9oGfdFyLxdlzzeiC8NHvs=",
+              "dev": true,
+              "requires": {
+                "mkdirp": "0.5.1",
+                "q": "1.5.0",
+                "rimraf": "2.5.4"
+              },
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "customize-write-files": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/customize-write-files/-/customize-write-files-1.1.0.tgz",
+          "integrity": "sha1-zCd89CCNT6OXJgUeQ8Z7G3QQU54=",
+          "dev": true,
+          "requires": {
+            "debug": "2.2.0",
+            "deep-aplus": "1.0.4",
+            "m-io": "0.3.1",
+            "q": "1.5.0",
+            "stream-equal": "0.1.13"
+          },
+          "dependencies": {
+            "deep-aplus": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/deep-aplus/-/deep-aplus-1.0.4.tgz",
+              "integrity": "sha1-4exMEKALUEa1ng3dBRnRAa4xXo8=",
+              "dev": true,
+              "requires": {
+                "lodash.isplainobject": "4.0.6"
+              },
+              "dependencies": {
+                "lodash.isplainobject": {
+                  "version": "4.0.6",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+                  "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+                  "dev": true
+                }
+              }
+            },
+            "m-io": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/m-io/-/m-io-0.3.1.tgz",
+              "integrity": "sha1-SgeSJG9oGfdFyLxdlzzeiC8NHvs=",
+              "dev": true,
+              "requires": {
+                "mkdirp": "0.5.1",
+                "q": "1.5.0",
+                "rimraf": "2.5.4"
+              },
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "stream-equal": {
+              "version": "0.1.13",
+              "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.13.tgz",
+              "integrity": "sha1-F8LXz43lVw0P+5njpRQqWMdrxK4=",
+              "dev": true,
+              "requires": {
+                "@types/node": "7.0.12"
+              },
+              "dependencies": {
+                "@types/node": {
+                  "version": "7.0.12",
+                  "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.12.tgz",
+                  "integrity": "sha1-rl9noZwV91IUgATbB8u7Ny5p78k=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
+          }
+        },
+        "get-promise": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/get-promise/-/get-promise-1.4.0.tgz",
+          "integrity": "sha1-RDBFyGUwvrvtIihh7+0TwNNv9qA=",
+          "dev": true,
+          "requires": {
+            "lodash": "3.10.1",
+            "q": "1.5.0"
+          }
+        },
+        "live-server": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/live-server/-/live-server-0.8.2.tgz",
+          "integrity": "sha1-PGoLBVkVhYZsmcccSFNjO/AZRP8=",
+          "dev": true,
+          "requires": {
+            "colors": "1.1.2",
+            "connect": "2.30.2",
+            "event-stream": "3.3.4",
+            "faye-websocket": "0.9.4",
+            "object-assign": "2.1.1",
+            "opn": "4.0.2",
+            "send": "0.15.1",
+            "watchr": "2.3.10"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+              "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+              "dev": true
+            },
+            "connect": {
+              "version": "2.30.2",
+              "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
+              "integrity": "sha1-jam8vooFTT0xjXTf7JA7XDmhtgk=",
+              "dev": true,
+              "requires": {
+                "basic-auth-connect": "1.0.0",
+                "body-parser": "1.13.3",
+                "bytes": "2.1.0",
+                "compression": "1.5.2",
+                "connect-timeout": "1.6.2",
+                "content-type": "1.0.2",
+                "cookie": "0.1.3",
+                "cookie-parser": "1.3.5",
+                "cookie-signature": "1.0.6",
+                "csurf": "1.8.3",
+                "debug": "2.2.0",
+                "depd": "1.0.1",
+                "errorhandler": "1.4.3",
+                "express-session": "1.11.3",
+                "finalhandler": "0.4.0",
+                "fresh": "0.3.0",
+                "http-errors": "1.3.1",
+                "method-override": "2.3.8",
+                "morgan": "1.6.1",
+                "multiparty": "3.3.2",
+                "on-headers": "1.0.1",
+                "parseurl": "1.3.1",
+                "pause": "0.1.0",
+                "qs": "4.0.0",
+                "response-time": "2.3.2",
+                "serve-favicon": "2.3.2",
+                "serve-index": "1.7.3",
+                "serve-static": "1.10.3",
+                "type-is": "1.6.15",
+                "utils-merge": "1.0.0",
+                "vhost": "3.0.2"
+              },
+              "dependencies": {
+                "basic-auth-connect": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
+                  "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI=",
+                  "dev": true
+                },
+                "body-parser": {
+                  "version": "1.13.3",
+                  "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+                  "integrity": "sha1-wIzzMMM1jhUQFqBXRvE/ApyX+pc=",
+                  "dev": true,
+                  "requires": {
+                    "bytes": "2.1.0",
+                    "content-type": "1.0.2",
+                    "debug": "2.2.0",
+                    "depd": "1.0.1",
+                    "http-errors": "1.3.1",
+                    "iconv-lite": "0.4.11",
+                    "on-finished": "2.3.0",
+                    "qs": "4.0.0",
+                    "raw-body": "2.1.7",
+                    "type-is": "1.6.15"
+                  },
+                  "dependencies": {
+                    "iconv-lite": {
+                      "version": "0.4.11",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+                      "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
+                      "dev": true
+                    },
+                    "raw-body": {
+                      "version": "2.1.7",
+                      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+                      "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+                      "dev": true,
+                      "requires": {
+                        "bytes": "2.4.0",
+                        "iconv-lite": "0.4.13",
+                        "unpipe": "1.0.0"
+                      },
+                      "dependencies": {
+                        "bytes": {
+                          "version": "2.4.0",
+                          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+                          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+                          "dev": true
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+                          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+                          "dev": true
+                        },
+                        "unpipe": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "bytes": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+                  "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q=",
+                  "dev": true
+                },
+                "compression": {
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
+                  "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
+                  "dev": true,
+                  "requires": {
+                    "accepts": "1.2.13",
+                    "bytes": "2.1.0",
+                    "compressible": "2.0.10",
+                    "debug": "2.2.0",
+                    "on-headers": "1.0.1",
+                    "vary": "1.0.1"
+                  },
+                  "dependencies": {
+                    "accepts": {
+                      "version": "1.2.13",
+                      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+                      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+                      "dev": true,
+                      "requires": {
+                        "mime-types": "2.1.15",
+                        "negotiator": "0.5.3"
+                      },
+                      "dependencies": {
+                        "mime-types": {
+                          "version": "2.1.15",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                          "dev": true,
+                          "requires": {
+                            "mime-db": "1.27.0"
+                          },
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.27.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                              "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "negotiator": {
+                          "version": "0.5.3",
+                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+                          "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "compressible": {
+                      "version": "2.0.10",
+                      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
+                      "integrity": "sha1-/tocf3YXkScyspv4zyYlKiC57s0=",
+                      "dev": true,
+                      "requires": {
+                        "mime-db": "1.27.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.27.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "vary": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+                      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA=",
+                      "dev": true
+                    }
+                  }
+                },
+                "connect-timeout": {
+                  "version": "1.6.2",
+                  "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
+                  "integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
+                  "dev": true,
+                  "requires": {
+                    "debug": "2.2.0",
+                    "http-errors": "1.3.1",
+                    "ms": "0.7.1",
+                    "on-headers": "1.0.1"
+                  },
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                      "dev": true
+                    }
+                  }
+                },
+                "content-type": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+                  "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
+                  "dev": true
+                },
+                "cookie": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
+                  "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
+                  "dev": true
+                },
+                "cookie-parser": {
+                  "version": "1.3.5",
+                  "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+                  "integrity": "sha1-nXVVcPtdF4kHcSJ6AjFNm+fPg1Y=",
+                  "dev": true,
+                  "requires": {
+                    "cookie": "0.1.3",
+                    "cookie-signature": "1.0.6"
+                  }
+                },
+                "cookie-signature": {
+                  "version": "1.0.6",
+                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                  "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+                  "dev": true
+                },
+                "csurf": {
+                  "version": "1.8.3",
+                  "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
+                  "integrity": "sha1-I/KhO/HY/OHQyZZYg5RELLqGpWo=",
+                  "dev": true,
+                  "requires": {
+                    "cookie": "0.1.3",
+                    "cookie-signature": "1.0.6",
+                    "csrf": "3.0.6",
+                    "http-errors": "1.3.1"
+                  },
+                  "dependencies": {
+                    "csrf": {
+                      "version": "3.0.6",
+                      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
+                      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+                      "dev": true,
+                      "requires": {
+                        "rndm": "1.2.0",
+                        "tsscmp": "1.0.5",
+                        "uid-safe": "2.1.4"
+                      },
+                      "dependencies": {
+                        "rndm": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
+                          "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=",
+                          "dev": true
+                        },
+                        "tsscmp": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
+                          "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc=",
+                          "dev": true
+                        },
+                        "uid-safe": {
+                          "version": "2.1.4",
+                          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
+                          "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
+                          "dev": true,
+                          "requires": {
+                            "random-bytes": "1.0.0"
+                          },
+                          "dependencies": {
+                            "random-bytes": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+                              "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "depd": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+                  "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
+                  "dev": true
+                },
+                "errorhandler": {
+                  "version": "1.4.3",
+                  "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
+                  "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
+                  "dev": true,
+                  "requires": {
+                    "accepts": "1.3.3",
+                    "escape-html": "1.0.3"
+                  },
+                  "dependencies": {
+                    "accepts": {
+                      "version": "1.3.3",
+                      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+                      "dev": true,
+                      "requires": {
+                        "mime-types": "2.1.15",
+                        "negotiator": "0.6.1"
+                      },
+                      "dependencies": {
+                        "mime-types": {
+                          "version": "2.1.15",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                          "dev": true,
+                          "requires": {
+                            "mime-db": "1.27.0"
+                          },
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.27.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                              "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "negotiator": {
+                          "version": "0.6.1",
+                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "escape-html": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+                      "dev": true
+                    }
+                  }
+                },
+                "express-session": {
+                  "version": "1.11.3",
+                  "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
+                  "integrity": "sha1-XMmPP1/4Ttg1+Ry/CqvQxxB0AK8=",
+                  "dev": true,
+                  "requires": {
+                    "cookie": "0.1.3",
+                    "cookie-signature": "1.0.6",
+                    "crc": "3.3.0",
+                    "debug": "2.2.0",
+                    "depd": "1.0.1",
+                    "on-headers": "1.0.1",
+                    "parseurl": "1.3.1",
+                    "uid-safe": "2.0.0",
+                    "utils-merge": "1.0.0"
+                  },
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.3.0",
+                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
+                      "integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo=",
+                      "dev": true
+                    },
+                    "uid-safe": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+                      "integrity": "sha1-p/PGymSh9qXQTsDvPkw9U2cxcTc=",
+                      "dev": true,
+                      "requires": {
+                        "base64-url": "1.2.1"
+                      },
+                      "dependencies": {
+                        "base64-url": {
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
+                          "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "finalhandler": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
+                  "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
+                  "dev": true,
+                  "requires": {
+                    "debug": "2.2.0",
+                    "escape-html": "1.0.2",
+                    "on-finished": "2.3.0",
+                    "unpipe": "1.0.0"
+                  },
+                  "dependencies": {
+                    "escape-html": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
+                      "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw=",
+                      "dev": true
+                    },
+                    "unpipe": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+                      "dev": true
+                    }
+                  }
+                },
+                "fresh": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                  "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
+                  "dev": true
+                },
+                "http-errors": {
+                  "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                  "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "statuses": "1.3.1"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "statuses": {
+                      "version": "1.3.1",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+                      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+                      "dev": true
+                    }
+                  }
+                },
+                "method-override": {
+                  "version": "2.3.8",
+                  "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.8.tgz",
+                  "integrity": "sha1-F4I0v0urhp+J35REsG/GFHtEgow=",
+                  "dev": true,
+                  "requires": {
+                    "debug": "2.6.3",
+                    "methods": "1.1.2",
+                    "parseurl": "1.3.1",
+                    "vary": "1.1.1"
+                  },
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.6.3",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+                      "integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
+                      "dev": true,
+                      "requires": {
+                        "ms": "0.7.2"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "methods": {
+                      "version": "1.1.2",
+                      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+                      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+                      "dev": true
+                    },
+                    "vary": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+                      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "morgan": {
+                  "version": "1.6.1",
+                  "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
+                  "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
+                  "dev": true,
+                  "requires": {
+                    "basic-auth": "1.0.4",
+                    "debug": "2.2.0",
+                    "depd": "1.0.1",
+                    "on-finished": "2.3.0",
+                    "on-headers": "1.0.1"
+                  },
+                  "dependencies": {
+                    "basic-auth": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
+                      "integrity": "sha1-Awk1sB3nyblKgksp8/zLdQ06UpA=",
+                      "dev": true
+                    }
+                  }
+                },
+                "multiparty": {
+                  "version": "3.3.2",
+                  "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+                  "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "1.1.14",
+                    "stream-counter": "0.2.0"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "stream-counter": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
+                      "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
+                      "dev": true,
+                      "requires": {
+                        "readable-stream": "1.1.14"
+                      }
+                    }
+                  }
+                },
+                "on-headers": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+                  "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+                  "dev": true
+                },
+                "parseurl": {
+                  "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+                  "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+                  "dev": true
+                },
+                "pause": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
+                  "integrity": "sha1-68ikqGGf8LioGsFRPDQ0/0af23Q=",
+                  "dev": true
+                },
+                "qs": {
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+                  "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+                  "dev": true
+                },
+                "response-time": {
+                  "version": "2.3.2",
+                  "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+                  "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+                  "dev": true,
+                  "requires": {
+                    "depd": "1.1.0",
+                    "on-headers": "1.0.1"
+                  },
+                  "dependencies": {
+                    "depd": {
+                      "version": "1.1.0",
+                      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
+                      "dev": true
+                    }
+                  }
+                },
+                "serve-favicon": {
+                  "version": "2.3.2",
+                  "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
+                  "integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
+                  "dev": true,
+                  "requires": {
+                    "etag": "1.7.0",
+                    "fresh": "0.3.0",
+                    "ms": "0.7.2",
+                    "parseurl": "1.3.1"
+                  },
+                  "dependencies": {
+                    "etag": {
+                      "version": "1.7.0",
+                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
+                      "dev": true
+                    },
+                    "ms": {
+                      "version": "0.7.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                      "dev": true
+                    }
+                  }
+                },
+                "serve-index": {
+                  "version": "1.7.3",
+                  "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
+                  "integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
+                  "dev": true,
+                  "requires": {
+                    "accepts": "1.2.13",
+                    "batch": "0.5.3",
+                    "debug": "2.2.0",
+                    "escape-html": "1.0.3",
+                    "http-errors": "1.3.1",
+                    "mime-types": "2.1.15",
+                    "parseurl": "1.3.1"
+                  },
+                  "dependencies": {
+                    "accepts": {
+                      "version": "1.2.13",
+                      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+                      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+                      "dev": true,
+                      "requires": {
+                        "mime-types": "2.1.15",
+                        "negotiator": "0.5.3"
+                      },
+                      "dependencies": {
+                        "negotiator": {
+                          "version": "0.5.3",
+                          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+                          "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "batch": {
+                      "version": "0.5.3",
+                      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+                      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
+                      "dev": true
+                    },
+                    "escape-html": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+                      "dev": true
+                    },
+                    "mime-types": {
+                      "version": "2.1.15",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                      "dev": true,
+                      "requires": {
+                        "mime-db": "1.27.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.27.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "serve-static": {
+                  "version": "1.10.3",
+                  "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+                  "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+                  "dev": true,
+                  "requires": {
+                    "escape-html": "1.0.3",
+                    "parseurl": "1.3.1",
+                    "send": "0.13.2"
+                  },
+                  "dependencies": {
+                    "escape-html": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+                      "dev": true
+                    },
+                    "send": {
+                      "version": "0.13.2",
+                      "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+                      "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
+                      "dev": true,
+                      "requires": {
+                        "debug": "2.2.0",
+                        "depd": "1.1.0",
+                        "destroy": "1.0.4",
+                        "escape-html": "1.0.3",
+                        "etag": "1.7.0",
+                        "fresh": "0.3.0",
+                        "http-errors": "1.3.1",
+                        "mime": "1.3.4",
+                        "ms": "0.7.1",
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.0.3",
+                        "statuses": "1.2.1"
+                      },
+                      "dependencies": {
+                        "depd": {
+                          "version": "1.1.0",
+                          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                          "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
+                          "dev": true
+                        },
+                        "destroy": {
+                          "version": "1.0.4",
+                          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+                          "dev": true
+                        },
+                        "etag": {
+                          "version": "1.7.0",
+                          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
+                          "dev": true
+                        },
+                        "mime": {
+                          "version": "1.3.4",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+                          "dev": true
+                        },
+                        "ms": {
+                          "version": "0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                          "dev": true
+                        },
+                        "range-parser": {
+                          "version": "1.0.3",
+                          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+                          "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU=",
+                          "dev": true
+                        },
+                        "statuses": {
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "type-is": {
+                  "version": "1.6.15",
+                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+                  "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+                  "dev": true,
+                  "requires": {
+                    "media-typer": "0.3.0",
+                    "mime-types": "2.1.15"
+                  },
+                  "dependencies": {
+                    "media-typer": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+                      "dev": true
+                    },
+                    "mime-types": {
+                      "version": "2.1.15",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+                      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+                      "dev": true,
+                      "requires": {
+                        "mime-db": "1.27.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.27.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+                          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+                  "dev": true
+                },
+                "vhost": {
+                  "version": "3.0.2",
+                  "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
+                  "integrity": "sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=",
+                  "dev": true
+                }
+              }
+            },
+            "event-stream": {
+              "version": "3.3.4",
+              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+              "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+              "dev": true,
+              "requires": {
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
+              },
+              "dependencies": {
+                "duplexer": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+                  "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+                  "dev": true
+                },
+                "from": {
+                  "version": "0.1.7",
+                  "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+                  "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+                  "dev": true
+                },
+                "map-stream": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+                  "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+                  "dev": true
+                },
+                "pause-stream": {
+                  "version": "0.0.11",
+                  "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+                  "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+                  "dev": true,
+                  "requires": {
+                    "through": "2.3.8"
+                  }
+                },
+                "split": {
+                  "version": "0.3.3",
+                  "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+                  "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+                  "dev": true,
+                  "requires": {
+                    "through": "2.3.8"
+                  }
+                },
+                "stream-combiner": {
+                  "version": "0.0.4",
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                  "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+                  "dev": true,
+                  "requires": {
+                    "duplexer": "0.1.1"
+                  }
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+                  "dev": true
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.9.4",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
+              "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
+              "dev": true,
+              "requires": {
+                "websocket-driver": "0.6.5"
+              },
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.5",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+                  "dev": true,
+                  "requires": {
+                    "websocket-extensions": "0.1.1"
+                  },
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                      "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+              "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+              "dev": true
+            },
+            "opn": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+              "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+              "dev": true,
+              "requires": {
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
+              },
+              "dependencies": {
+                "object-assign": {
+                  "version": "4.1.1",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                  "dev": true
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "dev": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "send": {
+              "version": "0.15.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.15.1.tgz",
+              "integrity": "sha1-igI1TCbm9cynAAZfXwzeupDse18=",
+              "dev": true,
+              "requires": {
+                "debug": "2.6.1",
+                "depd": "1.1.0",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.8.0",
+                "fresh": "0.5.0",
+                "http-errors": "1.6.1",
+                "mime": "1.3.4",
+                "ms": "0.7.2",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.3.1"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.1",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+                  "integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
+                  "dev": true,
+                  "requires": {
+                    "ms": "0.7.2"
+                  }
+                },
+                "depd": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                  "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
+                  "dev": true
+                },
+                "destroy": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                  "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+                  "dev": true
+                },
+                "encodeurl": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+                  "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+                  "dev": true
+                },
+                "escape-html": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                  "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+                  "dev": true
+                },
+                "etag": {
+                  "version": "1.8.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+                  "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+                  "dev": true
+                },
+                "fresh": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+                  "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+                  "dev": true
+                },
+                "http-errors": {
+                  "version": "1.6.1",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+                  "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+                  "dev": true,
+                  "requires": {
+                    "depd": "1.1.0",
+                    "inherits": "2.0.3",
+                    "setprototypeof": "1.0.3",
+                    "statuses": "1.3.1"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "setprototypeof": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+                      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+                  "dev": true
+                },
+                "ms": {
+                  "version": "0.7.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                  "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                  "dev": true
+                },
+                "range-parser": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                  "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+                  "dev": true
+                },
+                "statuses": {
+                  "version": "1.3.1",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+                  "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+                  "dev": true
+                }
+              }
+            },
+            "watchr": {
+              "version": "2.3.10",
+              "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.3.10.tgz",
+              "integrity": "sha1-L+CvU3BxyuandtRSM1b486Iwt84=",
+              "dev": true,
+              "requires": {
+                "bal-util": "1.18.0"
+              },
+              "dependencies": {
+                "bal-util": {
+                  "version": "1.18.0",
+                  "resolved": "https://registry.npmjs.org/bal-util/-/bal-util-1.18.0.tgz",
+                  "integrity": "sha1-Ti4tkIFtGmt+NxdAIAQqLOJYQh0=",
+                  "dev": true,
+                  "requires": {
+                    "ambi": "2.0.0",
+                    "eachr": "2.0.4",
+                    "extendr": "2.0.1",
+                    "getsetdeep": "2.0.0",
+                    "safecallback": "1.0.1",
+                    "safefs": "2.0.3",
+                    "taskgroup": "2.0.0",
+                    "typechecker": "2.0.8"
+                  },
+                  "dependencies": {
+                    "ambi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/ambi/-/ambi-2.0.0.tgz",
+                      "integrity": "sha1-QsK/mOjRAapNooqBJnil2+Nq2mY=",
+                      "dev": true,
+                      "requires": {
+                        "typechecker": "2.0.8"
+                      }
+                    },
+                    "eachr": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
+                      "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
+                      "dev": true,
+                      "requires": {
+                        "typechecker": "2.0.8"
+                      }
+                    },
+                    "extendr": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.0.1.tgz",
+                      "integrity": "sha1-2Ks3X8u4M+S6LNIoVA8E5KoH3pA=",
+                      "dev": true,
+                      "requires": {
+                        "typechecker": "2.0.8"
+                      }
+                    },
+                    "getsetdeep": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/getsetdeep/-/getsetdeep-2.0.0.tgz",
+                      "integrity": "sha1-8TOE/mVtCj9BwhTL3zEAGlfBJJI=",
+                      "dev": true,
+                      "requires": {
+                        "typechecker": "2.0.8"
+                      }
+                    },
+                    "safecallback": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/safecallback/-/safecallback-1.0.1.tgz",
+                      "integrity": "sha1-B8fxK0qNmr8bj83bp4UusLi27UE=",
+                      "dev": true
+                    },
+                    "safefs": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/safefs/-/safefs-2.0.3.tgz",
+                      "integrity": "sha1-LbKy3kxBYdbbpmCf7gXsqwYsTeU=",
+                      "dev": true
+                    },
+                    "taskgroup": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-2.0.0.tgz",
+                      "integrity": "sha1-GElEpCtWhKrXURiaUmPAMPYXREY=",
+                      "dev": true,
+                      "requires": {
+                        "ambi": "2.0.0",
+                        "typechecker": "2.0.8"
+                      }
+                    },
+                    "typechecker": {
+                      "version": "2.0.8",
+                      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
+                      "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "q": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+          "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+        },
+        "trace-and-clarify-if-possible": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/trace-and-clarify-if-possible/-/trace-and-clarify-if-possible-1.0.0.tgz",
+          "integrity": "sha1-8QlCVnCMQifWZ/kJEn4lvLv2B2o=",
+          "dev": true,
+          "requires": {
+            "clarify": "2.0.0",
+            "trace": "2.4.1"
+          },
+          "dependencies": {
+            "clarify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/clarify/-/clarify-2.0.0.tgz",
+              "integrity": "sha1-eDS3pui44Y2N/Sa899aVblNaE9o=",
+              "dev": true,
+              "requires": {
+                "stack-chain": "1.3.7"
+              },
+              "dependencies": {
+                "stack-chain": {
+                  "version": "1.3.7",
+                  "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+                  "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
+                  "dev": true
+                }
+              }
+            },
+            "trace": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/trace/-/trace-2.4.1.tgz",
+              "integrity": "sha1-0NXM42df61wTe4LvrCCg8XOjiCU=",
+              "dev": true,
+              "requires": {
+                "async-hook": "1.7.1",
+                "stack-chain": "1.3.7"
+              },
+              "dependencies": {
+                "async-hook": {
+                  "version": "1.7.1",
+                  "resolved": "https://registry.npmjs.org/async-hook/-/async-hook-1.7.1.tgz",
+                  "integrity": "sha1-38fZAjbkWosEvnwejIECS2vOnCo=",
+                  "dev": true,
+                  "requires": {
+                    "stack-chain": "1.3.7"
+                  }
+                },
+                "stack-chain": {
+                  "version": "1.3.7",
+                  "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+                  "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bootprint-swagger": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/bootprint-swagger/-/bootprint-swagger-0.13.1.tgz",
+      "integrity": "sha1-73HwuuKxZwoZSkx1IvUAv2HBUs8=",
+      "dev": true,
+      "requires": {
+        "bootprint-json-schema": "0.8.6",
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "bootprint-json-schema": {
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/bootprint-json-schema/-/bootprint-json-schema-0.8.6.tgz",
+          "integrity": "sha1-u6mmzGo1KIncZMr4D37sxwmP7qI=",
+          "dev": true,
+          "requires": {
+            "bootprint-base": "0.7.2"
+          },
+          "dependencies": {
+            "bootprint-base": {
+              "version": "0.7.2",
+              "resolved": "https://registry.npmjs.org/bootprint-base/-/bootprint-base-0.7.2.tgz",
+              "integrity": "sha1-uEIVbV6UZ9JSv/uszLUn+rGLy2s=",
+              "dev": true,
+              "requires": {
+                "bootstrap": "3.3.7",
+                "cheerio": "0.19.0",
+                "handlebars": "3.0.3",
+                "highlight.js": "8.9.1",
+                "json-stable-stringify": "1.0.1",
+                "marked": "0.3.6"
+              },
+              "dependencies": {
+                "bootstrap": {
+                  "version": "3.3.7",
+                  "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+                  "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E=",
+                  "dev": true
+                },
+                "cheerio": {
+                  "version": "0.19.0",
+                  "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+                  "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
+                  "dev": true,
+                  "requires": {
+                    "css-select": "1.0.0",
+                    "dom-serializer": "0.1.0",
+                    "entities": "1.1.1",
+                    "htmlparser2": "3.8.3",
+                    "lodash": "3.10.1"
+                  },
+                  "dependencies": {
+                    "css-select": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+                      "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
+                      "dev": true,
+                      "requires": {
+                        "boolbase": "1.0.0",
+                        "css-what": "1.0.0",
+                        "domutils": "1.4.3",
+                        "nth-check": "1.0.1"
+                      },
+                      "dependencies": {
+                        "boolbase": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+                          "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+                          "dev": true
+                        },
+                        "css-what": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+                          "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w=",
+                          "dev": true
+                        },
+                        "domutils": {
+                          "version": "1.4.3",
+                          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                          "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+                          "dev": true,
+                          "requires": {
+                            "domelementtype": "1.3.0"
+                          },
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.3.0",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                              "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "nth-check": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+                          "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+                          "dev": true,
+                          "requires": {
+                            "boolbase": "1.0.0"
+                          }
+                        }
+                      }
+                    },
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+                      "dev": true,
+                      "requires": {
+                        "domelementtype": "1.1.3",
+                        "entities": "1.1.1"
+                      },
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+                      "dev": true
+                    },
+                    "htmlparser2": {
+                      "version": "3.8.3",
+                      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+                      "dev": true,
+                      "requires": {
+                        "domelementtype": "1.3.0",
+                        "domhandler": "2.3.0",
+                        "domutils": "1.5.1",
+                        "entities": "1.0.0",
+                        "readable-stream": "1.1.14"
+                      },
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.3.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                          "dev": true
+                        },
+                        "domhandler": {
+                          "version": "2.3.0",
+                          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+                          "dev": true,
+                          "requires": {
+                            "domelementtype": "1.3.0"
+                          }
+                        },
+                        "domutils": {
+                          "version": "1.5.1",
+                          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+                          "dev": true,
+                          "requires": {
+                            "dom-serializer": "0.1.0",
+                            "domelementtype": "1.3.0"
+                          }
+                        },
+                        "entities": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+                          "dev": true
+                        },
+                        "readable-stream": {
+                          "version": "1.1.14",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                          "dev": true,
+                          "requires": {
+                            "core-util-is": "1.0.2",
+                            "inherits": "2.0.3",
+                            "isarray": "0.0.1",
+                            "string_decoder": "0.10.31"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                              "dev": true
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                              "dev": true
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                              "dev": true
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "handlebars": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+                  "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
+                  "dev": true,
+                  "requires": {
+                    "optimist": "0.6.1",
+                    "source-map": "0.1.43",
+                    "uglify-js": "2.3.6"
+                  },
+                  "dependencies": {
+                    "optimist": {
+                      "version": "0.6.1",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                      "dev": true,
+                      "requires": {
+                        "minimist": "0.0.10",
+                        "wordwrap": "0.0.3"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.10",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                          "dev": true
+                        },
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                      "dev": true,
+                      "requires": {
+                        "amdefine": "1.0.0"
+                      },
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "uglify-js": {
+                      "version": "2.3.6",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "async": "0.2.10",
+                        "optimist": "0.3.7",
+                        "source-map": "0.1.43"
+                      },
+                      "dependencies": {
+                        "async": {
+                          "version": "0.2.10",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "optimist": {
+                          "version": "0.3.7",
+                          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "wordwrap": "0.0.3"
+                          },
+                          "dependencies": {
+                            "wordwrap": {
+                              "version": "0.0.3",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "highlight.js": {
+                  "version": "8.9.1",
+                  "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.9.1.tgz",
+                  "integrity": "sha1-uKnFSTISqTkvAiK2SclhFJfr+4g=",
+                  "dev": true
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                  "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                  "dev": true,
+                  "requires": {
+                    "jsonify": "0.0.0"
+                  },
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+                      "dev": true
+                    }
+                  }
+                },
+                "marked": {
+                  "version": "0.3.6",
+                  "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+                  "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "bson": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+      "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
+    },
+    "buffer-writer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+    },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "requires": {
+        "long": "3.2.0"
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
+    },
+    "chai": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-2.3.0.tgz",
+      "integrity": "sha1-ii9qNHSNqAEJD9cyh7Kqc5pOkJo=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      },
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+          "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+          "dev": true
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "chai-as-promised": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-4.3.0.tgz",
+      "integrity": "sha1-D6hhsLMb/mhn9edw8Ph3vmDs5e4=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+      "requires": {
+        "ansi-styles": "1.0.0",
+        "has-color": "0.1.7",
+        "strip-ansi": "0.1.1"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+        }
+      }
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        }
+      }
+    },
+    "consul": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/consul/-/consul-0.27.0.tgz",
+      "integrity": "sha1-PYyIwqDYdTaa/EYJiDBJlSj8dMQ=",
+      "requires": {
+        "papi": "0.27.0"
+      },
+      "dependencies": {
+        "papi": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/papi/-/papi-0.27.0.tgz",
+          "integrity": "sha1-c5Kjjr76f7Z+mLNjvKPRNoJ8ryg="
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.0.tgz",
+      "integrity": "sha1-YmKIikn5zkxdGJ0p4dVxCrc+aoU=",
+      "requires": {
+        "vary": "1.1.0"
+      },
+      "dependencies": {
+        "vary": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+          "integrity": "sha1-4eWv+70WrnaN0mdDlLmtMCJlMUA="
+        }
+      }
+    },
+    "coveralls": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.12.tgz",
+      "integrity": "sha1-7DBpy3U8zQq9kltu2NeQhqnIALE=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.0.1",
+        "lcov-parse": "0.0.6",
+        "log-driver": "1.2.4",
+        "minimist": "1.2.0",
+        "request": "2.74.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
+          "integrity": "sha1-dkBf6lvOMPyPQF1Ixtyn8KMsav4=",
+          "dev": true,
+          "requires": {
+            "argparse": "0.1.16",
+            "esprima": "1.0.4"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+              "dev": true,
+              "requires": {
+                "underscore": "1.7.0",
+                "underscore.string": "2.4.0"
+              },
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+                  "dev": true
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+              "dev": true
+            }
+          }
+        },
+        "lcov-parse": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz",
+          "integrity": "sha1-gZ5dqL8HkfnT857qXtGGgYfxEXU=",
+          "dev": true
+        },
+        "log-driver": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz",
+          "integrity": "sha1-LWLX+u9F2KcTQZYaBLB2HsqZz6M=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.4.1",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.1",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.11",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.1",
+            "tunnel-agent": "0.4.3"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "dev": true
+            },
+            "aws4": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+              "dev": true
+            },
+            "bl": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "dev": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+              "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+              "dev": true,
+              "requires": {
+                "async": "2.0.1",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.11"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                  "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+                  "dev": true,
+                  "requires": {
+                    "lodash": "4.15.0"
+                  },
+                  "dependencies": {
+                    "lodash": {
+                      "version": "4.15.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+                      "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.13.1",
+                "pinkie-promise": "2.0.1"
+              },
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                      "dev": true
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                      "dev": true
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
+                  "dev": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "2.0.0",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "dev": true
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "dev": true,
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "dev": true
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "dev": true
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "dev": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "dev": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "dev": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "dev": true
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.3.0",
+                "sshpk": "1.10.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                  "dev": true
+                },
+                "jsprim": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                  "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+                  "dev": true,
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.2",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "dev": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "dev": true
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "dev": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+                  "integrity": "sha1-EE1roq+yrAmauVZ8DRk5d/Kcbfo=",
+                  "dev": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.0",
+                    "dashdash": "1.14.0",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.6",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.13.3"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "dev": true
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                      "dev": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.3"
+                      },
+                      "dependencies": {
+                        "tweetnacl": {
+                          "version": "0.14.3",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                      "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+              "dev": true,
+              "requires": {
+                "mime-db": "1.23.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
+                  "dev": true
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "dev": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "dev": true
+            },
+            "qs": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+              "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+              "dev": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "dev": true
+            },
+            "tough-cookie": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+              "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+              "dev": true
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "crypt3": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypt3/-/crypt3-1.0.0.tgz",
+      "integrity": "sha1-imWPHRaZm1UFrclszNe8aDIUvv4=",
+      "requires": {
+        "nan": "2.9.2",
+        "q": "1.5.1"
+      }
+    },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
+      }
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "di": {
+      "version": "git+https://github.com/RackHD/di.js.git#f903386e063460930b757c11a1d510ca0a77f638",
+      "requires": {
+        "es6-shim": "0.11.1",
+        "traceur": "0.0.111"
+      },
+      "dependencies": {
+        "es6-shim": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.11.1.tgz",
+          "integrity": "sha1-68OuSF71prxTSUx9FuSj7jbs8QM="
+        }
+      }
+    },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
+    "docker-modem": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.5.tgz",
+      "integrity": "sha512-i3J4TYW9iNp+nWzkgGvj9UwSmT6ZUFg2OsjRlUraHCaDCv8z6f0fN3q4ur0Qq27/1GPYXSjShGaE7fDznIJKUg==",
+      "requires": {
+        "JSONStream": "1.3.2",
+        "debug": "3.1.0",
+        "readable-stream": "1.0.31",
+        "split-ca": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "dockerode": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.5.4.tgz",
+      "integrity": "sha512-esqrDATdckYhkOFn4BSOrqnkj3jgBkHT07uEqTRwK6na4/Rg60vjXWRopv2BbRpvFruMmKvOSNVY4MbmVBUnWw==",
+      "requires": {
+        "concat-stream": "1.5.2",
+        "docker-modem": "1.0.5",
+        "tar-fs": "1.12.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ejs": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.1.tgz",
+      "integrity": "sha1-28CsQIEtO0UdrQY/zTaeTkfYAoc="
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "es6-promise": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+    },
+    "es6-shim": {
+      "version": "0.22.2",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.22.2.tgz",
+      "integrity": "sha1-Sv58VLuSsXjl1GTdXZwxxXQtdSE="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "eventemitter2": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+    },
+    "express": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+      "integrity": "sha1-we4/Qs3Ikfs9xlCoki1R7IR9DWY=",
+      "requires": {
+        "accepts": "1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.2.0",
+        "depd": "1.1.0",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.7.0",
+        "finalhandler": "0.5.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.1.2",
+        "qs": "6.2.0",
+        "range-parser": "1.2.0",
+        "send": "0.14.1",
+        "serve-static": "1.11.1",
+        "type-is": "1.6.13",
+        "utils-merge": "1.0.0",
+        "vary": "1.1.0"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+          "requires": {
+            "mime-types": "2.1.11",
+            "negotiator": "0.6.1"
+          },
+          "dependencies": {
+            "mime-types": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+              "requires": {
+                "mime-db": "1.23.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                }
+              }
+            },
+            "negotiator": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+              "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+            }
+          }
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+          "integrity": "sha1-h0dsamfI2qh+Muh2Ft+IO6f7Bxs="
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+          "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+        },
+        "depd": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+          "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+          "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+        },
+        "etag": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+          "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
+          "requires": {
+            "debug": "2.2.0",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "statuses": "1.3.0",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "statuses": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+              "integrity": "sha1-jlV1jLIOdoLB9Pzo3KswvwHR4Ho="
+            },
+            "unpipe": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            }
+          }
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+        },
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "proxy-addr": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+          "integrity": "sha1-tMxfImENlTWCTBI675089zxAujc=",
+          "requires": {
+            "forwarded": "0.1.0",
+            "ipaddr.js": "1.1.1"
+          },
+          "dependencies": {
+            "forwarded": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+              "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+            },
+            "ipaddr.js": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+              "integrity": "sha1-x5HZX1KynBJH1d+AraObinNkcjA="
+            }
+          }
+        },
+        "qs": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+          "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs="
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        },
+        "send": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+          "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
+          "requires": {
+            "debug": "2.2.0",
+            "depd": "1.1.0",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.7.0",
+            "fresh": "0.3.0",
+            "http-errors": "1.5.0",
+            "mime": "1.3.4",
+            "ms": "0.7.1",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.0"
+          },
+          "dependencies": {
+            "destroy": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+              "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+            },
+            "http-errors": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+              "integrity": "sha1-scs9gmD9jiOGytMYkEWUM3LUghE=",
+              "requires": {
+                "inherits": "2.0.1",
+                "setprototypeof": "1.0.1",
+                "statuses": "1.3.0"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "setprototypeof": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+                  "integrity": "sha1-UgCbJ4iMTcSPWRlJwKgnWDTByn4="
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+            },
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+            },
+            "statuses": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+              "integrity": "sha1-jlV1jLIOdoLB9Pzo3KswvwHR4Ho="
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+          "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.1",
+            "send": "0.14.1"
+          }
+        },
+        "type-is": {
+          "version": "1.6.13",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "integrity": "sha1-boO6e8MM0zp7sLf7AHN6IIW/nQg=",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.11"
+          },
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+              "requires": {
+                "mime-db": "1.23.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                }
+              }
+            }
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+        },
+        "vary": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+          "integrity": "sha1-4eWv+70WrnaN0mdDlLmtMCJlMUA="
+        }
+      }
+    },
+    "express-urlrewrite": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-urlrewrite/-/express-urlrewrite-1.2.0.tgz",
+      "integrity": "sha1-jmZ7d2H/HH/9sO+gXWQDU4fII+s=",
+      "requires": {
+        "debug": "2.2.0",
+        "path-to-regexp": "1.5.3"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz",
+          "integrity": "sha1-ciHd1CSDU4vd+f6tlCp5/zFk9Xo=",
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            }
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "flat": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-1.6.1.tgz",
+      "integrity": "sha1-R2udu3DV6TQNu8A4veCEoglFkhw=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "fs-extra": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "requires": {
+        "graceful-fs": "4.1.6",
+        "jsonfile": "2.3.1",
+        "klaw": "1.3.0",
+        "path-is-absolute": "1.0.0",
+        "rimraf": "2.5.4"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+          "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4="
+        },
+        "jsonfile": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
+          "integrity": "sha1-KLyynFlrW3qv005mKjKbpizYQvw="
+        },
+        "klaw": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
+          "integrity": "sha1-iFe/vB2CS63xPT0CQdi75G+xL3M="
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+        }
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "generic-pool": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz",
+      "integrity": "sha1-iGvFvwvrfblugby7oHiBjeWmJoM="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "glob": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+      "requires": {
+        "inflight": "1.0.5",
+        "inherits": "2.0.1",
+        "minimatch": "2.0.10",
+        "once": "1.3.3"
+      },
+      "dependencies": {
+        "inflight": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+          "requires": {
+            "once": "1.3.3",
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "1.1.6"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              },
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            }
+          }
+        }
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
+    "grpc": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.7.3.tgz",
+      "integrity": "sha512-7zXQJlDXMr/ZaDqdaIchgclViyoWo8GQxZSmFUAxR8GwSr28b6/BTgF221WG+2W693jpp74XJ/+I9DcPXsgt9Q==",
+      "requires": {
+        "arguejs": "0.2.3",
+        "lodash": "4.17.5",
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.6.39",
+        "protobufjs": "5.0.2"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        },
+        "mime-db": {
+          "version": "1.30.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.17",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.30.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.2",
+            "request": "2.81.0",
+            "rimraf": "2.6.2",
+            "semver": "5.4.1",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.1"
+          },
+          "dependencies": {
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.0.9",
+                "osenv": "0.1.4"
+              }
+            }
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.3.3",
+            "rimraf": "2.6.2",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "1.3.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
+      "dev": true,
+      "requires": {
+        "async": "0.1.22",
+        "coffee-script": "1.3.3",
+        "colors": "0.6.2",
+        "dateformat": "1.0.2-1.2.3",
+        "eventemitter2": "0.4.14",
+        "exit": "0.1.2",
+        "findup-sync": "0.1.3",
+        "getobject": "0.1.0",
+        "glob": "3.1.21",
+        "grunt-legacy-log": "0.1.3",
+        "grunt-legacy-util": "0.2.0",
+        "hooker": "0.2.3",
+        "iconv-lite": "0.2.11",
+        "js-yaml": "2.0.5",
+        "lodash": "0.9.2",
+        "minimatch": "0.2.14",
+        "nopt": "1.0.10",
+        "rimraf": "2.2.8",
+        "underscore.string": "2.2.1",
+        "which": "1.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
+          "dev": true
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
+          "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
+          "dev": true
+        },
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+          "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
+          "dev": true
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+          "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+          "dev": true
+        },
+        "exit": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+          "dev": true
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+          "dev": true,
+          "requires": {
+            "glob": "3.2.11",
+            "lodash": "2.4.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "minimatch": "0.3.0"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            }
+          }
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+          "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+              "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+              "dev": true
+            }
+          }
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+          "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
+          "dev": true,
+          "requires": {
+            "colors": "0.6.2",
+            "grunt-legacy-log-utils": "0.1.1",
+            "hooker": "0.2.3",
+            "lodash": "2.4.2",
+            "underscore.string": "2.3.3"
+          },
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+              "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
+              "dev": true,
+              "requires": {
+                "colors": "0.6.2",
+                "lodash": "2.4.2",
+                "underscore.string": "2.3.3"
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+              "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
+              "dev": true
+            }
+          }
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+          "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
+          "dev": true,
+          "requires": {
+            "async": "0.1.22",
+            "exit": "0.1.2",
+            "getobject": "0.1.0",
+            "hooker": "0.2.3",
+            "lodash": "0.9.2",
+            "underscore.string": "2.2.1",
+            "which": "1.0.9"
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+          "dev": true,
+          "requires": {
+            "argparse": "0.1.16",
+            "esprima": "1.0.4"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+              "dev": true,
+              "requires": {
+                "underscore": "1.7.0",
+                "underscore.string": "2.4.0"
+              },
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+                  "dev": true
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
+          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+              "dev": true
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+              "dev": true
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
+          "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-cli": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "0.1.3",
+        "nopt": "1.0.10",
+        "resolve": "0.3.1"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+          "dev": true,
+          "requires": {
+            "glob": "3.2.11",
+            "lodash": "2.4.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+              "dev": true,
+              "requires": {
+                "inherits": "2.0.1",
+                "minimatch": "0.3.0"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+              "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+              "dev": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+          "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
+          "dev": true
+        }
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.11.3.tgz",
+      "integrity": "sha1-gDaBgdzNVRGG5bg4XAEc7iTWQKA=",
+      "dev": true,
+      "requires": {
+        "hooker": "0.2.3",
+        "jshint": "2.8.0"
+      },
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+          "dev": true
+        },
+        "jshint": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
+          "integrity": "sha1-HQmjvZE8TK36gb8Y1YK9hb/+DUQ=",
+          "dev": true,
+          "requires": {
+            "cli": "0.6.6",
+            "console-browserify": "1.1.0",
+            "exit": "0.1.2",
+            "htmlparser2": "3.8.3",
+            "lodash": "3.7.0",
+            "minimatch": "2.0.10",
+            "shelljs": "0.3.0",
+            "strip-json-comments": "1.0.4"
+          },
+          "dependencies": {
+            "cli": {
+              "version": "0.6.6",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "integrity": "sha1-Aq1Eo4Cr8nraxebwzdewQ9dMU+M=",
+              "dev": true,
+              "requires": {
+                "exit": "0.1.2",
+                "glob": "3.2.11"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                  "dev": true,
+                  "requires": {
+                    "inherits": "2.0.1",
+                    "minimatch": "0.3.0"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "dev": true
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                      "dev": true,
+                      "requires": {
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
+                      },
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.3",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                          "dev": true
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+              "dev": true,
+              "requires": {
+                "date-now": "0.1.4"
+              },
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                  "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+                  "dev": true
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+              "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+              "dev": true
+            },
+            "htmlparser2": {
+              "version": "3.8.3",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+              "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+              "dev": true,
+              "requires": {
+                "domelementtype": "1.3.0",
+                "domhandler": "2.3.0",
+                "domutils": "1.5.1",
+                "entities": "1.0.0",
+                "readable-stream": "1.1.14"
+              },
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                  "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                  "dev": true
+                },
+                "domhandler": {
+                  "version": "2.3.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                  "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+                  "dev": true,
+                  "requires": {
+                    "domelementtype": "1.3.0"
+                  }
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+                  "dev": true,
+                  "requires": {
+                    "dom-serializer": "0.1.0",
+                    "domelementtype": "1.3.0"
+                  },
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+                      "dev": true,
+                      "requires": {
+                        "domelementtype": "1.1.3",
+                        "entities": "1.1.1"
+                      },
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                          "dev": true
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                  "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+                  "dev": true
+                },
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.7.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+              "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.6"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+              "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+              "dev": true
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "gaze": "0.5.2",
+        "lodash": "2.4.2",
+        "tiny-lr-fork": "0.0.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "gaze": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+          "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+          "dev": true,
+          "requires": {
+            "globule": "0.1.0"
+          },
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+              "dev": true,
+              "requires": {
+                "glob": "3.1.21",
+                "lodash": "1.0.2",
+                "minimatch": "0.2.14"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "3.1.21",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "1.2.3",
+                    "inherits": "1.0.2",
+                    "minimatch": "0.2.14"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                      "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+                      "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                  "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "tiny-lr-fork": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+          "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
+          "dev": true,
+          "requires": {
+            "debug": "0.7.4",
+            "faye-websocket": "0.4.4",
+            "noptify": "0.0.3",
+            "qs": "0.5.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+              "dev": true
+            },
+            "faye-websocket": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+              "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
+              "dev": true
+            },
+            "noptify": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+              "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
+              "dev": true,
+              "requires": {
+                "nopt": "2.0.0"
+              },
+              "dependencies": {
+                "nopt": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+                  "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
+                  "dev": true,
+                  "requires": {
+                    "abbrev": "1.0.9"
+                  },
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "qs": {
+              "version": "0.5.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+              "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "grunt-mocha-istanbul": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-istanbul/-/grunt-mocha-istanbul-2.4.0.tgz",
+      "integrity": "sha1-T/JF4Q8lRAJs4V3d/aJcxlQu1pI=",
+      "dev": true
+    },
+    "grunt-mocha-test": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.12.7.tgz",
+      "integrity": "sha1-xhzfMqZ2KVQRX+cSuYPj3Y4MlVQ=",
+      "dev": true,
+      "requires": {
+        "hooker": "0.2.3",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+          "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "grunt-notify": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt-notify/-/grunt-notify-0.4.5.tgz",
+      "integrity": "sha1-BSk5kGFhENtrwK0V5sBZL/4YrDE=",
+      "dev": true,
+      "requires": {
+        "semver": "5.3.0",
+        "stack-parser": "0.0.1",
+        "which": "1.2.11"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        },
+        "stack-parser": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/stack-parser/-/stack-parser-0.0.1.tgz",
+          "integrity": "sha1-fTtjoXiH6eLCv1Xb0zGP40o50ec=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+          "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+          "dev": true,
+          "requires": {
+            "isexe": "1.1.2"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "grunt-swagger-js-codegen": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/grunt-swagger-js-codegen/-/grunt-swagger-js-codegen-0.4.6.tgz",
+      "integrity": "sha1-v6gjcIJB7gGTAUE5cp5Albv1yrY=",
+      "dev": true,
+      "requires": {
+        "lodash": "2.4.2",
+        "q": "1.4.1",
+        "request": "2.74.0",
+        "swagger-js-codegen": "1.1.8",
+        "yamljs": "0.2.8"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+          "dev": true
+        },
+        "q": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.4.1",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.0",
+            "forever-agent": "0.6.1",
+            "form-data": "1.0.1",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.11",
+            "node-uuid": "1.4.7",
+            "oauth-sign": "0.8.2",
+            "qs": "6.2.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.1",
+            "tunnel-agent": "0.4.3"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "dev": true
+            },
+            "aws4": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+              "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+              "dev": true
+            },
+            "bl": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "2.0.6"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.1",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                      "dev": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+              "dev": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+              "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+              "dev": true,
+              "requires": {
+                "async": "2.0.1",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.11"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                  "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+                  "dev": true,
+                  "requires": {
+                    "lodash": "4.15.0"
+                  },
+                  "dependencies": {
+                    "lodash": {
+                      "version": "4.15.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+                      "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.13.1",
+                "pinkie-promise": "2.0.1"
+              },
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                      "dev": true
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                      "dev": true
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
+                  "dev": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "2.0.0",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                      "dev": true
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "dev": true,
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                      "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                      "dev": true
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                      "dev": true
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "dev": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "dev": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              },
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "dev": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                  "dev": true
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.3.0",
+                "sshpk": "1.10.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                  "dev": true
+                },
+                "jsprim": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                  "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+                  "dev": true,
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.2",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                      "dev": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                      "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                      "dev": true
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "dev": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+                  "integrity": "sha1-EE1roq+yrAmauVZ8DRk5d/Kcbfo=",
+                  "dev": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.0",
+                    "dashdash": "1.14.0",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.6",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.13.3"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "dev": true
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                      "dev": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.3"
+                      },
+                      "dependencies": {
+                        "tweetnacl": {
+                          "version": "0.14.3",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                      "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+              "dev": true,
+              "requires": {
+                "mime-db": "1.23.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
+                  "dev": true
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+              "dev": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "dev": true
+            },
+            "qs": {
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+              "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+              "dev": true
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "dev": true
+            },
+            "tough-cookie": {
+              "version": "2.3.1",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+              "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+              "dev": true
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+              "dev": true
+            }
+          }
+        },
+        "swagger-js-codegen": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/swagger-js-codegen/-/swagger-js-codegen-1.1.8.tgz",
+          "integrity": "sha1-8iPRIJazUjGb/hie+qOwZqCex6o=",
+          "dev": true,
+          "requires": {
+            "js-beautify": "1.5.10",
+            "jshint": "2.5.11",
+            "lodash": "2.4.2",
+            "mustache": "2.2.1"
+          },
+          "dependencies": {
+            "js-beautify": {
+              "version": "1.5.10",
+              "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.10.tgz",
+              "integrity": "sha1-TZU3FwJpk0SlFsomv1nwonu3Vxk=",
+              "dev": true,
+              "requires": {
+                "config-chain": "1.1.10",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6"
+              },
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.10",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+                  "integrity": "sha1-f8OD3g/MhNcRy0Zb0XZXnK1hI0Y=",
+                  "dev": true,
+                  "requires": {
+                    "ini": "1.3.4",
+                    "proto-list": "1.2.4"
+                  },
+                  "dependencies": {
+                    "ini": {
+                      "version": "1.3.4",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+                      "dev": true
+                    },
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.6",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+                  "dev": true,
+                  "requires": {
+                    "abbrev": "1.0.9"
+                  },
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "jshint": {
+              "version": "2.5.11",
+              "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.11.tgz",
+              "integrity": "sha1-4tlYWLuxqngwAQii6BCZ+wlWIuA=",
+              "dev": true,
+              "requires": {
+                "cli": "0.6.6",
+                "console-browserify": "1.1.0",
+                "exit": "0.1.2",
+                "htmlparser2": "3.8.3",
+                "minimatch": "1.0.0",
+                "shelljs": "0.3.0",
+                "strip-json-comments": "1.0.4",
+                "underscore": "1.6.0"
+              },
+              "dependencies": {
+                "cli": {
+                  "version": "0.6.6",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                  "integrity": "sha1-Aq1Eo4Cr8nraxebwzdewQ9dMU+M=",
+                  "dev": true,
+                  "requires": {
+                    "exit": "0.1.2",
+                    "glob": "3.2.11"
+                  },
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                      "dev": true,
+                      "requires": {
+                        "inherits": "2.0.1",
+                        "minimatch": "0.3.0"
+                      },
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                          "dev": true
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+                          "dev": true,
+                          "requires": {
+                            "lru-cache": "2.7.3",
+                            "sigmund": "1.0.1"
+                          },
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                              "dev": true
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+                  "dev": true,
+                  "requires": {
+                    "date-now": "0.1.4"
+                  },
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+                      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+                      "dev": true
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+                  "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+                  "dev": true
+                },
+                "htmlparser2": {
+                  "version": "3.8.3",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+                  "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+                  "dev": true,
+                  "requires": {
+                    "domelementtype": "1.3.0",
+                    "domhandler": "2.3.0",
+                    "domutils": "1.5.1",
+                    "entities": "1.0.0",
+                    "readable-stream": "1.1.14"
+                  },
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+                      "dev": true
+                    },
+                    "domhandler": {
+                      "version": "2.3.0",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+                      "dev": true,
+                      "requires": {
+                        "domelementtype": "1.3.0"
+                      }
+                    },
+                    "domutils": {
+                      "version": "1.5.1",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+                      "dev": true,
+                      "requires": {
+                        "dom-serializer": "0.1.0",
+                        "domelementtype": "1.3.0"
+                      },
+                      "dependencies": {
+                        "dom-serializer": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                          "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+                          "dev": true,
+                          "requires": {
+                            "domelementtype": "1.1.3",
+                            "entities": "1.1.1"
+                          },
+                          "dependencies": {
+                            "domelementtype": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                              "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                              "dev": true
+                            },
+                            "entities": {
+                              "version": "1.1.1",
+                              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                              "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+                      "dev": true
+                    },
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "dev": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                          "dev": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                          "dev": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "2.7.3",
+                    "sigmund": "1.0.1"
+                  },
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+                      "dev": true
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+                      "dev": true
+                    }
+                  }
+                },
+                "shelljs": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+                  "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+                  "dev": true
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                  "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+                  "dev": true
+                },
+                "underscore": {
+                  "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+                  "dev": true
+                }
+              }
+            },
+            "mustache": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz",
+              "integrity": "sha1-LEDKIcJ49TFQaCvPkJDkGjM5uHY=",
+              "dev": true
+            }
+          }
+        },
+        "yamljs": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.8.tgz",
+          "integrity": "sha1-7yP7AG5i9q4HtAaqKpSVYfM26lw=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.7",
+            "glob": "7.0.6"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.0.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+              "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.5",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.3",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                  "dev": true
+                },
+                "inflight": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                  "dev": true,
+                  "requires": {
+                    "once": "1.3.3",
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "minimatch": {
+                  "version": "3.0.3",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.6"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-yaml": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/grunt-yaml/-/grunt-yaml-0.4.2.tgz",
+      "integrity": "sha1-Sr9isogKnuTD39bktcdP5UGbCkg=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.0.2",
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.2.tgz",
+          "integrity": "sha1-mTeGX46Jel6JTnPCxc8uibMut3E=",
+          "dev": true,
+          "requires": {
+            "argparse": "0.1.16",
+            "esprima": "1.0.4"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+              "dev": true,
+              "requires": {
+                "underscore": "1.7.0",
+                "underscore.string": "2.4.0"
+              },
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+                  "dev": true
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "hogan.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+      "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
+      "requires": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      }
+    },
+    "html-pdf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/html-pdf/-/html-pdf-2.1.0.tgz",
+      "integrity": "sha1-w01Rj3+AL/vINL+AJ5z859oszks=",
+      "dev": true,
+      "requires": {
+        "phantomjs-prebuilt": "2.1.13"
+      },
+      "dependencies": {
+        "phantomjs-prebuilt": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.13.tgz",
+          "integrity": "sha1-ZlVq2ell2JPKWn3J52PffoaX920=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "es6-promise": "4.0.5",
+            "extract-zip": "1.5.0",
+            "fs-extra": "0.30.0",
+            "hasha": "2.2.0",
+            "kew": "0.7.0",
+            "progress": "1.1.8",
+            "request": "2.74.0",
+            "request-progress": "2.0.1",
+            "which": "1.2.11"
+          },
+          "dependencies": {
+            "es6-promise": {
+              "version": "4.0.5",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+              "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
+              "dev": true,
+              "optional": true
+            },
+            "extract-zip": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+              "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "concat-stream": "1.5.0",
+                "debug": "0.7.4",
+                "mkdirp": "0.5.0",
+                "yauzl": "2.4.1"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                  "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "inherits": "2.0.3",
+                    "readable-stream": "2.0.6",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                  "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
+                  "dev": true,
+                  "optional": true
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "yauzl": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+                  "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "fd-slicer": "1.0.1"
+                  },
+                  "dependencies": {
+                    "fd-slicer": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "pend": "1.2.0"
+                      },
+                      "dependencies": {
+                        "pend": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+                          "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "hasha": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+              "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "is-stream": "1.1.0",
+                "pinkie-promise": "2.0.1"
+              },
+              "dependencies": {
+                "is-stream": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                  "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                  "dev": true,
+                  "optional": true
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "kew": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+              "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+              "dev": true,
+              "optional": true
+            },
+            "progress": {
+              "version": "1.1.8",
+              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+              "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+              "dev": true,
+              "optional": true
+            },
+            "request": {
+              "version": "2.74.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+              "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.5.0",
+                "bl": "1.1.2",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.0",
+                "forever-agent": "0.6.1",
+                "form-data": "1.0.1",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.12",
+                "node-uuid": "1.4.7",
+                "oauth-sign": "0.8.2",
+                "qs": "6.2.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.1",
+                "tunnel-agent": "0.4.3"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "dev": true,
+                  "optional": true
+                },
+                "aws4": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+                  "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
+                  "dev": true,
+                  "optional": true
+                },
+                "bl": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                  "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "readable-stream": "2.0.6"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                  "dev": true,
+                  "optional": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "dev": true,
+                  "optional": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "dev": true,
+                  "optional": true
+                },
+                "form-data": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+                  "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "async": "2.1.2",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.12"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "2.1.2",
+                      "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
+                      "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "lodash": "4.16.4"
+                      },
+                      "dependencies": {
+                        "lodash": {
+                          "version": "4.16.4",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+                          "integrity": "sha1-Ac4wa5utExnypVKGdPiCl663ASc=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "commander": "2.9.0",
+                    "is-my-json-valid": "2.15.0",
+                    "pinkie-promise": "2.0.1"
+                  },
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                      "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.0",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "4.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                          "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+                      "dev": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.3.1",
+                    "sshpk": "1.10.1"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "jsprim": {
+                      "version": "1.3.1",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                      "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+                          "dev": true
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.1",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                      "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.0",
+                        "dashdash": "1.14.0",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.6",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.0",
+                        "tweetnacl": "0.14.3"
+                      },
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                          "dev": true
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                          "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.3"
+                          }
+                        },
+                        "dashdash": {
+                          "version": "1.14.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "getpass": {
+                          "version": "0.1.6",
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.3",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                          "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "dev": true,
+                  "optional": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "dev": true,
+                  "optional": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "dev": true,
+                  "optional": true
+                },
+                "mime-types": {
+                  "version": "2.1.12",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+                  "dev": true,
+                  "requires": {
+                    "mime-db": "1.24.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.24.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                      "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww=",
+                      "dev": true
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+                  "dev": true,
+                  "optional": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                  "dev": true,
+                  "optional": true
+                },
+                "qs": {
+                  "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+                  "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+                  "dev": true,
+                  "optional": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "dev": true,
+                  "optional": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.1",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+                  "dev": true,
+                  "optional": true
+                },
+                "tunnel-agent": {
+                  "version": "0.4.3",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "request-progress": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+              "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "throttleit": "1.0.0"
+              },
+              "dependencies": {
+                "throttleit": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+                  "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.11",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+              "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "isexe": "1.1.2"
+              },
+              "dependencies": {
+                "isexe": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                  "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.11.0.tgz",
+      "integrity": "sha1-DSebZ5Gx0WINygm2V/GG5jyEdj4=",
+      "requires": {
+        "http-proxy": "1.14.0",
+        "is-glob": "2.0.1",
+        "lodash": "3.10.1",
+        "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "http-proxy": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.14.0.tgz",
+          "integrity": "sha1-vjKrNN1SKeh4QPTCfLM17hlbKoM=",
+          "requires": {
+            "eventemitter3": "1.2.0",
+            "requires-port": "1.0.0"
+          },
+          "dependencies": {
+            "eventemitter3": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+              "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+            },
+            "requires-port": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+              "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+            }
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "1.0.0"
+          },
+          "dependencies": {
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+            }
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.0.4",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.0",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+              "requires": {
+                "arr-flatten": "1.0.1"
+              },
+              "dependencies": {
+                "arr-flatten": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                  "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs="
+                }
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+            },
+            "braces": {
+              "version": "1.8.5",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+              "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              },
+              "dependencies": {
+                "expand-range": {
+                  "version": "1.8.2",
+                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                  "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                  "requires": {
+                    "fill-range": "2.2.3"
+                  },
+                  "dependencies": {
+                    "fill-range": {
+                      "version": "2.2.3",
+                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                      "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.5",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.5.4"
+                      },
+                      "dependencies": {
+                        "is-number": {
+                          "version": "2.1.0",
+                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                          "requires": {
+                            "kind-of": "3.0.4"
+                          }
+                        },
+                        "isobject": {
+                          "version": "2.1.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                          "requires": {
+                            "isarray": "1.0.0"
+                          },
+                          "dependencies": {
+                            "isarray": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                            }
+                          }
+                        },
+                        "randomatic": {
+                          "version": "1.1.5",
+                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
+                          "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                          "requires": {
+                            "is-number": "2.1.0",
+                            "kind-of": "3.0.4"
+                          }
+                        },
+                        "repeat-string": {
+                          "version": "1.5.4",
+                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU="
+                        }
+                      }
+                    }
+                  }
+                },
+                "preserve": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                  "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+                },
+                "repeat-element": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                  "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              },
+              "dependencies": {
+                "is-posix-bracket": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                  "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+                }
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "filename-regex": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+              "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U="
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+            },
+            "kind-of": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+              "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+              "requires": {
+                "is-buffer": "1.1.4"
+              },
+              "dependencies": {
+                "is-buffer": {
+                  "version": "1.1.4",
+                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                  "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
+                }
+              }
+            },
+            "normalize-path": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+              "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o="
+            },
+            "object.omit": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+              "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+              "requires": {
+                "for-own": "0.1.4",
+                "is-extendable": "0.1.1"
+              },
+              "dependencies": {
+                "for-own": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
+                  "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
+                  "requires": {
+                    "for-in": "0.1.5"
+                  },
+                  "dependencies": {
+                    "for-in": {
+                      "version": "0.1.5",
+                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
+                      "integrity": "sha1-AHN04rbVxnQgoUeb23WgSHK3OMQ="
+                    }
+                  }
+                },
+                "is-extendable": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                  "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+                }
+              }
+            },
+            "parse-glob": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.2",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              },
+              "dependencies": {
+                "glob-base": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                  "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                  "requires": {
+                    "glob-parent": "2.0.0",
+                    "is-glob": "2.0.1"
+                  },
+                  "dependencies": {
+                    "glob-parent": {
+                      "version": "2.0.0",
+                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                      "requires": {
+                        "is-glob": "2.0.1"
+                      }
+                    }
+                  }
+                },
+                "is-dotfile": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                  "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0="
+                }
+              }
+            },
+            "regex-cache": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+              "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+              "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+              },
+              "dependencies": {
+                "is-equal-shallow": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                  "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                  "requires": {
+                    "is-primitive": "2.0.0"
+                  }
+                },
+                "is-primitive": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                  "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
+    },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "ip": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.3.tgz",
+      "integrity": "sha1-ErFilKOJJUhtYYoRA1BuTrT4spY="
+    },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "istanbul": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
+      "integrity": "sha1-PhZNhQIf4ZyYXR8OfvDD4i0BLrY=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.7.1",
+        "esprima": "2.5.0",
+        "fileset": "0.2.1",
+        "handlebars": "4.0.5",
+        "js-yaml": "3.6.1",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.3.3",
+        "resolve": "1.1.7",
+        "supports-color": "3.1.2",
+        "which": "1.2.11",
+        "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+          "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+          "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
+          "dev": true,
+          "requires": {
+            "esprima": "1.2.5",
+            "estraverse": "1.9.3",
+            "esutils": "2.0.2",
+            "optionator": "0.5.0",
+            "source-map": "0.2.0"
+          },
+          "dependencies": {
+            "esprima": {
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek=",
+              "dev": true
+            },
+            "estraverse": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+              "dev": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+              "dev": true
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
+              "dev": true,
+              "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "1.0.7",
+                "levn": "0.2.5",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "deep-is": {
+                  "version": "0.1.3",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+                  "dev": true
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                  "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+                  "dev": true
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2"
+                  }
+                },
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                  "dev": true
+                },
+                "type-check": {
+                  "version": "0.3.2",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                  "dev": true,
+                  "requires": {
+                    "prelude-ls": "1.1.2"
+                  }
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz",
+          "integrity": "sha1-84ekb9NEwbGjm6+MIL+0O20AWMw=",
+          "dev": true
+        },
+        "fileset": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+          "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "minimatch": "2.0.10"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.5",
+                "inherits": "2.0.1",
+                "minimatch": "2.0.10",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                  "dev": true,
+                  "requires": {
+                    "once": "1.3.3",
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "dev": true
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.6"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "handlebars": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+          "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.7.3"
+          },
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                  "dev": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.0"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                  "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                  "dev": true
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
+              "integrity": "sha1-ObOnMpuJ9exQfjRMbiJWhpjvSGg=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "async": "0.2.10",
+                "source-map": "0.5.6",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                  "dev": true,
+                  "optional": true
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                  "dev": true,
+                  "optional": true
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                  "dev": true,
+                  "optional": true
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "align-text": "0.1.4",
+                            "lazy-cache": "1.0.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "kind-of": "3.0.4",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.4"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.4",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                  "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.4"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.4",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "align-text": "0.1.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "kind-of": "3.0.4",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.5.4"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.4",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                  "integrity": "sha1-e47PGKThf4Jp1ztQHJ8jLJaIenQ=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.4"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.4",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
+                                  "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.7",
+            "esprima": "2.7.3"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.9"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          },
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "dev": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+              "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+              "dev": true
+            }
+          }
+        },
+        "which": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
+          "integrity": "sha1-yLLu6muMFln6fB3U/aq+lTPcXos=",
+          "dev": true,
+          "requires": {
+            "isexe": "1.1.2"
+          },
+          "dependencies": {
+            "isexe": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+              "dev": true
+            }
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+    },
+    "js-yaml": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "requires": {
+        "argparse": "1.0.7",
+        "esprima": "2.7.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+          "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+          "requires": {
+            "sprintf-js": "1.0.3"
+          },
+          "dependencies": {
+            "sprintf-js": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+              "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "jsdoc": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.0.tgz",
+      "integrity": "sha1-NBzbBuRKET2VQe/SEslaSIBk6e4=",
+      "dev": true,
+      "requires": {
+        "async": "1.4.2",
+        "bluebird": "2.9.34",
+        "catharsis": "0.8.8",
+        "escape-string-regexp": "1.0.5",
+        "espree": "2.2.5",
+        "js2xmlparser": "1.0.0",
+        "marked": "0.3.6",
+        "requizzle": "0.2.1",
+        "strip-json-comments": "1.0.4",
+        "taffydb": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
+        "underscore": "1.8.3",
+        "wrench": "1.5.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.9.34",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
+          "integrity": "sha1-L3tOyAIWMoqf3evfacjUlC/v99g=",
+          "dev": true
+        },
+        "catharsis": {
+          "version": "0.8.8",
+          "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.8.tgz",
+          "integrity": "sha1-aTR59DqsVJ2Aa9c+kkzQ2USVGgY=",
+          "dev": true,
+          "requires": {
+            "underscore-contrib": "0.3.0"
+          },
+          "dependencies": {
+            "underscore-contrib": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+              "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
+              "dev": true,
+              "requires": {
+                "underscore": "1.6.0"
+              },
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                  "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
+          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+          "dev": true
+        },
+        "js2xmlparser": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
+          "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
+          "dev": true
+        },
+        "marked": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+          "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+          "dev": true
+        },
+        "requizzle": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
+          "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+          "dev": true,
+          "requires": {
+            "underscore": "1.6.0"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+              "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+              "dev": true
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        },
+        "taffydb": {
+          "version": "https://github.com/hegemonic/taffydb/tarball/7d100bcee0e997ee4977e273cdce60bd8933050e",
+          "integrity": "sha1-PFSdL1cS19HRCa1rsaQITxt63U4=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
+        },
+        "wrench": {
+          "version": "1.5.9",
+          "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
+          "integrity": "sha1-QRaRxjqbJTGxcAJnJ5veyiOyFCo=",
+          "dev": true
+        }
+      }
+    },
+    "jshint": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.3.tgz",
+      "integrity": "sha1-ouFP+Fwta/jICA5apVEp68ai0yA=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.0",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.3",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "cli": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz",
+          "integrity": "sha1-7gffwTkOPy5qmVfPiOHUv6d3cZ0=",
+          "dev": true,
+          "requires": {
+            "exit": "0.1.2",
+            "glob": "7.0.6"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.0.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+              "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.5",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.3",
+                "once": "1.3.3",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                  "dev": true
+                },
+                "inflight": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                  "dev": true,
+                  "requires": {
+                    "once": "1.3.3",
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+          "dev": true,
+          "requires": {
+            "date-now": "0.1.4"
+          },
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+              "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+              "dev": true
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.3.0",
+            "domutils": "1.5.1",
+            "entities": "1.0.0",
+            "readable-stream": "1.1.14"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+              "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+              "dev": true
+            },
+            "domhandler": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+              "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+              "dev": true,
+              "requires": {
+                "domelementtype": "1.3.0"
+              }
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+              "dev": true,
+              "requires": {
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
+              },
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+                  "dev": true,
+                  "requires": {
+                    "domelementtype": "1.1.3",
+                    "entities": "1.1.1"
+                  },
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                      "dev": true
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.6"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.6",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+              "dev": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              },
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+                  "dev": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonlint-lines": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/jsonlint-lines/-/jsonlint-lines-1.7.1.tgz",
+      "integrity": "sha1-UH3mgNP7jEvhZBzFfW9nnynxeP8=",
+      "requires": {
+        "JSV": "4.0.2",
+        "nomnom": "1.8.1"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
+    "jsonschema": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
+    },
+    "jsonwebtoken": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
+      "integrity": "sha1-HJD5qGzlt0j1+XnBK3BAK0r83bQ=",
+      "requires": {
+        "jws": "3.1.3",
+        "ms": "0.7.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "jws": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.3.tgz",
+          "integrity": "sha1-uI8bRYGixe6IE8BrP9+Q6ptcfmw=",
+          "requires": {
+            "base64url": "1.0.6",
+            "jwa": "1.1.3"
+          },
+          "dependencies": {
+            "base64url": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+              "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
+              "requires": {
+                "concat-stream": "1.4.10",
+                "meow": "2.0.0"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.4.10",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                  "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
+                  "requires": {
+                    "inherits": "2.0.1",
+                    "readable-stream": "1.1.14",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "readable-stream": {
+                      "version": "1.1.14",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                        }
+                      }
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+                    }
+                  }
+                },
+                "meow": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+                  "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
+                  "requires": {
+                    "camelcase-keys": "1.0.0",
+                    "indent-string": "1.2.2",
+                    "minimist": "1.2.0",
+                    "object-assign": "1.0.0"
+                  },
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
+                      "requires": {
+                        "camelcase": "1.2.1",
+                        "map-obj": "1.0.1"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.2",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
+                      "requires": {
+                        "get-stdin": "4.0.1",
+                        "minimist": "1.2.0",
+                        "repeating": "1.1.3"
+                      },
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+                          "requires": {
+                            "is-finite": "1.0.1"
+                          },
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
+                              "requires": {
+                                "number-is-nan": "1.0.0"
+                              },
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                                  "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es="
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                    },
+                    "object-assign": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                      "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
+                    }
+                  }
+                }
+              }
+            },
+            "jwa": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.3.tgz",
+              "integrity": "sha1-+p8vAF/wxjDnxBUmox8395czzW0=",
+              "requires": {
+                "base64url": "1.0.6",
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.7"
+              },
+              "dependencies": {
+                "buffer-equal-constant-time": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+                  "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+                },
+                "ecdsa-sig-formatter": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz",
+                  "integrity": "sha1-MTfpdqHWIyUX4lE+BOMveby98SY=",
+                  "requires": {
+                    "base64-url": "1.3.2"
+                  },
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.3.2",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.2.tgz",
+                      "integrity": "sha1-SwgRO0nSOInzBr5kNydi0xQS96g="
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "requires": {
+        "chalk": "1.1.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        }
+      }
+    },
+    "long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+    },
+    "lru-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+      "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+      "requires": {
+        "pseudomap": "1.0.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+      "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+    },
+    "mktemp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+    },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "mockery": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.0.0.tgz",
+      "integrity": "sha1-BWmhGhhIRh/cNHz4zKLfLzEpvAM="
+    },
+    "moment": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
+      "integrity": "sha1-h5aOX5WsA4wuQqyVnHWBnNP1KQE="
+    },
+    "mongodb": {
+      "version": "1.4.40",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.4.40.tgz",
+      "integrity": "sha1-z9gLdP3w+gU/LM+19JxHyjKjjvs=",
+      "requires": {
+        "bson": "0.2.22",
+        "kerberos": "0.0.11",
+        "readable-stream": "2.1.5"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "0.2.22",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.22.tgz",
+          "integrity": "sha1-/NoQPybQwHTVpS1Qkn24D9ArSzk=",
+          "requires": {
+            "nan": "1.8.4"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "1.8.4",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+              "integrity": "sha1-PHa1OC6rM+RLdY0oE8qdkuk0LzQ="
+            }
+          }
+        },
+        "kerberos": {
+          "version": "0.0.11",
+          "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.11.tgz",
+          "integrity": "sha1-yymJHCHCKsGV8xQLl90SIE/qfcI=",
+          "optional": true,
+          "requires": {
+            "nan": "1.8.4"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "1.8.4",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+              "integrity": "sha1-PHa1OC6rM+RLdY0oE8qdkuk0LzQ=",
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "optional": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.1",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          },
+          "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "optional": true
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "optional": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+              "optional": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "optional": true
+            }
+          }
+        }
+      }
+    },
+    "mongodb-core": {
+      "version": "1.2.31",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.31.tgz",
+      "integrity": "sha1-8eZAXwPUCEb9uDinAlB6/6PLLDk=",
+      "requires": {
+        "bson": "0.4.23"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz",
+      "integrity": "sha1-sy1TY0OVC/Ysbtp4F+cfc3ZRb+0=",
+      "requires": {
+        "append-field": "0.1.0",
+        "busboy": "0.2.13",
+        "concat-stream": "1.5.2",
+        "mkdirp": "0.5.1",
+        "object-assign": "3.0.0",
+        "on-finished": "2.3.0",
+        "type-is": "1.6.13",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "append-field": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
+          "integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo="
+        },
+        "busboy": {
+          "version": "0.2.13",
+          "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
+          "integrity": "sha1-kPxPajln2BVhb8l2v6jlau0MWLY=",
+          "requires": {
+            "dicer": "0.2.5",
+            "readable-stream": "1.1.14"
+          },
+          "dependencies": {
+            "dicer": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+              "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+              "requires": {
+                "readable-stream": "1.1.14",
+                "streamsearch": "0.1.2"
+              },
+              "dependencies": {
+                "streamsearch": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+                  "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+              }
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+          "requires": {
+            "inherits": "2.0.1",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        },
+        "type-is": {
+          "version": "1.6.13",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "integrity": "sha1-boO6e8MM0zp7sLf7AHN6IIW/nQg=",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.11"
+          },
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+              "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+              "requires": {
+                "mime-db": "1.23.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                }
+              }
+            }
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        }
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "nan": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
+    },
+    "nanoid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.0.2.tgz",
+      "integrity": "sha512-sCTwJt690lduNHyqknXJp8pRwzm80neOLGaiTHU2KUJZFVSErl778NNCIivEQCX5gNT0xR1Jy3HEMe/TABT6lw=="
+    },
+    "nconf": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.7.2.tgz",
+      "integrity": "sha1-oF/fItwBw3jdXE3yfy3JC5qouwA=",
+      "requires": {
+        "async": "0.9.2",
+        "ini": "1.3.5",
+        "yargs": "3.15.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "requires": {
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "yargs": {
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.15.0.tgz",
+          "integrity": "sha1-PZRG7yH7N5GzmFaQZi5LloPH8YE=",
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.4"
+          }
+        }
+      }
+    },
+    "ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ="
+    },
+    "nock": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-3.5.0.tgz",
+      "integrity": "sha1-IxPKU3yU7MNwf+9NU7A5sii/9Cc=",
+      "dev": true,
+      "requires": {
+        "chai": "2.3.0",
+        "debug": "2.2.0",
+        "deep-equal": "1.0.1",
+        "json-stringify-safe": "5.0.1",
+        "lodash": "2.4.1",
+        "mkdirp": "0.5.1",
+        "propagate": "0.3.1"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "propagate": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.3.1.tgz",
+          "integrity": "sha1-46hEBKfs6CDda76p9tkk4xNa4Jw=",
+          "dev": true
+        }
+      }
+    },
+    "node-cache": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.1.0.tgz",
+      "integrity": "sha1-KmpmRgvwY3gROCBpiCN+wCwTUVc=",
+      "requires": {
+        "clone": "1.0.2",
+        "lodash": "4.16.4"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+          "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+        },
+        "lodash": {
+          "version": "4.16.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
+          "integrity": "sha1-Ac4wa5utExnypVKGdPiCl663ASc="
+        }
+      }
+    },
+    "node-ssdp": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/node-ssdp/-/node-ssdp-2.7.2.tgz",
+      "integrity": "sha1-wSaLRMUPPXw5+a+/gTn+liPKui8=",
+      "requires": {
+        "debug": "2.2.0",
+        "ip": "1.1.3"
+      }
+    },
+    "node-statsd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz",
+      "integrity": "sha1-J6WTSHY9CvegN6wqAx/vPwUQE9M="
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "nomnom": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "requires": {
+        "chalk": "0.4.0",
+        "underscore": "1.6.0"
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "ntlm": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ntlm/-/ntlm-0.1.3.tgz",
+      "integrity": "sha1-O4FOvFMKHmzXEtzwz1kBVZMRlcE="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "on-core": {
+      "//": "Don't add commit hash here.",
+      "version": "git+https://github.com/RackHD/on-core.git",
+      "requires": {
+        "ajv": "4.11.8",
+        "always-tail": "0.2.0",
+        "amqp": "0.2.3",
+        "anchor": "0.10.5",
+        "assert-plus": "1.0.0",
+        "bluebird": "2.11.0",
+        "bson": "0.4.23",
+        "colors": "1.1.2",
+        "crypt3": "1.0.0",
+        "di": "git+https://github.com/RackHD/di.js.git#f903386e063460930b757c11a1d510ca0a77f638",
+        "ejs": "2.5.1",
+        "eventemitter2": "0.4.14",
+        "flat": "1.6.1",
+        "glob": "4.5.3",
+        "hogan.js": "3.0.2",
+        "jsonschema": "1.2.2",
+        "lodash": "3.10.1",
+        "lru-cache": "3.2.0",
+        "nanoid": "1.0.2",
+        "nconf": "0.7.2",
+        "node-statsd": "0.1.1",
+        "node-uuid": "1.4.8",
+        "pg": "4.5.7",
+        "pluralize": "1.1.6",
+        "prettyjson": "1.2.1",
+        "resolve": "1.5.0",
+        "rx": "4.0.6",
+        "sails-mongo": "0.11.7",
+        "sails-postgresql": "0.11.4",
+        "stack-trace": "0.0.9",
+        "validate.js": "0.3.2",
+        "validator": "3.43.0",
+        "waterline": "0.10.31",
+        "waterline-criteria": "0.11.2"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "3.43.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
+          "integrity": "sha1-lkZLmS1BloM9l6GUv0Cxn/VLrgU="
+        }
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      },
+      "dependencies": {
+        "ee-first": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        }
+      }
+    },
+    "on-tasks": {
+      "//": "Don't add commit hash here.",
+      "version": "git+https://github.com/RackHD/on-tasks.git",
+      "requires": {
+        "ajv": "4.11.8",
+        "di": "git+https://github.com/RackHD/di.js.git#f903386e063460930b757c11a1d510ca0a77f638",
+        "dockerode": "2.5.4",
+        "lodash": "3.10.1",
+        "node-uuid": "1.4.8",
+        "//": "Don't add commit hash here.",
+        "on-core": "git+https://github.com/RackHD/on-core.git",
+        "request": "2.83.0",
+        "request-promise": "4.2.2",
+        "requestretry": "1.13.0",
+        "smb2": "0.2.7",
+        "ssh2": "0.5.0",
+        "temp": "0.8.3",
+        "url-parse": "1.0.5",
+        "xml2js": "0.4.19",
+        "xmldom": "0.1.27"
+      },
+      "dependencies": {
+        "url-parse": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+          "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+          "requires": {
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
+          }
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
+      "integrity": "sha1-6bQjoe2vR5iCVi6S7XHXdDoHG24="
+    },
+    "packet-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
+      "integrity": "sha1-gZ300BC4LV6lZx+KGjrPA5vNdwA="
+    },
+    "passport": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
+      "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
+      "requires": {
+        "passport-strategy": "1.0.0",
+        "pause": "0.0.1"
+      },
+      "dependencies": {
+        "passport-strategy": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+          "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+        },
+        "pause": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+          "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
+        }
+      }
+    },
+    "passport-anonymous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-anonymous/-/passport-anonymous-1.0.1.tgz",
+      "integrity": "sha1-JB43J07ETft/bK0jS0HEODhrwRc=",
+      "requires": {
+        "passport-strategy": "1.0.0"
+      },
+      "dependencies": {
+        "passport-strategy": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+          "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+        }
+      }
+    },
+    "passport-http": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/passport-http/-/passport-http-0.3.0.tgz",
+      "integrity": "sha1-juU9Q4C+nGDfIVGSUCmCb3cRVgM=",
+      "requires": {
+        "passport-strategy": "1.0.0"
+      },
+      "dependencies": {
+        "passport-strategy": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+          "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+        }
+      }
+    },
+    "passport-jwt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-3.0.1.tgz",
+      "integrity": "sha1-5Pcnba2L0lHUPG/DiIMTC5YycvY=",
+      "requires": {
+        "jsonwebtoken": "7.4.3",
+        "passport-strategy": "1.0.0"
+      },
+      "dependencies": {
+        "jsonwebtoken": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
+          "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+          "requires": {
+            "joi": "6.10.1",
+            "jws": "3.1.4",
+            "lodash.once": "4.1.1",
+            "ms": "2.0.0",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "joi": {
+              "version": "6.10.1",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+              "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+              "requires": {
+                "hoek": "2.16.3",
+                "isemail": "1.2.0",
+                "moment": "2.11.2",
+                "topo": "1.1.0"
+              },
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                },
+                "isemail": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+                  "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+                },
+                "topo": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+                  "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                }
+              }
+            },
+            "jws": {
+              "version": "3.1.4",
+              "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
+              "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+              "requires": {
+                "base64url": "2.0.0",
+                "jwa": "1.1.5",
+                "safe-buffer": "5.1.1"
+              },
+              "dependencies": {
+                "base64url": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
+                  "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
+                },
+                "jwa": {
+                  "version": "1.1.5",
+                  "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
+                  "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+                  "requires": {
+                    "base64url": "2.0.0",
+                    "buffer-equal-constant-time": "1.0.1",
+                    "ecdsa-sig-formatter": "1.0.9",
+                    "safe-buffer": "5.1.1"
+                  },
+                  "dependencies": {
+                    "buffer-equal-constant-time": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+                      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+                    },
+                    "ecdsa-sig-formatter": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
+                      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+                      "requires": {
+                        "base64url": "2.0.0",
+                        "safe-buffer": "5.1.1"
+                      }
+                    }
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                  "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+                }
+              }
+            },
+            "lodash.once": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+              "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+              "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+            }
+          }
+        },
+        "passport-strategy": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+          "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+        }
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
+      "requires": {
+        "passport-strategy": "1.0.0"
+      },
+      "dependencies": {
+        "passport-strategy": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+          "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+        }
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pg": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.7.tgz",
+      "integrity": "sha1-Ra4WsjcGpjRaAyed7MaveVwW0ps=",
+      "requires": {
+        "buffer-writer": "1.0.1",
+        "generic-pool": "2.4.2",
+        "js-string-escape": "1.0.1",
+        "packet-reader": "0.2.0",
+        "pg-connection-string": "0.1.3",
+        "pg-types": "1.13.0",
+        "pgpass": "0.0.3",
+        "semver": "4.3.6"
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-types": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
+      "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "1.0.2",
+        "postgres-bytea": "1.0.0",
+        "postgres-date": "1.0.3",
+        "postgres-interval": "1.1.1"
+      }
+    },
+    "pgpass": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
+      "integrity": "sha1-EuZ+NDsxicLzEgbrycwL7//PkUA=",
+      "requires": {
+        "split": "0.3.3"
+      }
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "1.4.0"
+      }
+    },
+    "pluralize": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.1.6.tgz",
+      "integrity": "sha1-5L9dazayr8IsgB98Nyk2F+C9xW0="
+    },
+    "postgres-array": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
+      "integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
+      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
+    },
+    "postgres-interval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
+      "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
+      "requires": {
+        "xtend": "4.0.1"
+      }
+    },
+    "prettyjson": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
+      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "requires": {
+        "colors": "1.1.2",
+        "minimist": "1.2.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "prompt": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+      "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
+      "requires": {
+        "pkginfo": "0.4.1",
+        "read": "1.0.7",
+        "revalidator": "0.1.8",
+        "utile": "0.2.1",
+        "winston": "0.8.3"
+      }
+    },
+    "protobufjs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
+      "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
+      "requires": {
+        "ascli": "1.0.1",
+        "bytebuffer": "5.0.1",
+        "glob": "7.1.2",
+        "yargs": "3.32.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "pump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "optional": true
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "querystringify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "0.0.7"
+      }
+    },
+    "readable-stream": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+      "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+    },
+    "request": {
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        }
+      }
+    },
+    "requestretry": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.13.0.tgz",
+      "integrity": "sha512-Lmh9qMvnQXADGAQxsXHP4rbgO6pffCfuR8XUBdP9aitJcLQJxhp7YZK4xAVYXnPJ5E52mwrfiKQtKonPL8xsmg==",
+      "requires": {
+        "extend": "3.0.1",
+        "lodash": "4.17.5",
+        "request": "2.83.0",
+        "when": "3.7.8"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        }
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "restify-links": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/restify-links/-/restify-links-1.1.0.tgz",
+      "integrity": "sha1-aFxeDYUXpIvDvfGzJu8YaP/wynI="
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
+    },
+    "rewire": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
+      "integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "requires": {
+        "align-text": "0.1.4"
+      }
+    },
+    "rimraf": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+      "requires": {
+        "glob": "7.0.6"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.5",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.3",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
+          },
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            },
+            "inflight": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+              "requires": {
+                "once": "1.3.3",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+              "requires": {
+                "brace-expansion": "1.1.6"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+            }
+          }
+        }
+      }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+    },
+    "rx": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.0.6.tgz",
+      "integrity": "sha1-KHdKqENS0MAQUU62mdcUEl6upDY="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sails-mongo": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/sails-mongo/-/sails-mongo-0.11.7.tgz",
+      "integrity": "sha1-goMye520TSwqQGRqSZjFwcOTtQg=",
+      "requires": {
+        "async": "1.5.2",
+        "lodash": "3.10.1",
+        "mongodb": "2.1.3",
+        "validator": "4.5.1",
+        "waterline-cursor": "0.0.7",
+        "waterline-errors": "0.10.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "mongodb": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.3.tgz",
+          "integrity": "sha1-jB60Q+d6wuoQ4oEwexaS78whh7U=",
+          "requires": {
+            "es6-promise": "3.0.2",
+            "mongodb-core": "1.2.31",
+            "readable-stream": "1.0.31"
+          }
+        },
+        "validator": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-4.5.1.tgz",
+          "integrity": "sha1-QK6XYw7lLNlvQ38NSanaq1wLG68="
+        }
+      }
+    },
+    "sails-postgresql": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/sails-postgresql/-/sails-postgresql-0.11.4.tgz",
+      "integrity": "sha1-NbmOIl/trrfIr32jzFzfw/D9aI0=",
+      "requires": {
+        "async": "1.5.2",
+        "lodash": "3.10.1",
+        "pg": "4.5.5",
+        "waterline-cursor": "0.0.6",
+        "waterline-errors": "0.10.1",
+        "waterline-sequel": "0.5.7"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "pg": {
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.5.tgz",
+          "integrity": "sha1-wXr1E+MLp+k6GLuq2+cahNPGy70=",
+          "requires": {
+            "buffer-writer": "1.0.1",
+            "generic-pool": "2.1.1",
+            "packet-reader": "0.2.0",
+            "pg-connection-string": "0.1.3",
+            "pg-types": "1.11.0",
+            "pgpass": "0.0.3",
+            "semver": "4.3.6"
+          },
+          "dependencies": {
+            "buffer-writer": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+              "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+            },
+            "generic-pool": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz",
+              "integrity": "sha1-rwTcLDJc/Ll1Aj+lK/zpYXp0Nf0="
+            },
+            "packet-reader": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
+              "integrity": "sha1-gZ300BC4LV6lZx+KGjrPA5vNdwA="
+            },
+            "pg-connection-string": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+              "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+            },
+            "pg-types": {
+              "version": "1.11.0",
+              "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz",
+              "integrity": "sha1-qukagtlStjO7iNAGNQoWbar26pA=",
+              "requires": {
+                "ap": "0.2.0",
+                "postgres-array": "1.0.0",
+                "postgres-bytea": "1.0.0",
+                "postgres-date": "1.0.1",
+                "postgres-interval": "1.0.2"
+              },
+              "dependencies": {
+                "ap": {
+                  "version": "0.2.0",
+                  "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
+                  "integrity": "sha1-rglCYAspkS8NKxTsYMRejzMLYRA="
+                },
+                "postgres-array": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.0.tgz",
+                  "integrity": "sha1-SMLoKTWxeL+AXg3/aJ0Tfuwr/ms="
+                },
+                "postgres-bytea": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+                  "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+                },
+                "postgres-date": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.1.tgz",
+                  "integrity": "sha1-XHjImYQF/xalrE7LKc9oL64HFIs="
+                },
+                "postgres-interval": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz",
+                  "integrity": "sha1-cmFDjYYrQSkhxv23YXZoQktzpu0=",
+                  "requires": {
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "xtend": {
+                      "version": "4.0.1",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+                    }
+                  }
+                }
+              }
+            },
+            "pgpass": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
+              "integrity": "sha1-EuZ+NDsxicLzEgbrycwL7//PkUA=",
+              "requires": {
+                "split": "0.3.3"
+              },
+              "dependencies": {
+                "split": {
+                  "version": "0.3.3",
+                  "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+                  "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+                  "requires": {
+                    "through": "2.3.8"
+                  },
+                  "dependencies": {
+                    "through": {
+                      "version": "2.3.8",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+                      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.6",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+              "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+            }
+          }
+        },
+        "waterline-cursor": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/waterline-cursor/-/waterline-cursor-0.0.6.tgz",
+          "integrity": "sha1-d1DuqIuI+ACZbRFTBH28hQ9FL08=",
+          "requires": {
+            "async": "0.9.2",
+            "lodash": "2.4.2"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+            }
+          }
+        },
+        "waterline-errors": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/waterline-errors/-/waterline-errors-0.10.1.tgz",
+          "integrity": "sha1-7mNjKq3emTJxt1FLfKmNn9W4ai4="
+        },
+        "waterline-sequel": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/waterline-sequel/-/waterline-sequel-0.5.7.tgz",
+          "integrity": "sha1-HX5DKLq/rYoxvT+yaobXGACtgo0=",
+          "requires": {
+            "lodash": "3.10.0"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.0.tgz",
+              "integrity": "sha1-k9UcZygopEFqEq9XIguoqHN+L7s="
+            }
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+    },
+    "sinon": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.16.1.tgz",
+      "integrity": "sha1-Xm1sDmsvcqMtz8ZsJAfW0GXIkZ0=",
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.1",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "formatio": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+          "dev": true,
+          "requires": {
+            "samsam": "1.1.2"
+          }
+        },
+        "lolex": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.1.tgz",
+          "integrity": "sha1-ktSXPF/osIwAlPcycNrwkzK77fA=",
+          "dev": true
+        },
+        "samsam": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+          "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "sinon-as-promised": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sinon-as-promised/-/sinon-as-promised-2.0.3.tgz",
+      "integrity": "sha1-SY7yN0molBcQDBEjzpgCdXT8mrs=",
+      "dev": true,
+      "requires": {
+        "bluebird": "2.11.0"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        }
+      }
+    },
+    "sinon-chai": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.8.0.tgz",
+      "integrity": "sha1-Qyqbv9Uab8AHmPTSUmqCnAYGh6w=",
+      "dev": true
+    },
+    "smb2": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/smb2/-/smb2-0.2.7.tgz",
+      "integrity": "sha1-c8CZuKNhW73wwgiLrZDPZ9CF9Rs=",
+      "requires": {
+        "ntlm": "0.1.3"
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
+    "source-map": {
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+      "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "source-map-support": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+      "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+      "requires": {
+        "source-map": "0.1.32"
+      }
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
+    },
+    "ssh2": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.0.tgz",
+      "integrity": "sha1-jlAflcFjN+IfrirAxuXnc1SwB5k=",
+      "requires": {
+        "ssh2-streams": "0.1.20"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+      "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+      "requires": {
+        "asn1": "0.2.3",
+        "semver": "5.5.0",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supertest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-1.2.0.tgz",
+      "integrity": "sha1-hQp5X5Bo0vrxngF5n/CZYuDOQ74=",
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "1.8.4"
+      },
+      "dependencies": {
+        "methods": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+          "dev": true
+        },
+        "superagent": {
+          "version": "1.8.4",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz",
+          "integrity": "sha1-aLLIpADxdT3bOUEJBomeQvQg/To=",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.0.6",
+            "debug": "2.2.0",
+            "extend": "3.0.0",
+            "form-data": "1.0.0-rc3",
+            "formidable": "1.0.17",
+            "methods": "1.1.2",
+            "mime": "1.3.4",
+            "qs": "2.3.3",
+            "readable-stream": "1.0.27-1",
+            "reduce-component": "1.0.1"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+              "dev": true
+            },
+            "cookiejar": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+              "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4=",
+              "dev": true
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.11"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                  "dev": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mime-types": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                  "dev": true,
+                  "requires": {
+                    "mime-db": "1.23.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "formidable": {
+              "version": "1.0.17",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=",
+              "dev": true
+            },
+            "mime": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+              "dev": true
+            },
+            "qs": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.0.27-1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+              "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                  "dev": true
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                  "dev": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                  "dev": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                  "dev": true
+                }
+              }
+            },
+            "reduce-component": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+              "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "swagger-express-mw": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/swagger-express-mw/-/swagger-express-mw-0.6.0.tgz",
+      "integrity": "sha1-fTcYBn/umeWvzqiPFEn0Qy0N4LM=",
+      "requires": {
+        "swagger-node-runner": "0.6.16"
+      },
+      "dependencies": {
+        "swagger-node-runner": {
+          "version": "0.6.16",
+          "resolved": "https://registry.npmjs.org/swagger-node-runner/-/swagger-node-runner-0.6.16.tgz",
+          "integrity": "sha1-OUlu/xbZxjCXdn6Lfq//v5PKC0M=",
+          "requires": {
+            "async": "1.5.2",
+            "bagpipes": "0.1.0",
+            "body-parser": "1.15.2",
+            "config": "1.21.0",
+            "cors": "2.8.0",
+            "debug": "2.2.0",
+            "js-yaml": "3.6.1",
+            "lodash": "3.10.1",
+            "multer": "1.1.0",
+            "parseurl": "1.3.1",
+            "qs": "5.2.1",
+            "sway": "0.6.0",
+            "type-is": "1.6.13"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+            },
+            "bagpipes": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/bagpipes/-/bagpipes-0.1.0.tgz",
+              "integrity": "sha1-0oAFC0BEkozJw9uwMhweuKvQ1/A=",
+              "requires": {
+                "async": "1.5.2",
+                "debug": "2.2.0",
+                "jspath": "0.3.3",
+                "lodash": "3.10.1",
+                "machinepack-http": "2.4.0",
+                "mustache": "2.2.1",
+                "pipeworks": "1.3.0"
+              },
+              "dependencies": {
+                "jspath": {
+                  "version": "0.3.3",
+                  "resolved": "https://registry.npmjs.org/jspath/-/jspath-0.3.3.tgz",
+                  "integrity": "sha1-0fO0RlUpo5f+bRi1DSQD1uP+YcA="
+                },
+                "machinepack-http": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/machinepack-http/-/machinepack-http-2.4.0.tgz",
+                  "integrity": "sha1-CnhcF9xrnBuaxAiBvu+uiudIVek=",
+                  "requires": {
+                    "lodash": "3.10.1",
+                    "machine": "10.4.0",
+                    "machinepack-urls": "4.1.0",
+                    "request": "2.74.0"
+                  },
+                  "dependencies": {
+                    "machine": {
+                      "version": "10.4.0",
+                      "resolved": "https://registry.npmjs.org/machine/-/machine-10.4.0.tgz",
+                      "integrity": "sha1-m1Ys5GeCEzKCijd9GQ65NrTkB7I=",
+                      "requires": {
+                        "convert-to-ecmascript-compatible-varname": "0.1.5",
+                        "debug": "2.2.0",
+                        "lodash": "3.10.1",
+                        "object-hash": "0.3.0",
+                        "rttc": "7.4.0",
+                        "switchback": "2.0.1"
+                      },
+                      "dependencies": {
+                        "convert-to-ecmascript-compatible-varname": {
+                          "version": "0.1.5",
+                          "resolved": "https://registry.npmjs.org/convert-to-ecmascript-compatible-varname/-/convert-to-ecmascript-compatible-varname-0.1.5.tgz",
+                          "integrity": "sha1-9npJOMUjNENWQlBHnGcBS6yHhJk="
+                        },
+                        "object-hash": {
+                          "version": "0.3.0",
+                          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-0.3.0.tgz",
+                          "integrity": "sha1-VIII5Ds2pE5NowutbFasU7iF50Q="
+                        },
+                        "rttc": {
+                          "version": "7.4.0",
+                          "resolved": "https://registry.npmjs.org/rttc/-/rttc-7.4.0.tgz",
+                          "integrity": "sha1-vJys1Grdkj3rYklaAZNOt+9hn7Q=",
+                          "requires": {
+                            "lodash": "3.10.1"
+                          }
+                        },
+                        "switchback": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/switchback/-/switchback-2.0.1.tgz",
+                          "integrity": "sha1-3zCAUiDOwG1QrUATrt5C1QOXqOY=",
+                          "requires": {
+                            "lodash": "3.10.1"
+                          }
+                        }
+                      }
+                    },
+                    "machinepack-urls": {
+                      "version": "4.1.0",
+                      "resolved": "https://registry.npmjs.org/machinepack-urls/-/machinepack-urls-4.1.0.tgz",
+                      "integrity": "sha1-0l4y6Xw8LLiVaLqMmNIp1cMF45E=",
+                      "requires": {
+                        "lodash": "3.10.1",
+                        "machine": "9.1.2"
+                      },
+                      "dependencies": {
+                        "machine": {
+                          "version": "9.1.2",
+                          "resolved": "https://registry.npmjs.org/machine/-/machine-9.1.2.tgz",
+                          "integrity": "sha1-hL+Pt3ZqlqplqpbWbpUJ62oFqDQ=",
+                          "requires": {
+                            "convert-to-ecmascript-compatible-varname": "0.1.5",
+                            "debug": "2.2.0",
+                            "lodash": "3.10.1",
+                            "object-hash": "0.3.0",
+                            "rttc": "4.5.2",
+                            "switchback": "1.1.3"
+                          },
+                          "dependencies": {
+                            "convert-to-ecmascript-compatible-varname": {
+                              "version": "0.1.5",
+                              "resolved": "https://registry.npmjs.org/convert-to-ecmascript-compatible-varname/-/convert-to-ecmascript-compatible-varname-0.1.5.tgz",
+                              "integrity": "sha1-9npJOMUjNENWQlBHnGcBS6yHhJk="
+                            },
+                            "object-hash": {
+                              "version": "0.3.0",
+                              "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-0.3.0.tgz",
+                              "integrity": "sha1-VIII5Ds2pE5NowutbFasU7iF50Q="
+                            },
+                            "rttc": {
+                              "version": "4.5.2",
+                              "resolved": "https://registry.npmjs.org/rttc/-/rttc-4.5.2.tgz",
+                              "integrity": "sha1-umo+komLQnTxI7usSUhddhajfLw=",
+                              "requires": {
+                                "lodash": "3.10.1"
+                              }
+                            },
+                            "switchback": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/switchback/-/switchback-1.1.3.tgz",
+                              "integrity": "sha1-EscBCTSNailvc5upEO64U/i25jE=",
+                              "requires": {
+                                "lodash": "2.4.2"
+                              },
+                              "dependencies": {
+                                "lodash": {
+                                  "version": "2.4.2",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "request": {
+                      "version": "2.74.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+                      "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+                      "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.4.1",
+                        "bl": "1.1.2",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.0",
+                        "forever-agent": "0.6.1",
+                        "form-data": "1.0.1",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.11",
+                        "node-uuid": "1.4.7",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.2.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.1",
+                        "tunnel-agent": "0.4.3"
+                      },
+                      "dependencies": {
+                        "aws-sign2": {
+                          "version": "0.6.0",
+                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+                        },
+                        "aws4": {
+                          "version": "1.4.1",
+                          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+                          "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE="
+                        },
+                        "bl": {
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                          "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+                          "requires": {
+                            "readable-stream": "2.0.6"
+                          },
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "2.0.6",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                              "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.1",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                              },
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                                },
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.7",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "caseless": {
+                          "version": "0.11.0",
+                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+                        },
+                        "combined-stream": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                          "requires": {
+                            "delayed-stream": "1.0.0"
+                          },
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                            }
+                          }
+                        },
+                        "extend": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1",
+                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+                        },
+                        "form-data": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+                          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+                          "requires": {
+                            "async": "2.0.1",
+                            "combined-stream": "1.0.5",
+                            "mime-types": "2.1.11"
+                          },
+                          "dependencies": {
+                            "async": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                              "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+                              "requires": {
+                                "lodash": "4.15.0"
+                              },
+                              "dependencies": {
+                                "lodash": {
+                                  "version": "4.15.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+                                  "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "har-validator": {
+                          "version": "2.0.6",
+                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                          "requires": {
+                            "chalk": "1.1.3",
+                            "commander": "2.9.0",
+                            "is-my-json-valid": "2.13.1",
+                            "pinkie-promise": "2.0.1"
+                          },
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                              "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                              },
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                                }
+                              }
+                            },
+                            "commander": {
+                              "version": "2.9.0",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                              "requires": {
+                                "graceful-readlink": "1.0.1"
+                              },
+                              "dependencies": {
+                                "graceful-readlink": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                                  "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+                                }
+                              }
+                            },
+                            "is-my-json-valid": {
+                              "version": "2.13.1",
+                              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                              "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
+                              "requires": {
+                                "generate-function": "2.0.0",
+                                "generate-object-property": "1.2.0",
+                                "jsonpointer": "2.0.0",
+                                "xtend": "4.0.1"
+                              },
+                              "dependencies": {
+                                "generate-function": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                                  "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+                                },
+                                "generate-object-property": {
+                                  "version": "1.2.0",
+                                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                  "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                                  "requires": {
+                                    "is-property": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "is-property": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                                      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+                                    }
+                                  }
+                                },
+                                "jsonpointer": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                                  "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk="
+                                },
+                                "xtend": {
+                                  "version": "4.0.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+                                }
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "hawk": {
+                          "version": "3.1.3",
+                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                          "requires": {
+                            "boom": "2.10.1",
+                            "cryptiles": "2.0.5",
+                            "hoek": "2.16.3",
+                            "sntp": "1.0.9"
+                          },
+                          "dependencies": {
+                            "boom": {
+                              "version": "2.10.1",
+                              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                              "requires": {
+                                "hoek": "2.16.3"
+                              }
+                            },
+                            "cryptiles": {
+                              "version": "2.0.5",
+                              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                              "requires": {
+                                "boom": "2.10.1"
+                              }
+                            },
+                            "hoek": {
+                              "version": "2.16.3",
+                              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                            },
+                            "sntp": {
+                              "version": "1.0.9",
+                              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                              "requires": {
+                                "hoek": "2.16.3"
+                              }
+                            }
+                          }
+                        },
+                        "http-signature": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                          "requires": {
+                            "assert-plus": "0.2.0",
+                            "jsprim": "1.3.0",
+                            "sshpk": "1.10.0"
+                          },
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+                            },
+                            "jsprim": {
+                              "version": "1.3.0",
+                              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                              "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+                              "requires": {
+                                "extsprintf": "1.0.2",
+                                "json-schema": "0.2.2",
+                                "verror": "1.3.6"
+                              },
+                              "dependencies": {
+                                "extsprintf": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                                  "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                                },
+                                "json-schema": {
+                                  "version": "0.2.2",
+                                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                                  "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY="
+                                },
+                                "verror": {
+                                  "version": "1.3.6",
+                                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                                  "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                                  "requires": {
+                                    "extsprintf": "1.0.2"
+                                  }
+                                }
+                              }
+                            },
+                            "sshpk": {
+                              "version": "1.10.0",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+                              "integrity": "sha1-EE1roq+yrAmauVZ8DRk5d/Kcbfo=",
+                              "requires": {
+                                "asn1": "0.2.3",
+                                "assert-plus": "1.0.0",
+                                "bcrypt-pbkdf": "1.0.0",
+                                "dashdash": "1.14.0",
+                                "ecc-jsbn": "0.1.1",
+                                "getpass": "0.1.6",
+                                "jodid25519": "1.0.2",
+                                "jsbn": "0.1.0",
+                                "tweetnacl": "0.13.3"
+                              },
+                              "dependencies": {
+                                "asn1": {
+                                  "version": "0.2.3",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                                  "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+                                },
+                                "assert-plus": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                                },
+                                "bcrypt-pbkdf": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                                  "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                                  "optional": true,
+                                  "requires": {
+                                    "tweetnacl": "0.14.3"
+                                  },
+                                  "dependencies": {
+                                    "tweetnacl": {
+                                      "version": "0.14.3",
+                                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                                      "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "dashdash": {
+                                  "version": "1.14.0",
+                                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                                  "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                                  "requires": {
+                                    "assert-plus": "1.0.0"
+                                  }
+                                },
+                                "ecc-jsbn": {
+                                  "version": "0.1.1",
+                                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                                  "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                                  "optional": true,
+                                  "requires": {
+                                    "jsbn": "0.1.0"
+                                  }
+                                },
+                                "getpass": {
+                                  "version": "0.1.6",
+                                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                                  "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                                  "requires": {
+                                    "assert-plus": "1.0.0"
+                                  }
+                                },
+                                "jodid25519": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                                  "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                                  "optional": true,
+                                  "requires": {
+                                    "jsbn": "0.1.0"
+                                  }
+                                },
+                                "jsbn": {
+                                  "version": "0.1.0",
+                                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                                  "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                                  "optional": true
+                                },
+                                "tweetnacl": {
+                                  "version": "0.13.3",
+                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                                  "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-typedarray": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+                        },
+                        "isstream": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1",
+                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+                        },
+                        "mime-types": {
+                          "version": "2.1.11",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                          "requires": {
+                            "mime-db": "1.23.0"
+                          },
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.23.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                              "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                            }
+                          }
+                        },
+                        "node-uuid": {
+                          "version": "1.4.7",
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
+                        },
+                        "oauth-sign": {
+                          "version": "0.8.2",
+                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+                        },
+                        "qs": {
+                          "version": "6.2.1",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+                          "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU="
+                        },
+                        "stringstream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+                        },
+                        "tough-cookie": {
+                          "version": "2.3.1",
+                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                          "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0="
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.3",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+                        }
+                      }
+                    }
+                  }
+                },
+                "mustache": {
+                  "version": "2.2.1",
+                  "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.2.1.tgz",
+                  "integrity": "sha1-LEDKIcJ49TFQaCvPkJDkGjM5uHY="
+                },
+                "pipeworks": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/pipeworks/-/pipeworks-1.3.0.tgz",
+                  "integrity": "sha1-TEj0biFN0pQSeDUqhAY50JVYSYw="
+                }
+              }
+            },
+            "config": {
+              "version": "1.21.0",
+              "resolved": "https://registry.npmjs.org/config/-/config-1.21.0.tgz",
+              "integrity": "sha1-g3GcAmOmaeS8TMnJ5YGM2ZajLLk=",
+              "requires": {
+                "json5": "0.4.0"
+              },
+              "dependencies": {
+                "json5": {
+                  "version": "0.4.0",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+                  "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.6.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+              "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+              "requires": {
+                "argparse": "1.0.7",
+                "esprima": "2.7.3"
+              },
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.7",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+                  "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  },
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.7.3",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                  "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+            },
+            "qs": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
+              "integrity": "sha1-gB/uAw4LlFDWOFrcSKTMVbRK7fw="
+            },
+            "sway": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/sway/-/sway-0.6.0.tgz",
+              "integrity": "sha1-qztQeUj++aTZQP49gG0LEE+9FaI=",
+              "requires": {
+                "debug": "2.2.0",
+                "glob": "5.0.15",
+                "js-base64": "2.1.9",
+                "js-yaml": "3.6.1",
+                "json-refs": "1.3.0",
+                "json-schema-faker": "0.2.16",
+                "lodash": "3.10.1",
+                "native-promise-only": "0.8.1",
+                "path-loader": "0.2.1",
+                "path-to-regexp": "1.5.3",
+                "z-schema": "3.17.0"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "requires": {
+                    "inflight": "1.0.5",
+                    "inherits": "2.0.1",
+                    "minimatch": "3.0.3",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
+                  },
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.5",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                      "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI="
+                    }
+                  }
+                },
+                "js-base64": {
+                  "version": "2.1.9",
+                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+                  "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4="
+                },
+                "json-refs": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-1.3.0.tgz",
+                  "integrity": "sha1-bNGLqhFH8nSZUzo3tkqwWAjdeIw=",
+                  "requires": {
+                    "native-promise-only": "0.8.1",
+                    "path-loader": "0.2.1",
+                    "traverse": "0.6.6"
+                  },
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.6.6",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+                      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+                    }
+                  }
+                },
+                "json-schema-faker": {
+                  "version": "0.2.16",
+                  "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.2.16.tgz",
+                  "integrity": "sha1-UdPKSJVdj+c09ZHXR7ckU75aePI=",
+                  "requires": {
+                    "chance": "1.0.4",
+                    "deref": "0.6.4",
+                    "faker": "3.1.0",
+                    "randexp": "0.4.3"
+                  },
+                  "dependencies": {
+                    "chance": {
+                      "version": "1.0.4",
+                      "resolved": "https://registry.npmjs.org/chance/-/chance-1.0.4.tgz",
+                      "integrity": "sha1-Lbw+pq0FQff5Zb0K8l0conXIU8Q="
+                    },
+                    "deref": {
+                      "version": "0.6.4",
+                      "resolved": "https://registry.npmjs.org/deref/-/deref-0.6.4.tgz",
+                      "integrity": "sha1-vVqW1F2+0wEbuBvfaN31S+jhvU4=",
+                      "requires": {
+                        "deep-extend": "0.4.1"
+                      },
+                      "dependencies": {
+                        "deep-extend": {
+                          "version": "0.4.1",
+                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+                          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
+                        }
+                      }
+                    },
+                    "faker": {
+                      "version": "3.1.0",
+                      "resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
+                      "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8="
+                    },
+                    "randexp": {
+                      "version": "0.4.3",
+                      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.3.tgz",
+                      "integrity": "sha1-FxLU+c3VfgAFwTBk4OII+6jljVA=",
+                      "requires": {
+                        "discontinuous-range": "1.0.0",
+                        "ret": "0.1.12"
+                      },
+                      "dependencies": {
+                        "discontinuous-range": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+                          "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+                        },
+                        "ret": {
+                          "version": "0.1.12",
+                          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.12.tgz",
+                          "integrity": "sha1-KTSNyLh5OTaS3EdXRJTDiia/ZI8="
+                        }
+                      }
+                    }
+                  }
+                },
+                "native-promise-only": {
+                  "version": "0.8.1",
+                  "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+                  "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+                },
+                "path-loader": {
+                  "version": "0.2.1",
+                  "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-0.2.1.tgz",
+                  "integrity": "sha1-c4SLA3S/tmvlSj9w7NsISzJjvJ0=",
+                  "requires": {
+                    "native-promise-only": "0.8.1",
+                    "superagent": "1.8.4"
+                  },
+                  "dependencies": {
+                    "superagent": {
+                      "version": "1.8.4",
+                      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz",
+                      "integrity": "sha1-aLLIpADxdT3bOUEJBomeQvQg/To=",
+                      "requires": {
+                        "component-emitter": "1.2.1",
+                        "cookiejar": "2.0.6",
+                        "debug": "2.2.0",
+                        "extend": "3.0.0",
+                        "form-data": "1.0.0-rc3",
+                        "formidable": "1.0.17",
+                        "methods": "1.1.2",
+                        "mime": "1.3.4",
+                        "qs": "2.3.3",
+                        "readable-stream": "1.0.27-1",
+                        "reduce-component": "1.0.1"
+                      },
+                      "dependencies": {
+                        "component-emitter": {
+                          "version": "1.2.1",
+                          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+                        },
+                        "cookiejar": {
+                          "version": "2.0.6",
+                          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+                          "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4="
+                        },
+                        "extend": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+                        },
+                        "form-data": {
+                          "version": "1.0.0-rc3",
+                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                          "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+                          "requires": {
+                            "async": "1.5.2",
+                            "combined-stream": "1.0.5",
+                            "mime-types": "2.1.11"
+                          },
+                          "dependencies": {
+                            "combined-stream": {
+                              "version": "1.0.5",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                              "requires": {
+                                "delayed-stream": "1.0.0"
+                              },
+                              "dependencies": {
+                                "delayed-stream": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                                }
+                              }
+                            },
+                            "mime-types": {
+                              "version": "2.1.11",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                              "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                              "requires": {
+                                "mime-db": "1.23.0"
+                              },
+                              "dependencies": {
+                                "mime-db": {
+                                  "version": "1.23.0",
+                                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                                  "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "formidable": {
+                          "version": "1.0.17",
+                          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+                          "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
+                        },
+                        "methods": {
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+                          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+                        },
+                        "mime": {
+                          "version": "1.3.4",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+                        },
+                        "qs": {
+                          "version": "2.3.3",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+                        },
+                        "readable-stream": {
+                          "version": "1.0.27-1",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+                          "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+                          "requires": {
+                            "core-util-is": "1.0.2",
+                            "inherits": "2.0.1",
+                            "isarray": "0.0.1",
+                            "string_decoder": "0.10.31"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                            }
+                          }
+                        },
+                        "reduce-component": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+                          "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-to-regexp": {
+                  "version": "1.5.3",
+                  "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz",
+                  "integrity": "sha1-ciHd1CSDU4vd+f6tlCp5/zFk9Xo=",
+                  "requires": {
+                    "isarray": "0.0.1"
+                  },
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                    }
+                  }
+                },
+                "z-schema": {
+                  "version": "3.17.0",
+                  "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.17.0.tgz",
+                  "integrity": "sha1-RCs4+denr3rke/z8NWhz6GFq0bc=",
+                  "requires": {
+                    "commander": "2.9.0",
+                    "lodash.get": "4.4.2",
+                    "request": "2.74.0",
+                    "validator": "5.6.0"
+                  },
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                      "optional": true,
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+                          "optional": true
+                        }
+                      }
+                    },
+                    "lodash.get": {
+                      "version": "4.4.2",
+                      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+                      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+                    },
+                    "request": {
+                      "version": "2.74.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+                      "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+                      "optional": true,
+                      "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.4.1",
+                        "bl": "1.1.2",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.0",
+                        "forever-agent": "0.6.1",
+                        "form-data": "1.0.1",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.11",
+                        "node-uuid": "1.4.7",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.2.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.1",
+                        "tunnel-agent": "0.4.3"
+                      },
+                      "dependencies": {
+                        "aws-sign2": {
+                          "version": "0.6.0",
+                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                          "optional": true
+                        },
+                        "aws4": {
+                          "version": "1.4.1",
+                          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+                          "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+                          "optional": true
+                        },
+                        "bl": {
+                          "version": "1.1.2",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                          "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+                          "optional": true,
+                          "requires": {
+                            "readable-stream": "2.0.6"
+                          },
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "2.0.6",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                              "optional": true,
+                              "requires": {
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.1",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "1.0.7",
+                                "string_decoder": "0.10.31",
+                                "util-deprecate": "1.0.2"
+                              },
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                                  "optional": true
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                                  "optional": true
+                                },
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                                  "optional": true
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.7",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                                  "optional": true
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                                  "optional": true
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "caseless": {
+                          "version": "0.11.0",
+                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                          "optional": true
+                        },
+                        "combined-stream": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                          "requires": {
+                            "delayed-stream": "1.0.0"
+                          },
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "1.0.0",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                            }
+                          }
+                        },
+                        "extend": {
+                          "version": "3.0.0",
+                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                          "optional": true
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1",
+                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                          "optional": true
+                        },
+                        "form-data": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+                          "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+                          "optional": true,
+                          "requires": {
+                            "async": "2.0.1",
+                            "combined-stream": "1.0.5",
+                            "mime-types": "2.1.11"
+                          },
+                          "dependencies": {
+                            "async": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                              "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+                              "optional": true,
+                              "requires": {
+                                "lodash": "4.15.0"
+                              },
+                              "dependencies": {
+                                "lodash": {
+                                  "version": "4.15.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+                                  "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk=",
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "har-validator": {
+                          "version": "2.0.6",
+                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                          "optional": true,
+                          "requires": {
+                            "chalk": "1.1.3",
+                            "commander": "2.9.0",
+                            "is-my-json-valid": "2.13.1",
+                            "pinkie-promise": "2.0.1"
+                          },
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                              "optional": true,
+                              "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                              },
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                                  "optional": true
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                                  "optional": true
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                                  "optional": true,
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                                  "optional": true,
+                                  "requires": {
+                                    "ansi-regex": "2.0.0"
+                                  },
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "is-my-json-valid": {
+                              "version": "2.13.1",
+                              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                              "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
+                              "optional": true,
+                              "requires": {
+                                "generate-function": "2.0.0",
+                                "generate-object-property": "1.2.0",
+                                "jsonpointer": "2.0.0",
+                                "xtend": "4.0.1"
+                              },
+                              "dependencies": {
+                                "generate-function": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                                  "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                                  "optional": true
+                                },
+                                "generate-object-property": {
+                                  "version": "1.2.0",
+                                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                  "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                                  "optional": true,
+                                  "requires": {
+                                    "is-property": "1.0.2"
+                                  },
+                                  "dependencies": {
+                                    "is-property": {
+                                      "version": "1.0.2",
+                                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                                      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "jsonpointer": {
+                                  "version": "2.0.0",
+                                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                                  "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                                  "optional": true
+                                },
+                                "xtend": {
+                                  "version": "4.0.1",
+                                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "optional": true,
+                              "requires": {
+                                "pinkie": "2.0.4"
+                              },
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "hawk": {
+                          "version": "3.1.3",
+                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                          "optional": true,
+                          "requires": {
+                            "boom": "2.10.1",
+                            "cryptiles": "2.0.5",
+                            "hoek": "2.16.3",
+                            "sntp": "1.0.9"
+                          },
+                          "dependencies": {
+                            "boom": {
+                              "version": "2.10.1",
+                              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                              "requires": {
+                                "hoek": "2.16.3"
+                              }
+                            },
+                            "cryptiles": {
+                              "version": "2.0.5",
+                              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                              "optional": true,
+                              "requires": {
+                                "boom": "2.10.1"
+                              }
+                            },
+                            "hoek": {
+                              "version": "2.16.3",
+                              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                            },
+                            "sntp": {
+                              "version": "1.0.9",
+                              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                              "optional": true,
+                              "requires": {
+                                "hoek": "2.16.3"
+                              }
+                            }
+                          }
+                        },
+                        "http-signature": {
+                          "version": "1.1.1",
+                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "0.2.0",
+                            "jsprim": "1.3.0",
+                            "sshpk": "1.10.0"
+                          },
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "0.2.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                              "optional": true
+                            },
+                            "jsprim": {
+                              "version": "1.3.0",
+                              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                              "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+                              "optional": true,
+                              "requires": {
+                                "extsprintf": "1.0.2",
+                                "json-schema": "0.2.2",
+                                "verror": "1.3.6"
+                              },
+                              "dependencies": {
+                                "extsprintf": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                                  "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                                },
+                                "json-schema": {
+                                  "version": "0.2.2",
+                                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                                  "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                                  "optional": true
+                                },
+                                "verror": {
+                                  "version": "1.3.6",
+                                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                                  "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                                  "optional": true,
+                                  "requires": {
+                                    "extsprintf": "1.0.2"
+                                  }
+                                }
+                              }
+                            },
+                            "sshpk": {
+                              "version": "1.10.0",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+                              "integrity": "sha1-EE1roq+yrAmauVZ8DRk5d/Kcbfo=",
+                              "optional": true,
+                              "requires": {
+                                "asn1": "0.2.3",
+                                "assert-plus": "1.0.0",
+                                "bcrypt-pbkdf": "1.0.0",
+                                "dashdash": "1.14.0",
+                                "ecc-jsbn": "0.1.1",
+                                "getpass": "0.1.6",
+                                "jodid25519": "1.0.2",
+                                "jsbn": "0.1.0",
+                                "tweetnacl": "0.13.3"
+                              },
+                              "dependencies": {
+                                "asn1": {
+                                  "version": "0.2.3",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                                  "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                                  "optional": true
+                                },
+                                "assert-plus": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                                },
+                                "bcrypt-pbkdf": {
+                                  "version": "1.0.0",
+                                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                                  "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                                  "optional": true,
+                                  "requires": {
+                                    "tweetnacl": "0.14.3"
+                                  },
+                                  "dependencies": {
+                                    "tweetnacl": {
+                                      "version": "0.14.3",
+                                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                                      "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "dashdash": {
+                                  "version": "1.14.0",
+                                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                                  "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                                  "optional": true,
+                                  "requires": {
+                                    "assert-plus": "1.0.0"
+                                  }
+                                },
+                                "ecc-jsbn": {
+                                  "version": "0.1.1",
+                                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                                  "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                                  "optional": true,
+                                  "requires": {
+                                    "jsbn": "0.1.0"
+                                  }
+                                },
+                                "getpass": {
+                                  "version": "0.1.6",
+                                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                                  "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                                  "optional": true,
+                                  "requires": {
+                                    "assert-plus": "1.0.0"
+                                  }
+                                },
+                                "jodid25519": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                                  "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                                  "optional": true,
+                                  "requires": {
+                                    "jsbn": "0.1.0"
+                                  }
+                                },
+                                "jsbn": {
+                                  "version": "0.1.0",
+                                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                                  "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                                  "optional": true
+                                },
+                                "tweetnacl": {
+                                  "version": "0.13.3",
+                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                                  "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-typedarray": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                          "optional": true
+                        },
+                        "isstream": {
+                          "version": "0.1.2",
+                          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                          "optional": true
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1",
+                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                          "optional": true
+                        },
+                        "mime-types": {
+                          "version": "2.1.11",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                          "requires": {
+                            "mime-db": "1.23.0"
+                          },
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.23.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                              "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                            }
+                          }
+                        },
+                        "node-uuid": {
+                          "version": "1.4.7",
+                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+                          "optional": true
+                        },
+                        "oauth-sign": {
+                          "version": "0.8.2",
+                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                          "optional": true
+                        },
+                        "qs": {
+                          "version": "6.2.1",
+                          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+                          "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+                          "optional": true
+                        },
+                        "stringstream": {
+                          "version": "0.0.5",
+                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                          "optional": true
+                        },
+                        "tough-cookie": {
+                          "version": "2.3.1",
+                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                          "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+                          "optional": true
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.3",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.6.13",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+              "integrity": "sha1-boO6e8MM0zp7sLf7AHN6IIW/nQg=",
+              "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.11"
+              },
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+                },
+                "mime-types": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                  "requires": {
+                    "mime-db": "1.23.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "swagger-tools": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/swagger-tools/-/swagger-tools-0.9.16.tgz",
+      "integrity": "sha1-45+uPVgdcTaCSR4ZJs2Hvywgm/s=",
+      "requires": {
+        "async": "1.5.2",
+        "body-parser": "1.12.4",
+        "commander": "2.9.0",
+        "debug": "2.2.0",
+        "js-yaml": "3.6.1",
+        "json-refs": "2.1.6",
+        "lodash-compat": "3.10.2",
+        "multer": "1.1.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "1.5.3",
+        "qs": "4.0.0",
+        "serve-static": "1.11.1",
+        "spark-md5": "1.0.1",
+        "string": "3.3.1",
+        "superagent": "1.8.4",
+        "swagger-converter": "0.1.7",
+        "traverse": "0.6.6",
+        "z-schema": "3.17.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "body-parser": {
+          "version": "1.12.4",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
+          "integrity": "sha1-CQcAxLoohiqFIO83g5X97l9hwik=",
+          "requires": {
+            "bytes": "1.0.0",
+            "content-type": "1.0.2",
+            "debug": "2.2.0",
+            "depd": "1.0.1",
+            "iconv-lite": "0.4.8",
+            "on-finished": "2.2.1",
+            "qs": "2.4.2",
+            "raw-body": "2.0.2",
+            "type-is": "1.6.13"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+              "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
+            },
+            "content-type": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+              "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+            },
+            "depd": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+              "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
+            },
+            "iconv-lite": {
+              "version": "0.4.8",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
+              "integrity": "sha1-xgGadZXyzvynAuq2lKAQvNkpjSA="
+            },
+            "on-finished": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+              "integrity": "sha1-XIXBzDYpn3gCllP2Z/J7a5nrwCk=",
+              "requires": {
+                "ee-first": "1.1.0"
+              },
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
+                  "integrity": "sha1-ag18YiHkkP7v2S7D9EHJzozQl/Q="
+                }
+              }
+            },
+            "qs": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+              "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o="
+            },
+            "raw-body": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz",
+              "integrity": "sha1-osL5jIUxzumcY9jSOLfel7tln8o=",
+              "requires": {
+                "bytes": "2.1.0",
+                "iconv-lite": "0.4.8"
+              },
+              "dependencies": {
+                "bytes": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
+                  "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q="
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.6.13",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+              "integrity": "sha1-boO6e8MM0zp7sLf7AHN6IIW/nQg=",
+              "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.1.11"
+              },
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+                },
+                "mime-types": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                  "requires": {
+                    "mime-db": "1.23.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          },
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+          "requires": {
+            "argparse": "1.0.7",
+            "esprima": "2.7.3"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
+              "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+            }
+          }
+        },
+        "json-refs": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-2.1.6.tgz",
+          "integrity": "sha1-hVZm8iDWVNNAWyPDu+TEkQYLSU0=",
+          "requires": {
+            "commander": "2.9.0",
+            "js-yaml": "3.6.1",
+            "native-promise-only": "0.8.1",
+            "path-loader": "1.0.1",
+            "slash": "1.0.0",
+            "uri-js": "2.1.1"
+          },
+          "dependencies": {
+            "native-promise-only": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+              "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+            },
+            "path-loader": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-loader/-/path-loader-1.0.1.tgz",
+              "integrity": "sha1-iMns5G8fmLOrQNBlX0WL5EZVZlA=",
+              "requires": {
+                "native-promise-only": "0.8.1",
+                "superagent": "1.8.4"
+              }
+            },
+            "slash": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+              "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+            },
+            "uri-js": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-2.1.1.tgz",
+              "integrity": "sha1-6z+FBfRolpv5LLec6M6qwu1mdmE="
+            }
+          }
+        },
+        "lodash-compat": {
+          "version": "3.10.2",
+          "resolved": "https://registry.npmjs.org/lodash-compat/-/lodash-compat-3.10.2.tgz",
+          "integrity": "sha1-xpQBKKnTD46QLNLPmf0Muk7PwYM="
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+          "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+        },
+        "path-to-regexp": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz",
+          "integrity": "sha1-ciHd1CSDU4vd+f6tlCp5/zFk9Xo=",
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            }
+          }
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+        },
+        "serve-static": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+          "integrity": "sha1-1sznaTUF9zPHWd5Xvvwa92wPCAU=",
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.1",
+            "send": "0.14.1"
+          },
+          "dependencies": {
+            "encodeurl": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+              "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+              "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+            },
+            "send": {
+              "version": "0.14.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+              "integrity": "sha1-qVSYQyU5L1FTKndgdg5FlZjIn3o=",
+              "requires": {
+                "debug": "2.2.0",
+                "depd": "1.1.0",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.1",
+                "escape-html": "1.0.3",
+                "etag": "1.7.0",
+                "fresh": "0.3.0",
+                "http-errors": "1.5.0",
+                "mime": "1.3.4",
+                "ms": "0.7.1",
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.3.0"
+              },
+              "dependencies": {
+                "depd": {
+                  "version": "1.1.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                  "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
+                },
+                "destroy": {
+                  "version": "1.0.4",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                  "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+                },
+                "etag": {
+                  "version": "1.7.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                  "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+                },
+                "fresh": {
+                  "version": "0.3.0",
+                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                  "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+                },
+                "http-errors": {
+                  "version": "1.5.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                  "integrity": "sha1-scs9gmD9jiOGytMYkEWUM3LUghE=",
+                  "requires": {
+                    "inherits": "2.0.1",
+                    "setprototypeof": "1.0.1",
+                    "statuses": "1.3.0"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    },
+                    "setprototypeof": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+                      "integrity": "sha1-UgCbJ4iMTcSPWRlJwKgnWDTByn4="
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                },
+                "range-parser": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                  "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+                },
+                "statuses": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                  "integrity": "sha1-jlV1jLIOdoLB9Pzo3KswvwHR4Ho="
+                }
+              }
+            }
+          }
+        },
+        "spark-md5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-1.0.1.tgz",
+          "integrity": "sha1-xLmo1Bz3sIRUI6ghgk+N/6D1G3w="
+        },
+        "string": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/string/-/string-3.3.1.tgz",
+          "integrity": "sha1-jSdX7BwObFJnlvu2sUA2pAmDmLc="
+        },
+        "superagent": {
+          "version": "1.8.4",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.4.tgz",
+          "integrity": "sha1-aLLIpADxdT3bOUEJBomeQvQg/To=",
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.0.6",
+            "debug": "2.2.0",
+            "extend": "3.0.0",
+            "form-data": "1.0.0-rc3",
+            "formidable": "1.0.17",
+            "methods": "1.1.2",
+            "mime": "1.3.4",
+            "qs": "2.3.3",
+            "readable-stream": "1.0.27-1",
+            "reduce-component": "1.0.1"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "cookiejar": {
+              "version": "2.0.6",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
+              "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4="
+            },
+            "extend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+              "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+              "requires": {
+                "async": "1.5.2",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.11"
+              },
+              "dependencies": {
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                    }
+                  }
+                },
+                "mime-types": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                  "requires": {
+                    "mime-db": "1.23.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                    }
+                  }
+                }
+              }
+            },
+            "formidable": {
+              "version": "1.0.17",
+              "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+              "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
+            },
+            "methods": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+              "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+            },
+            "mime": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+            },
+            "qs": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+            },
+            "readable-stream": {
+              "version": "1.0.27-1",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+              "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+              }
+            },
+            "reduce-component": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+              "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
+            }
+          }
+        },
+        "swagger-converter": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/swagger-converter/-/swagger-converter-0.1.7.tgz",
+          "integrity": "sha1-oJdRnG8e5N1n4wjZtT3cnCslf5c=",
+          "requires": {
+            "lodash.clonedeep": "2.4.1"
+          },
+          "dependencies": {
+            "lodash.clonedeep": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-2.4.1.tgz",
+              "integrity": "sha1-8pIDtAsS/uCkXTYxZIJZvrq8eGg=",
+              "requires": {
+                "lodash._baseclone": "2.4.1",
+                "lodash._basecreatecallback": "2.4.1"
+              },
+              "dependencies": {
+                "lodash._baseclone": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-2.4.1.tgz",
+                  "integrity": "sha1-MPgj5X4X43NdODvWK2Czh1Q7QYY=",
+                  "requires": {
+                    "lodash._getarray": "2.4.1",
+                    "lodash._releasearray": "2.4.1",
+                    "lodash._slice": "2.4.1",
+                    "lodash.assign": "2.4.1",
+                    "lodash.foreach": "2.4.1",
+                    "lodash.forown": "2.4.1",
+                    "lodash.isarray": "2.4.1",
+                    "lodash.isobject": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._getarray": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
+                      "integrity": "sha1-+vH3+BD6mFolHCGHQESBCUg55e4=",
+                      "requires": {
+                        "lodash._arraypool": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._arraypool": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                          "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q="
+                        }
+                      }
+                    },
+                    "lodash._releasearray": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
+                      "integrity": "sha1-phOWMNdtFTawfdyAliiJsIL2pkE=",
+                      "requires": {
+                        "lodash._arraypool": "2.4.1",
+                        "lodash._maxpoolsize": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._arraypool": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz",
+                          "integrity": "sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q="
+                        },
+                        "lodash._maxpoolsize": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz",
+                          "integrity": "sha1-nUgvRjuOZq++WcLBTtsRcGAXIzQ="
+                        }
+                      }
+                    },
+                    "lodash._slice": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                      "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8="
+                    },
+                    "lodash.assign": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-2.4.1.tgz",
+                      "integrity": "sha1-hMOVlt1xGBqXsGUpE6fJZ15Jsao=",
+                      "requires": {
+                        "lodash._basecreatecallback": "2.4.1",
+                        "lodash._objecttypes": "2.4.1",
+                        "lodash.keys": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                        },
+                        "lodash.keys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+                          "requires": {
+                            "lodash._isnative": "2.4.1",
+                            "lodash._shimkeys": "2.4.1",
+                            "lodash.isobject": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                            },
+                            "lodash._shimkeys": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                              "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+                              "requires": {
+                                "lodash._objecttypes": "2.4.1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.foreach": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz",
+                      "integrity": "sha1-/j/Do0yGyUyrb5UiVgKCdB4BYwk=",
+                      "requires": {
+                        "lodash._basecreatecallback": "2.4.1",
+                        "lodash.forown": "2.4.1"
+                      }
+                    },
+                    "lodash.forown": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+                      "integrity": "sha1-eLQer+FAX6lmRZ6kGT/VAtCEUks=",
+                      "requires": {
+                        "lodash._basecreatecallback": "2.4.1",
+                        "lodash._objecttypes": "2.4.1",
+                        "lodash.keys": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                        },
+                        "lodash.keys": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+                          "requires": {
+                            "lodash._isnative": "2.4.1",
+                            "lodash._shimkeys": "2.4.1",
+                            "lodash.isobject": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._isnative": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                              "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                            },
+                            "lodash._shimkeys": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                              "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+                              "requires": {
+                                "lodash._objecttypes": "2.4.1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.isarray": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                      "integrity": "sha1-tSoybB9i9tfac6MdVAHfbvRPD6E=",
+                      "requires": {
+                        "lodash._isnative": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                        }
+                      }
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                      "requires": {
+                        "lodash._objecttypes": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                          "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._basecreatecallback": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+                  "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
+                  "requires": {
+                    "lodash._setbinddata": "2.4.1",
+                    "lodash.bind": "2.4.1",
+                    "lodash.identity": "2.4.1",
+                    "lodash.support": "2.4.1"
+                  },
+                  "dependencies": {
+                    "lodash._setbinddata": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                      "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
+                      "requires": {
+                        "lodash._isnative": "2.4.1",
+                        "lodash.noop": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                        },
+                        "lodash.noop": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                          "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
+                        }
+                      }
+                    },
+                    "lodash.bind": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                      "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
+                      "requires": {
+                        "lodash._createwrapper": "2.4.1",
+                        "lodash._slice": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._createwrapper": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                          "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
+                          "requires": {
+                            "lodash._basebind": "2.4.1",
+                            "lodash._basecreatewrapper": "2.4.1",
+                            "lodash._slice": "2.4.1",
+                            "lodash.isfunction": "2.4.1"
+                          },
+                          "dependencies": {
+                            "lodash._basebind": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                              "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
+                              "requires": {
+                                "lodash._basecreate": "2.4.1",
+                                "lodash._setbinddata": "2.4.1",
+                                "lodash._slice": "2.4.1",
+                                "lodash.isobject": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._basecreate": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                  "requires": {
+                                    "lodash._isnative": "2.4.1",
+                                    "lodash.isobject": "2.4.1",
+                                    "lodash.noop": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                                    },
+                                    "lodash.noop": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
+                                    }
+                                  }
+                                },
+                                "lodash.isobject": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                  "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                  "requires": {
+                                    "lodash._objecttypes": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._objecttypes": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                                      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash._basecreatewrapper": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                              "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
+                              "requires": {
+                                "lodash._basecreate": "2.4.1",
+                                "lodash._setbinddata": "2.4.1",
+                                "lodash._slice": "2.4.1",
+                                "lodash.isobject": "2.4.1"
+                              },
+                              "dependencies": {
+                                "lodash._basecreate": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                                  "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
+                                  "requires": {
+                                    "lodash._isnative": "2.4.1",
+                                    "lodash.isobject": "2.4.1",
+                                    "lodash.noop": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._isnative": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                                      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                                    },
+                                    "lodash.noop": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz",
+                                      "integrity": "sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o="
+                                    }
+                                  }
+                                },
+                                "lodash.isobject": {
+                                  "version": "2.4.1",
+                                  "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                                  "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+                                  "requires": {
+                                    "lodash._objecttypes": "2.4.1"
+                                  },
+                                  "dependencies": {
+                                    "lodash._objecttypes": {
+                                      "version": "2.4.1",
+                                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+                                      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "lodash.isfunction": {
+                              "version": "2.4.1",
+                              "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz",
+                              "integrity": "sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE="
+                            }
+                          }
+                        },
+                        "lodash._slice": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz",
+                          "integrity": "sha1-dFz0GlNZexj2iImFREBe+isG2Q8="
+                        }
+                      }
+                    },
+                    "lodash.identity": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz",
+                      "integrity": "sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE="
+                    },
+                    "lodash.support": {
+                      "version": "2.4.1",
+                      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                      "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
+                      "requires": {
+                        "lodash._isnative": "2.4.1"
+                      },
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+                          "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "traverse": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+          "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+        },
+        "z-schema": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.17.0.tgz",
+          "integrity": "sha1-RCs4+denr3rke/z8NWhz6GFq0bc=",
+          "requires": {
+            "commander": "2.9.0",
+            "lodash.get": "4.4.2",
+            "request": "2.74.0",
+            "validator": "5.6.0"
+          },
+          "dependencies": {
+            "lodash.get": {
+              "version": "4.4.2",
+              "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+              "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+            },
+            "request": {
+              "version": "2.74.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+              "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+              "optional": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.4.1",
+                "bl": "1.1.2",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.0",
+                "forever-agent": "0.6.1",
+                "form-data": "1.0.1",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.11",
+                "node-uuid": "1.4.7",
+                "oauth-sign": "0.8.2",
+                "qs": "6.2.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.1",
+                "tunnel-agent": "0.4.3"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+                  "optional": true
+                },
+                "aws4": {
+                  "version": "1.4.1",
+                  "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
+                  "integrity": "sha1-/efVKSRm0jDl7g9OA42d+qsI/GE=",
+                  "optional": true
+                },
+                "bl": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                  "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
+                  "optional": true,
+                  "requires": {
+                    "readable-stream": "2.0.6"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                      "optional": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "optional": true
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                          "optional": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                          "optional": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                          "optional": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                          "optional": true
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                  "optional": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                  "optional": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                  "optional": true
+                },
+                "form-data": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+                  "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+                  "optional": true,
+                  "requires": {
+                    "async": "2.0.1",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.11"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+                      "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+                      "optional": true,
+                      "requires": {
+                        "lodash": "4.15.0"
+                      },
+                      "dependencies": {
+                        "lodash": {
+                          "version": "4.15.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+                          "integrity": "sha1-MWI5HY8BQKoiz49rPDTWt/Y9Oqk=",
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+                  "optional": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "commander": "2.9.0",
+                    "is-my-json-valid": "2.13.1",
+                    "pinkie-promise": "2.0.1"
+                  },
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                      "optional": true,
+                      "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                          "optional": true
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                          "optional": true
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                          "optional": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "optional": true
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                          "optional": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                              "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                              "optional": true
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                          "optional": true
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.13.1",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                      "integrity": "sha1-1Vd4qC/rawlj/0vhEdXRaE6JBwc=",
+                      "optional": true,
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "2.0.0",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+                          "optional": true
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                          "optional": true,
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                              "optional": true
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                          "integrity": "sha1-OvHdIP6FRjkQ1GmjheMwF9KgMNk=",
+                          "optional": true
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                          "optional": true
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "optional": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+                  "optional": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                      "optional": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                      "optional": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.3.0",
+                    "sshpk": "1.10.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+                      "optional": true
+                    },
+                    "jsprim": {
+                      "version": "1.3.0",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                      "integrity": "sha1-zi4b74NSBLTzCZkoxgL4tq5hVlA=",
+                      "optional": true,
+                      "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.2",
+                        "verror": "1.3.6"
+                      },
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+                        },
+                        "json-schema": {
+                          "version": "0.2.2",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                          "integrity": "sha1-UDVPGfYDkXxpX3C4Wvp3w7DyNQY=",
+                          "optional": true
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                          "optional": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
+                      "integrity": "sha1-EE1roq+yrAmauVZ8DRk5d/Kcbfo=",
+                      "optional": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.0",
+                        "dashdash": "1.14.0",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.6",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.0",
+                        "tweetnacl": "0.13.3"
+                      },
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                          "optional": true
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                          "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.3"
+                          },
+                          "dependencies": {
+                            "tweetnacl": {
+                              "version": "0.14.3",
+                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                              "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
+                              "optional": true
+                            }
+                          }
+                        },
+                        "dashdash": {
+                          "version": "1.14.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                          "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "getpass": {
+                          "version": "0.1.6",
+                          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                          "optional": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                          "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.13.3",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                          "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+                  "optional": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+                  "optional": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+                  "optional": true
+                },
+                "mime-types": {
+                  "version": "2.1.11",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "integrity": "sha1-wlnEcb2oCKhdbNGTtDCl+uRHOzw=",
+                  "requires": {
+                    "mime-db": "1.23.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.23.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                      "integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8=",
+                  "optional": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                  "optional": true
+                },
+                "qs": {
+                  "version": "6.2.1",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+                  "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU=",
+                  "optional": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+                  "optional": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.1",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "integrity": "sha1-mcd9+7fYBCSeiimdTLD9gf7wg/0=",
+                  "optional": true
+                },
+                "tunnel-agent": {
+                  "version": "0.4.3",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                  "optional": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "switchback": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/switchback/-/switchback-2.0.2.tgz",
+      "integrity": "sha1-ls8ODTY7VZ0Lt/8htip6qRDsYHk=",
+      "requires": {
+        "lodash": "3.10.1"
+      }
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.10",
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "block-stream": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+          "requires": {
+            "graceful-fs": "4.1.6",
+            "inherits": "2.0.1",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.5.4"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.6",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+              "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4="
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+              }
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        }
+      }
+    },
+    "tar-fs": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.12.0.tgz",
+      "integrity": "sha1-pqgFU9ilTHPeHQrg553ncDVgXh0=",
+      "requires": {
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.5.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.4",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "temp": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
+      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "requires": {
+        "os-tmpdir": "1.0.1",
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        }
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "traceur": {
+      "version": "0.0.111",
+      "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.111.tgz",
+      "integrity": "sha1-wE3nTRRpbDNzQn3k/Ajsr5E/w6E=",
+      "requires": {
+        "commander": "2.9.0",
+        "glob": "5.0.15",
+        "rsvp": "3.6.2",
+        "semver": "4.3.6",
+        "source-map-support": "0.2.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tv4": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz",
+      "integrity": "sha1-vSk4mvxzreSa5fSBQrXVRL9o0SA="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz",
+      "integrity": "sha1-PMvcU2ee7W7PN3fdf14yKcG2qjw="
+    },
+    "url-parse": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz",
+      "integrity": "sha1-zv3SS+LnH/2R7/xrpWiGwiW9ESQ=",
+      "requires": {
+        "querystringify": "0.0.4",
+        "requires-port": "1.0.0"
+      },
+      "dependencies": {
+        "querystringify": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+          "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+          "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utile": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+      "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
+      "requires": {
+        "async": "0.2.10",
+        "deep-equal": "1.0.1",
+        "i": "0.3.6",
+        "mkdirp": "0.3.0",
+        "ncp": "0.4.2",
+        "rimraf": "2.5.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        }
+      }
+    },
+    "validate.js": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.3.2.tgz",
+      "integrity": "sha1-jfpkDb/M5qEPVLW3JYZQXfff4FA="
+    },
+    "validator": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-5.6.0.tgz",
+      "integrity": "sha1-nXeoIXH20OfRW6V3ilKy8ho1YKw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "vfile": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.0.0.tgz",
+      "integrity": "sha1-iGIFAONrrQJaCwHMJRBtvLMJBUg=",
+      "requires": {
+        "has": "1.0.1",
+        "is-buffer": "1.1.6",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "1.1.1",
+        "x-is-string": "0.1.0"
+      }
+    },
+    "vfile-reporter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-3.0.0.tgz",
+      "integrity": "sha1-/lBxTjc+DSlAUQA4qZvWCb3IIJ8=",
+      "requires": {
+        "chalk": "1.1.3",
+        "log-symbols": "1.0.2",
+        "plur": "2.1.2",
+        "repeat-string": "1.6.1",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "trim": "0.0.1",
+        "unist-util-stringify-position": "1.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        }
+      }
+    },
+    "walk": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
+      "integrity": "sha1-MbTbZnjyrgHDnqn7hyWpAx5Vins=",
+      "requires": {
+        "foreachasync": "3.0.0"
+      },
+      "dependencies": {
+        "foreachasync": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+          "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
+        }
+      }
+    },
+    "waterline": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/waterline/-/waterline-0.10.31.tgz",
+      "integrity": "sha1-Bq7/jDy6W1+POn6kNBpcVA4i/xk=",
+      "requires": {
+        "anchor": "0.11.6",
+        "async": "1.2.1",
+        "bluebird": "2.9.34",
+        "deep-diff": "0.3.8",
+        "lodash": "3.9.3",
+        "prompt": "0.2.14",
+        "switchback": "2.0.2",
+        "waterline-criteria": "0.11.2",
+        "waterline-schema": "0.1.20"
+      },
+      "dependencies": {
+        "anchor": {
+          "version": "0.11.6",
+          "resolved": "https://registry.npmjs.org/anchor/-/anchor-0.11.6.tgz",
+          "integrity": "sha1-4Ir+9pRxvHE7YcDY7d8jmoV7sQw=",
+          "requires": {
+            "@mapbox/geojsonhint": "2.0.1",
+            "@sailshq/lodash": "3.10.2",
+            "validator": "4.4.0"
+          }
+        },
+        "async": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
+        },
+        "bluebird": {
+          "version": "2.9.34",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
+          "integrity": "sha1-L3tOyAIWMoqf3evfacjUlC/v99g="
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI="
+        },
+        "validator": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-4.4.0.tgz",
+          "integrity": "sha1-NeKVVd1feCb5cKTq7P+ebfbfPaY="
+        }
+      }
+    },
+    "waterline-criteria": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/waterline-criteria/-/waterline-criteria-0.11.2.tgz",
+      "integrity": "sha1-apEVVjd47531TEbF0Wh8unmoTqE=",
+      "requires": {
+        "lodash": "2.4.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "waterline-cursor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/waterline-cursor/-/waterline-cursor-0.0.7.tgz",
+      "integrity": "sha1-zNnP7WYdlK9gJ0lZQrX6J61l/rM=",
+      "requires": {
+        "async": "1.5.2",
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
+    "waterline-errors": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/waterline-errors/-/waterline-errors-0.10.1.tgz",
+      "integrity": "sha1-7mNjKq3emTJxt1FLfKmNn9W4ai4="
+    },
+    "waterline-schema": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/waterline-schema/-/waterline-schema-0.1.20.tgz",
+      "integrity": "sha1-/3AH2+ass2+ODq5ZrZ36HP+TdhM=",
+      "requires": {
+        "lodash": "3.10.1"
+      }
+    },
+    "when": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+    },
+    "winston": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+      "requires": {
+        "async": "0.2.10",
+        "colors": "0.6.2",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.9"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+        },
+        "xmlbuilder": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+          "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+        }
+      }
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "xunit-file": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/xunit-file/-/xunit-file-0.0.6.tgz",
+      "integrity": "sha1-+pAfF+J0bGjoC0GWLAqqsos4VaM=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "os-locale": "1.4.0",
+        "string-width": "1.0.2",
+        "window-size": "0.1.4",
+        "y18n": "3.2.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Add publishable npm-shrinkwrap.json, which is repurposed from package-lock.json.
* Not lock down the dependent on-core/on-tasks, so don't add commit hash or version to on-core/on-tasks.
  The benefits:
    * Don't need to update npm-shrinkwrap.json every time when on-core/on-tasks has a new commit.
    * Ease the dependent PRs merging.
* Install npm@5.6.0 in travis-ci which is the same as concourse-ci.

Please refer to https://github.com/RackHD/on-tasks/pull/585 and https://rackhd.atlassian.net/browse/RAC-6681 for details.


@RackHD/corecommitters @iceiilin @nortonluo 