### PR TITLE
Fix deleting tag issue from nodes in RAC-6680

### DIFF
--- a/lib/api/2.0/nodes.js
+++ b/lib/api/2.0/nodes.js
@@ -5,8 +5,8 @@
 var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
 var addLinks = injector.get('Http.Services.Swagger').addLinksHeader;
+var getTagName = injector.get('Http.Services.Swagger').getTagName;
 var nodes = injector.get('Http.Services.Api.Nodes');
-var waterline = injector.get('Services.Waterline');
 var _ = injector.get('_'); // jshint ignore:line
 var constants = injector.get('Constants');
 var Errors = injector.get('Errors');
@@ -115,7 +115,7 @@ var nodesGetTagsById = controller(function(req) {
 
 var nodesDelTagById = controller({success: 204}, function(req) {
     return nodes.removeTagsById(req.swagger.params.identifier.value,
-                                req.swagger.params.tagName.value);
+                                getTagName(req));
 });
 
 var nodesPatchTagById = controller(function(req) {
@@ -124,7 +124,7 @@ var nodesPatchTagById = controller(function(req) {
 });
 
 var nodesMasterDelTagById = controller({success: 204}, function(req) {
-    return nodes.masterDelTagById(req.swagger.params.tagName.value);
+    return nodes.masterDelTagById(getTagName(req));
 });
 
 var nodesDelRelations = controller(function(req) {

--- a/lib/api/2.0/tags.js
+++ b/lib/api/2.0/tags.js
@@ -4,23 +4,11 @@
 
 var injector = require('../../../index.js').injector;
 var controller = injector.get('Http.Services.Swagger').controller;
+var getTagName = injector.get('Http.Services.Swagger').getTagName;
 var nodes = injector.get('Http.Services.Api.Nodes');
 var tags = injector.get('Http.Services.Api.Tags');
 var _ = injector.get('_'); // jshint ignore:line
 var Errors = injector.get('Errors');
-var parseUrl = require('url').parse;
-
-function getTagName(req) {
-    //TODO: sway 1.0.0 implements a fix for this, but it is lacking in the ^0.6.0 versions
-    //      so we duplicate the 1.0.0 implementation here.
-    // Ref: https://github.com/apigee-127/sway/commit/1b7acd9743aae2f2f94057d3f8911e2af72614f5
-    var pathObject = req.swagger.operation.pathObject;
-    var pathMatch = pathObject.regexp.exec(parseUrl(req.url).pathname);
-    var value = decodeURIComponent(pathMatch[_.findIndex(pathObject.regexp.keys, function(key) {
-        return key.name === 'tagName';
-    }) + 1]);
-    return value;
-}
 
 var getAllTags = controller(function(req) {
     return tags.findTags(req.query);

--- a/lib/services/nodes-api-service.js
+++ b/lib/services/nodes-api-service.js
@@ -666,10 +666,17 @@ function nodeApiServiceFactory(
         .then(function() {
             return waterline.nodes.findByTag(tagName);
         })
+        .then(function(nodes) {
+            if(_.isEmpty(nodes)) {
+                throw new Errors.NotFoundError('name ' + tagName + ' was not found in nodes');
+            }
+            return nodes;
+        })
         .map(function(node) {
             return waterline.nodes.remTags(node.id, tagName)
-                .then(function()
-                {return node.id; });
+                .then(function() {
+                    return node.id;
+                });
         });
     };
 

--- a/lib/services/swagger-api-service.js
+++ b/lib/services/swagger-api-service.js
@@ -5,6 +5,7 @@
 var di = require('di');
 var util = require('util');
 var path = require('path');
+var parseUrl = require('url').parse;
 
 module.exports = swaggerFactory;
 
@@ -392,11 +393,24 @@ function swaggerFactory(
         });
     }
 
+    function getTagName(req) {
+        //TODO: sway 1.0.0 implements a fix for this, but it is lacking in the ^0.6.0 versions
+        //      so we duplicate the 1.0.0 implementation here.
+        // Ref: https://github.com/apigee-127/sway/commit/1b7acd9743aae2f2f94057d3f8911e2af72614f5
+        var pathObject = req.swagger.operation.pathObject;
+        var pathMatch = pathObject.regexp.exec(parseUrl(req.url).pathname);
+        var value = decodeURIComponent(pathMatch[_.findIndex(pathObject.regexp.keys, function(key) {
+            return key.name === 'tagName';
+        }) + 1]);
+        return value;
+    }
+
     return {
         controller: swaggerController,
-        renderer: swaggerRenderer,
         validator: swaggerValidator,
+        renderer: swaggerRenderer,
         makeRenderableOptions: makeRenderableOptions,
-        addLinksHeader: addLinksHeader
+        addLinksHeader: addLinksHeader,
+        getTagName: getTagName
     };
 }

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -822,11 +822,27 @@ describe('2.0 Http.Api.Nodes', function () {
                 });
         });
 
+        it('should call removeTagsById with special characters', function() {
+            return helper.request().delete('/api/2.0/nodes/123/tags/tag name')
+                .expect(204)
+                .expect(function() {
+                    expect(nodesApi.removeTagsById).to.have.been.calledWith('123', 'tag name');
+                });
+        });
+
         it('should call masterDelTagById', function() {
             return helper.request().delete('/api/2.0/nodes/tags/name')
                 .expect(204)
                 .expect(function() {
                     expect(nodesApi.masterDelTagById).to.have.been.calledWith('name');
+                });
+        });
+
+        it('should call masterDelTagById with special characters', function () {
+            return helper.request().delete('/api/2.0/nodes/tags/tag name')
+                .expect(204)
+                .expect(function() {
+                    expect(nodesApi.masterDelTagById).to.have.been.calledWith('tag name');
                 });
         });
     });

--- a/spec/lib/services/nodes-api-service-spec.js
+++ b/spec/lib/services/nodes-api-service-spec.js
@@ -1220,6 +1220,13 @@ describe("Http.Services.Api.Nodes", function () {
                     expect(waterline.nodes.remTags).to.have.been.calledWith(node1.id,tagName);
                 });
         });
+
+        it('should throw NotFoundError when the specified tag is not found in nodes', function() {
+            var tagName = 'name1';
+            waterline.nodes.findByTag.resolves([]);
+            return expect(nodeApiService.masterDelTagById(tagName))
+                .to.be.rejectedWith(Errors.NotFoundError);
+        });
     });
 
     describe('Obms', function() {


### PR DESCRIPTION
* FIX the issue that Cannot delete a tag from a node if tag contains spaces
(https://rackhd.atlassian.net/browse/RAC-6680)
* throw NotFoundError when tagName not found in nodes for API `/nodes/{identifier}/tags/{tagName}
`

depends on: https://github.com/RackHD/RackHD/pull/923

@RackHD/corecommitters @pengz1