### PR TITLE
 Expose timestamp for getAllCatalogs API 

### DIFF
--- a/data/views/catalogs.2.0.json
+++ b/data/views/catalogs.2.0.json
@@ -1,6 +1,16 @@
 {
     "id": "<%= id %>",
     "node": "<%=basepath%>/nodes/<%=node%>",
+    <% if ( typeof(createdAt.toISOString) === "function" ) { %>
+    "createdAt": "<%= createdAt.toISOString() %>",
+    <% } else { %>
+    "createdAt": "<%= createdAt %>",
+    <% } %>
+    <% if ( typeof(updatedAt.toISOString) === "function" ) { %>
+    "updatedAt": "<%= updatedAt.toISOString() %>",
+    <% } else { %>
+    "updatedAt": "<%= updatedAt %>",
+    <% } %>
 
     <% if (source !== null) { %>
     "source": "<%= source %>",

--- a/lib/services/catalogs-api-service.js
+++ b/lib/services/catalogs-api-service.js
@@ -24,7 +24,7 @@ function catalogApiServiceFactory(
      * @return {Promise}
      */
     CatalogApiService.prototype.getCatalog = function(query) {
-        return waterline.catalogs.find(query);
+        return waterline.catalogs.findMongo(query);
     };
 
     /**

--- a/spec/lib/api/2.0/catalogs-spec.js
+++ b/spec/lib/api/2.0/catalogs-spec.js
@@ -22,21 +22,23 @@ describe('2.0 Http.Api.Catalogs', function () {
 
     beforeEach('set up mocks', function() {
         stubNeedByIdentifier = this.sandbox.stub(waterline.catalogs, "needByIdentifier");
-        stubFind = this.sandbox.stub(waterline.catalogs, "find");
+        stubFind = this.sandbox.stub(waterline.catalogs, "findMongo");
     });
 
     helper.httpServerAfter();
 
     describe("GET /catalogs", function() {
 
-        it("should a list of all catalogs", function() {
+        it("should get a list of all catalogs", function() {
 
             stubFind.returns(Promise.resolve([
                 {
                     id: '123',
                     node: '123',
                     source: 'foo',
-                    data: { something: 'here' }
+                    data: { something: 'here' },
+                    updatedAt: new Date(),
+                    createdAt: new Date()
                 }
             ]));
 
@@ -67,7 +69,9 @@ describe('2.0 Http.Api.Catalogs', function () {
                     id: '123',
                     node: '123',
                     source: 'foo',
-                    data: { something: 'here' }
+                    data: { something: 'here' },
+                    updatedAt: new Date(),
+                    createdAt: new Date()
                 }
             ]));
 
@@ -89,7 +93,9 @@ describe('2.0 Http.Api.Catalogs', function () {
                     id: '123',
                     node: '123',
                     source: 'foo',
-                    data: { something: 'here' }
+                    data: { something: 'here' },
+                    updatedAt: new Date(),
+                    createdAt: new Date()
                 }));
 
             return helper.request().get('/api/2.0/catalogs/123')

--- a/spec/lib/api/2.0/nodes-spec.js
+++ b/spec/lib/api/2.0/nodes-spec.js
@@ -449,7 +449,9 @@ describe('2.0 Http.Api.Nodes', function () {
                         source: 'dummysource',
                         data: {
                             foo: 'bar'
-                        }
+                        },
+                        createdAt: new Date(),
+                        updatedAt: new Date() 
                     }
                 ]
             };

--- a/spec/lib/services/catalogs-api-service-spec.js
+++ b/spec/lib/services/catalogs-api-service-spec.js
@@ -15,7 +15,7 @@ describe("Http.Services.Api.Catalogs", function () {
         waterline = helper.injector.get('Services.Waterline');
         waterline.catalogs = {
             needByIdentifier: sinon.stub().resolves(),
-            find: sinon.stub().resolves([])
+            findMongo: sinon.stub().resolves([])
         };
 
         catalogService = helper.injector.get("Http.Services.Api.Catalogs");
@@ -29,14 +29,14 @@ describe("Http.Services.Api.Catalogs", function () {
         });
         it('Run getCatalog', function() {
             var mockCatalog = [{ id: 'foobar' }];
-            waterline.catalogs.find.resolves([mockCatalog]);
+            waterline.catalogs.findMongo.resolves([mockCatalog]);
             return catalogService.getCatalog().then(function (catalogs) {
                 expect(catalogs).to.deep.equal([mockCatalog]);
             });
         });
 
         it('should return empty array if no catalog informations are found', function () {
-            waterline.catalogs.find.resolves([]);
+            waterline.catalogs.findMongo.resolves([]);
             var mockCatalog = [];
             return catalogService.getCatalog().should.eventually.become(mockCatalog);
         });
@@ -56,7 +56,7 @@ describe("Http.Services.Api.Catalogs", function () {
         });
 
         it('should return empty array if no specific catalog information are found', function () {
-            waterline.catalogs.find.resolves({});
+            waterline.catalogs.findMongo.resolves({});
             var mockCatalog = {};
             return catalogService.getCatalog().should.eventually.become(mockCatalog);
         });


### PR DESCRIPTION
 Expose timestamp for getAllCatalogs API. Otherwise user can't tell difference between catalogs with the same source and nodeId but created at different time.