### PR TITLE
 Fix can't delete graph by instanceId issue

### DIFF
--- a/lib/services/taskgraph-api-service.js
+++ b/lib/services/taskgraph-api-service.js
@@ -192,14 +192,14 @@ function taskgraphApiServiceFactory(
 
     TaskgraphApiService.prototype.workflowsAction = function(graphId, command) {
         return runRpc('workflowsAction', {
-            command: command, 
+            command: command,
             identifier: graphId
         });
     };
 
     TaskgraphApiService.prototype.workflowsDeleteByInstanceId = function(graphId) {
         return runRpc('workflowsDeleteByInstanceId', {
-            graphId: graphId
+            identifier: graphId
         });
     };
 


### PR DESCRIPTION
For method TaskgraphApiService.prototype.workflowsDeleteByInstanceId in lib/services/taskgraph-api-service.js, we should use "identifier" instead of "graphId".

It is defined in: https://github.com/RackHD/on-http/blob/master/lib/services/scheduler.proto#L84

@iceiilin @lanchongyizu 
