### PR TITLE
RAC-6686: Refine installation script for web-ui-2.0

### DIFF
--- a/install-web-ui.sh
+++ b/install-web-ui.sh
@@ -1,16 +1,22 @@
 # Copyright 2015-2017, Dell EMC, Inc.
 
 cd ./static
-
 rm -rf web-ui
-curl --fail -L -o on-web-ui-gh-pages.zip https://github.com/RackHD/on-web-ui/archive/gh-pages.zip
+version=$(curl https://raw.githubusercontent.com/rackhd/rackhd-ui-2.0/version/version)
+curl --fail -L -o on-web-ui-gh-pages.zip https://github.com/rackhd/rackhd-ui-2.0/archive/${version}.zip
 
 if [ $? -ne 0 ]; then
     echo 'failed to download, retrying'
-    curl --fail -L -o on-web-ui-gh-pages.zip https://github.com/RackHD/on-web-ui/archive/gh-pages.zip \
+    curl --fail -L -o on-web-ui-gh-pages.zip https://github.com/rackhd/rackhd-ui-2.0/archive/${version}.zip \
         || { echo "failed to download, exiting" && exit 1; }
 fi
 
 unzip on-web-ui-gh-pages.zip
 rm on-web-ui-gh-pages.zip
-mv on-web-ui-gh-pages web-ui
+mv rackhd-ui-2.0-${version} web-ui
+
+pushd web-ui
+npm install webpack-dev-server rimraf webpack -g
+npm install
+npm run build:aot
+popd

--- a/install-web-ui.sh
+++ b/install-web-ui.sh
@@ -2,21 +2,16 @@
 
 cd ./static
 rm -rf web-ui
-version=$(curl https://raw.githubusercontent.com/rackhd/rackhd-ui-2.0/version/version)
-curl --fail -L -o on-web-ui-gh-pages.zip https://github.com/rackhd/rackhd-ui-2.0/archive/${version}.zip
+githubUser=rackhd
+repo=on-web-ui
+curl --fail -L -o on-web-ui-gh-pages-2.0.zip https://github.com/${githubUser}/${repo}/archive/gh-pages-2.0.zip
 
 if [ $? -ne 0 ]; then
     echo 'failed to download, retrying'
-    curl --fail -L -o on-web-ui-gh-pages.zip https://github.com/rackhd/rackhd-ui-2.0/archive/${version}.zip \
+    curl --fail -L -o on-web-ui-gh-pages-2.0 https://github.com/${githubUser}/${repo}/archive/gh-pages-2.0.zip \
         || { echo "failed to download, exiting" && exit 1; }
 fi
 
-unzip on-web-ui-gh-pages.zip
-rm on-web-ui-gh-pages.zip
-mv rackhd-ui-2.0-${version} web-ui
-
-pushd web-ui
-npm install webpack-dev-server rimraf webpack -g
-npm install
-npm run build:aot
-popd
+unzip on-web-ui-gh-pages-2.0.zip
+rm on-web-ui-gh-pages-2.0.zip
+mv on-web-ui-gh-pages-2.0 web-ui


### PR DESCRIPTION
**Background**
To install web-ui-2.0 in on-http, the installation script needs to be refined. The source code of web-ui needs to be pulled and then execute some installation steps to build code. After the installation script is executed, users can visit the web-ui-2.0 with this url: http://ip:port/ui.

**Reviewers**
@pengz1 @AlaricChan